### PR TITLE
fix: use form-urlencoded and Claude CLI User-Agent for OAuth token requests

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,16 +42,17 @@ export async function exchange(
   const result = await fetch('https://console.anthropic.com/v1/oauth/token', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': 'claude-cli/2.1.2 (external, cli)',
     },
-    body: JSON.stringify({
+    body: new URLSearchParams({
       code: splits[0],
       state: splits[1],
       grant_type: 'authorization_code',
       client_id: CLIENT_ID,
       redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
       code_verifier: verifier,
-    }),
+    }).toString(),
   })
 
   if (!result.ok) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,13 +67,14 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       {
                         method: 'POST',
                         headers: {
-                          'Content-Type': 'application/json',
+                          'Content-Type': 'application/x-www-form-urlencoded',
+                          'User-Agent': 'claude-cli/2.1.2 (external, cli)',
                         },
-                        body: JSON.stringify({
+                        body: new URLSearchParams({
                           grant_type: 'refresh_token',
-                          refresh_token: auth.refresh,
+                          refresh_token: auth.refresh!,
                           client_id: CLIENT_ID,
-                        }),
+                        }).toString(),
                       },
                     )
 

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -85,11 +85,13 @@ describe('exchange', () => {
     }
   })
 
-  test('sends correct request body', async () => {
+  test('sends correct request body as form-urlencoded', async () => {
     let capturedBody: string | undefined
+    let capturedHeaders: Record<string, string> | undefined
 
     globalThis.fetch = mock((input: any, init: any) => {
       capturedBody = init?.body
+      capturedHeaders = init?.headers
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -104,15 +106,17 @@ describe('exchange', () => {
 
     await exchange('mycode#mystate', 'myverifier')
 
-    const body = JSON.parse(capturedBody!)
-    expect(body.code).toBe('mycode')
-    expect(body.state).toBe('mystate')
-    expect(body.grant_type).toBe('authorization_code')
-    expect(body.client_id).toBe(CLIENT_ID)
-    expect(body.redirect_uri).toBe(
+    const body = new URLSearchParams(capturedBody!)
+    expect(body.get('code')).toBe('mycode')
+    expect(body.get('state')).toBe('mystate')
+    expect(body.get('grant_type')).toBe('authorization_code')
+    expect(body.get('client_id')).toBe(CLIENT_ID)
+    expect(body.get('redirect_uri')).toBe(
       'https://console.anthropic.com/oauth/code/callback',
     )
-    expect(body.code_verifier).toBe('myverifier')
+    expect(body.get('code_verifier')).toBe('myverifier')
+    expect(capturedHeaders?.['Content-Type']).toBe('application/x-www-form-urlencoded')
+    expect(capturedHeaders?.['User-Agent']).toBe('claude-cli/2.1.2 (external, cli)')
   })
 
   test('returns failed on non-OK response', async () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -242,9 +242,9 @@ describe('auth.loader', () => {
     // Should have called token endpoint first
     const tokenCall = fetchCalls.find((c) => c.url.includes('/v1/oauth/token'))
     expect(tokenCall).toBeDefined()
-    const tokenBody = JSON.parse(tokenCall!.body!)
-    expect(tokenBody.grant_type).toBe('refresh_token')
-    expect(tokenBody.refresh_token).toBe('old-refresh')
+    const tokenBody = new URLSearchParams(tokenCall!.body!)
+    expect(tokenBody.get('grant_type')).toBe('refresh_token')
+    expect(tokenBody.get('refresh_token')).toBe('old-refresh')
 
     // Should have called client.auth.set with new tokens
     expect(mockClient.auth.set).toHaveBeenCalled()


### PR DESCRIPTION
## Summary

- Switch `Content-Type` from `application/json` to `application/x-www-form-urlencoded` for both token exchange (`exchange()`) and token refresh requests
- Add `User-Agent: claude-cli/2.1.2 (external, cli)` header to token exchange and refresh requests — this header was already set for API calls in `setOAuthHeaders()` but was missing from the OAuth token endpoint requests
- Update tests to validate the new request format and headers

## Root Cause

Anthropic's `/v1/oauth/token` endpoint validates the request shape including `User-Agent`. Requests without the Claude CLI User-Agent are rate-limited with **HTTP 429** (`rate_limit_error: "Rate limited. Please try again later."`), even when the authorization code is valid.

The `Content-Type: application/json` was also incorrect — the OAuth token endpoint expects `application/x-www-form-urlencoded` per the OAuth 2.0 spec (RFC 6749 §4.1.3).

## Verified Fix

After applying both changes:
1. `opencode auth login` → Anthropic → Claude Pro/Max → **successfully obtains tokens**
2. Claude models work correctly through OpenCode

## Related Issues

- anomalyco/opencode#18329 — Anthropic Claude Pro/Max OAuth login fails with 429 on token exchange
- anomalyco/opencode#15562 — Claude OAuth token requires re-authentication after every usage limit reset

## Test plan

- [x] All 59 existing tests pass
- [x] `auth.test.ts` updated to verify form-urlencoded body and User-Agent header
- [x] `index.test.ts` updated to parse URLSearchParams for refresh token body
- [x] Manual end-to-end test: `opencode auth login` with Claude Pro/Max succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)