### PR TITLE
fix: retry transient OAuth token refresh failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,41 +52,79 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               const auth = await getAuth()
               if (auth.type !== 'oauth') return fetch(input, init)
               if (!auth.access || !auth.expires || auth.expires < Date.now()) {
-                const response = await fetch(
-                  'https://console.anthropic.com/v1/oauth/token',
-                  {
-                    method: 'POST',
-                    headers: {
-                      'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify({
-                      grant_type: 'refresh_token',
-                      refresh_token: auth.refresh,
-                      client_id: CLIENT_ID,
-                    }),
-                  },
-                )
-                if (!response.ok) {
-                  throw new Error(`Token refresh failed: ${response.status}`)
+                const maxRetries = 2
+                const baseDelayMs = 500
+
+                for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                  try {
+                    if (attempt > 0) {
+                      const delay = baseDelayMs * 2 ** (attempt - 1)
+                      await new Promise((resolve) => setTimeout(resolve, delay))
+                    }
+
+                    const response = await fetch(
+                      'https://console.anthropic.com/v1/oauth/token',
+                      {
+                        method: 'POST',
+                        headers: {
+                          'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                          grant_type: 'refresh_token',
+                          refresh_token: auth.refresh,
+                          client_id: CLIENT_ID,
+                        }),
+                      },
+                    )
+
+                    if (!response.ok) {
+                      if (response.status >= 500 && attempt < maxRetries) {
+                        response.body?.cancel()
+                        continue
+                      }
+
+                      throw new Error(
+                        `Token refresh failed: ${response.status}`,
+                      )
+                    }
+
+                    const json = (await response.json()) as {
+                      refresh_token: string
+                      access_token: string
+                      expires_in: number
+                    }
+
+                    // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
+                    await (client as any).auth.set({
+                      path: {
+                        id: 'anthropic',
+                      },
+                      body: {
+                        type: 'oauth',
+                        refresh: json.refresh_token,
+                        access: json.access_token,
+                        expires: Date.now() + json.expires_in * 1000,
+                      },
+                    })
+                    auth.access = json.access_token
+                    break
+                  } catch (error) {
+                    const isNetworkError =
+                      error instanceof Error &&
+                      (error.message.includes('fetch failed') ||
+                        ('code' in error &&
+                          (error.code === 'ECONNRESET' ||
+                            error.code === 'ECONNREFUSED' ||
+                            error.code === 'ETIMEDOUT' ||
+                            error.code === 'UND_ERR_CONNECT_TIMEOUT')))
+
+                    if (attempt < maxRetries && isNetworkError) {
+                      continue
+                    }
+
+                    throw error
+                  }
                 }
-                const json = (await response.json()) as {
-                  refresh_token: string
-                  access_token: string
-                  expires_in: number
-                }
-                // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
-                await (client as any).auth.set({
-                  path: {
-                    id: 'anthropic',
-                  },
-                  body: {
-                    type: 'oauth',
-                    refresh: json.refresh_token,
-                    access: json.access_token,
-                    expires: Date.now() + json.expires_in * 1000,
-                  },
-                })
-                auth.access = json.access_token
               }
 
               const requestHeaders = mergeHeaders(input, init)

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
 
                     if (!response.ok) {
                       if (response.status >= 500 && attempt < maxRetries) {
-                        response.body?.cancel()
+                        await response.body?.cancel()
                         continue
                       }
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -248,7 +248,66 @@ describe('auth.loader', () => {
     expect(mockClient.auth.set).toHaveBeenCalled()
   })
 
-  test('fetch wrapper throws on failed token refresh', async () => {
+  test('fetch wrapper retries transient token refresh failures', async () => {
+    let tokenRefreshCalls = 0
+
+    globalThis.fetch = mock((input: any) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+
+      if (url.includes('/v1/oauth/token')) {
+        tokenRefreshCalls += 1
+
+        if (tokenRefreshCalls === 1) {
+          return Promise.resolve(
+            new Response('Temporary failure', { status: 500 }),
+          )
+        }
+
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'new-refresh',
+              access_token: 'new-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'expired',
+          refresh: 'refresh',
+          expires: Date.now() - 1000,
+        }),
+      { models: {} },
+    )
+
+    await result.fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      body: '{}',
+    })
+
+    expect(tokenRefreshCalls).toBe(2)
+    expect(mockClient.auth.set).toHaveBeenCalledTimes(1)
+  })
+
+  test('fetch wrapper does not retry non-transient token refresh failures', async () => {
+    let tokenRefreshCalls = 0
+
     globalThis.fetch = mock((input: any) => {
       const url =
         typeof input === 'string'
@@ -257,6 +316,7 @@ describe('auth.loader', () => {
             ? input.toString()
             : input.url
       if (url.includes('/v1/oauth/token')) {
+        tokenRefreshCalls += 1
         return Promise.resolve(new Response('Forbidden', { status: 403 }))
       }
       return Promise.resolve(new Response(null, { status: 200 }))
@@ -280,6 +340,8 @@ describe('auth.loader', () => {
         body: '{}',
       }),
     ).rejects.toThrow('Token refresh failed: 403')
+
+    expect(tokenRefreshCalls).toBe(1)
   })
 
   test('fetch wrapper strips tool prefix from streaming response', async () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -94,9 +94,11 @@ describe('auth.methods', () => {
 
 describe('auth.loader', () => {
   const originalFetch = globalThis.fetch
+  const originalSetTimeout = globalThis.setTimeout
 
   beforeEach(() => {
     globalThis.fetch = originalFetch
+    globalThis.setTimeout = originalSetTimeout
   })
 
   test('returns empty object for non-oauth auth', async () => {
@@ -250,6 +252,14 @@ describe('auth.loader', () => {
 
   test('fetch wrapper retries transient token refresh failures', async () => {
     let tokenRefreshCalls = 0
+    const setTimeoutMock = mock((handler: TimerHandler) => {
+      if (typeof handler === 'function') {
+        handler()
+      }
+      return 0 as ReturnType<typeof setTimeout>
+    }) as typeof setTimeout
+
+    globalThis.setTimeout = setTimeoutMock
 
     globalThis.fetch = mock((input: any) => {
       const url =
@@ -302,6 +312,8 @@ describe('auth.loader', () => {
     })
 
     expect(tokenRefreshCalls).toBe(2)
+    expect(setTimeoutMock).toHaveBeenCalledTimes(1)
+    expect(setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), 500)
     expect(mockClient.auth.set).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
This ports the earlier retry fix onto the latest TypeScript rewrite from `main`.

### What changed

- retry transient refresh failures when the plugin refreshes an expired OAuth token
- use exponential backoff across 3 attempts total (initial request + 2 retries)
- retry only on transient cases (`5xx` and fetch/network failures)
- do not retry on `4xx` auth failures
- cancel the failed response body before retrying on `5xx`

### Tests

Added coverage in `src/tests/index.test.ts` for:

- retrying a transient `500` refresh failure and succeeding on the second attempt
- not retrying a non-transient `403` refresh failure

### Verification

- `bun test`
- `bun run build`

This supersedes the earlier JS-based PR and applies the same fix to the current TS layout.