### PR TITLE
fix: add retry with exponential backoff to OAuth token refresh

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -105,36 +105,61 @@ export async function AnthropicAuthPlugin({ client }) {
               const auth = await getAuth();
               if (auth.type !== "oauth") return fetch(input, init);
               if (!auth.access || auth.expires < Date.now()) {
-                const response = await fetch(
-                  "https://console.anthropic.com/v1/oauth/token",
-                  {
-                    method: "POST",
-                    headers: {
-                      "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                      grant_type: "refresh_token",
-                      refresh_token: auth.refresh,
-                      client_id: CLIENT_ID,
-                    }),
-                  },
-                );
-                if (!response.ok) {
-                  throw new Error(`Token refresh failed: ${response.status}`);
+                const MAX_RETRIES = 2;
+                const BASE_DELAY_MS = 500;
+                for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+                  try {
+                    if (attempt > 0) {
+                      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+                      await new Promise((r) => setTimeout(r, delay));
+                    }
+                    const response = await fetch(
+                      "https://console.anthropic.com/v1/oauth/token",
+                      {
+                        method: "POST",
+                        headers: {
+                          "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({
+                          grant_type: "refresh_token",
+                          refresh_token: auth.refresh,
+                          client_id: CLIENT_ID,
+                        }),
+                      },
+                    );
+                    if (!response.ok) {
+                      if (response.status >= 500 && attempt < MAX_RETRIES) {
+                        continue;
+                      }
+                      throw new Error(`Token refresh failed: ${response.status}`);
+                    }
+                    const json = await response.json();
+                    await client.auth.set({
+                      path: {
+                        id: "anthropic",
+                      },
+                      body: {
+                        type: "oauth",
+                        refresh: json.refresh_token,
+                        access: json.access_token,
+                        expires: Date.now() + json.expires_in * 1000,
+                      },
+                    });
+                    auth.access = json.access_token;
+                    break;
+                  } catch (err) {
+                    const isNetworkError =
+                      err.code === "ECONNRESET" ||
+                      err.code === "ECONNREFUSED" ||
+                      err.code === "ETIMEDOUT" ||
+                      err.code === "UND_ERR_CONNECT_TIMEOUT" ||
+                      err.message?.includes("fetch failed");
+                    if (attempt < MAX_RETRIES && isNetworkError) {
+                      continue;
+                    }
+                    throw err;
+                  }
                 }
-                const json = await response.json();
-                await client.auth.set({
-                  path: {
-                    id: "anthropic",
-                  },
-                  body: {
-                    type: "oauth",
-                    refresh: json.refresh_token,
-                    access: json.access_token,
-                    expires: Date.now() + json.expires_in * 1000,
-                  },
-                });
-                auth.access = json.access_token;
               }
               const requestInit = init ?? {};
 


### PR DESCRIPTION
### What does this PR do?

The token refresh `fetch()` has no retry logic. If the single request to `console.anthropic.com/v1/oauth/token` fails transiently (network glitch, 5xx), the entire API request dies immediately:

```js
if (!response.ok) {
  throw new Error(`Token refresh failed: ${response.status}`);
}
```

This wraps the token refresh in a retry loop:

- **3 attempts** total (1 original + 2 retries)
- **Exponential backoff**: 500ms, 1000ms
- **Retries on**: 5xx status codes, network errors (`ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `fetch failed`)
- **Does not retry on**: 4xx (real auth issues like revoked tokens)

Only `index.mjs` is changed — the token refresh block is wrapped in a `for` loop with `try/catch`. No new dependencies, no new files.

### How did you verify your code works?

Tested with a mock token server that returns configurable 500s before succeeding:

| Test | Setup | Result |
|------|-------|--------|
| Before (no retry) | Mock returns 500 once | `throw "Token refresh failed: 500"` immediately |
| After (with retry) | Mock returns 500 then 200 | Retries after 500ms, succeeds on attempt 2 |

```
Phase 1: Testing ORIGINAL plugin (no retry)
  mock: request #1 → 500
PASS ✓: Threw as expected — "Token refresh failed: 500" (mock requests: 1)

Phase 2: Testing PATCHED plugin (with retry)
  mock: request #1 → 500
  mock: request #2 → 200
PASS ✓: Token refresh succeeded (mock requests: 2)
```