### PR TITLE
Fix OAuth flow to match new requirements

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,57 +1,135 @@
+import { appendFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:http'
 import { generatePKCE } from '@openauthjs/openauth/pkce'
-import { CLIENT_ID } from './constants'
+import { AUTHORIZE_URLS, CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from './constants'
 
-export async function authorize(mode: 'max' | 'console') {
-  const pkce = await generatePKCE()
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
+const DEBUG_LOG_PATH = '/tmp/opencode-anthropic-auth.log'
 
-  const url = new URL(
-    `https://${mode === 'console' ? 'console.anthropic.com' : 'claude.ai'}/oauth/authorize`,
-    import.meta.url,
-  )
-
-  url.searchParams.set('code', 'true')
-  url.searchParams.set('client_id', CLIENT_ID)
-  url.searchParams.set('response_type', 'code')
-  url.searchParams.set(
-    'redirect_uri',
-    'https://console.anthropic.com/oauth/code/callback',
-  )
-  url.searchParams.set(
-    'scope',
-    'org:create_api_key user:profile user:inference',
-  )
-  url.searchParams.set('code_challenge', pkce.challenge)
-  url.searchParams.set('code_challenge_method', 'S256')
-  url.searchParams.set('state', pkce.verifier)
-
-  return {
-    url: url.toString(),
-    verifier: pkce.verifier,
-  }
+function debug(event: string, data?: Record<string, unknown>) {
+  const details = data ? ` ${JSON.stringify(data)}` : ''
+  const line = `[${new Date().toISOString()}] [anthropic-auth] ${event}${details}\n`
+  void appendFile(DEBUG_LOG_PATH, line)
 }
 
-export type ExchangeResult =
-  | { type: 'success'; refresh: string; access: string; expires: number }
-  | { type: 'failed' }
+type CallbackParams = {
+  code: string
+  state: string
+}
 
-export async function exchange(
-  code: string,
+type AuthorizationResult = {
+  url: string
+  redirectUri: string
+  state: string
+  callback: () => Promise<ExchangeResult>
+}
+
+async function listen(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve())
+  })
+}
+
+async function close(server: Server) {
+  if (!server.listening) return
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve()
+    })
+  })
+}
+
+function generateState() {
+  return crypto.randomUUID().replace(/-/g, '')
+}
+
+function parseCallbackInput(input: string) {
+  const trimmed = input.trim()
+
+  try {
+    const url = new URL(trimmed)
+    const code = url.searchParams.get('code')
+    const state = url.searchParams.get('state')
+    if (code && state) {
+      return { code, state }
+    }
+  } catch {
+    // Fall through to legacy/manual formats.
+  }
+
+  const hashSplits = trimmed.split('#')
+  if (hashSplits.length === 2 && hashSplits[0] && hashSplits[1]) {
+    return { code: hashSplits[0], state: hashSplits[1] }
+  }
+
+  const params = new URLSearchParams(trimmed)
+  const code = params.get('code')
+  const state = params.get('state')
+  if (code && state) {
+    return { code, state }
+  }
+
+  return null
+}
+
+function successPage() {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Authorization complete</title>
+  </head>
+  <body>
+    <h1>Authorization complete</h1>
+    <p>You can close this window and return to OpenCode.</p>
+  </body>
+</html>`
+}
+
+async function exchangeCode(
+  callback: CallbackParams,
   verifier: string,
+  redirectUri: string,
 ): Promise<ExchangeResult> {
-  const splits = code.split('#')
-  const result = await fetch('https://console.anthropic.com/v1/oauth/token', {
+  debug('token.exchange.start', {
+    tokenUrl: TOKEN_URL,
+    redirectUri,
+    codeLength: callback.code.length,
+    stateLength: callback.state.length,
+    verifierLength: verifier.length,
+  })
+
+  const result = await fetch(TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Accept: 'application/json, text/plain, */*',
+      'User-Agent': 'axios/1.13.6',
     },
     body: JSON.stringify({
-      code: splits[0],
-      state: splits[1],
+      code: callback.code,
+      state: callback.state,
       grant_type: 'authorization_code',
       client_id: CLIENT_ID,
-      redirect_uri: 'https://console.anthropic.com/oauth/code/callback',
+      redirect_uri: redirectUri,
       code_verifier: verifier,
     }),
+  })
+
+  const responseText = await result.text()
+
+  debug('token.exchange.response', {
+    ok: result.ok,
+    status: result.status,
+    statusText: result.statusText,
+    bodyPreview: responseText.slice(0, 500),
   })
 
   if (!result.ok) {
@@ -60,15 +138,207 @@ export async function exchange(
     }
   }
 
-  const json = (await result.json()) as {
+  const json = JSON.parse(responseText) as {
     refresh_token: string
     access_token: string
     expires_in: number
   }
+
+  debug('token.exchange.success', {
+    expiresIn: json.expires_in,
+    hasRefresh: Boolean(json.refresh_token),
+    hasAccess: Boolean(json.access_token),
+  })
+
   return {
     type: 'success',
     refresh: json.refresh_token,
     access: json.access_token,
     expires: Date.now() + json.expires_in * 1000,
   }
+}
+
+async function createCallbackServer(expectedState: string) {
+  let settled = false
+  let cleanupTimer: ReturnType<typeof setTimeout> | undefined
+  let resolveResult: ((result: string) => void) | undefined
+  let rejectResult: ((error: Error) => void) | undefined
+
+  const server = createServer((req, res) => {
+    const requestUrl = new URL(
+      req.url ?? '/',
+      `http://${req.headers.host ?? 'localhost'}`,
+    )
+
+    if (requestUrl.pathname !== '/callback') {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+      res.end('Not found')
+      return
+    }
+
+    const code = requestUrl.searchParams.get('code')
+    const state = requestUrl.searchParams.get('state')
+
+    if (!code || !state) {
+      debug('callback.invalid', {
+        pathname: requestUrl.pathname,
+        hasCode: Boolean(code),
+        hasState: Boolean(state),
+      })
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
+      res.end('Missing code or state')
+      return
+    }
+
+    if (state !== expectedState) {
+      debug('callback.state_mismatch', {
+        pathname: requestUrl.pathname,
+        expectedStateLength: expectedState.length,
+        actualStateLength: state.length,
+      })
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
+      res.end('Invalid state')
+      if (!settled) {
+        settled = true
+        rejectResult?.(new Error('OAuth state mismatch'))
+      }
+      return
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    res.end(successPage())
+
+    debug('callback.received', {
+      pathname: requestUrl.pathname,
+      host: req.headers.host ?? null,
+      codeLength: code.length,
+      stateLength: state.length,
+    })
+
+    if (!settled) {
+      settled = true
+      resolveResult?.(requestUrl.toString())
+    }
+  })
+
+  const callbackUrl = new Promise<string>((resolve, reject) => {
+    resolveResult = resolve
+    rejectResult = reject
+  })
+
+  await listen(server)
+
+  cleanupTimer = setTimeout(() => {
+    if (settled) return
+    settled = true
+    rejectResult?.(new Error('Timed out waiting for OAuth callback'))
+  }, CALLBACK_TIMEOUT_MS)
+
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    clearTimeout(cleanupTimer)
+    await close(server)
+    throw new Error('Failed to allocate localhost redirect port')
+  }
+
+  return {
+    redirectUri: `http://localhost:${address.port}/callback`,
+    waitForCallback: async () => {
+      debug('callback.waiting', {
+        redirectUri: `http://localhost:${address.port}/callback`,
+      })
+
+      try {
+        return await callbackUrl
+      } finally {
+        if (cleanupTimer) clearTimeout(cleanupTimer)
+        await close(server)
+      }
+    },
+  }
+}
+
+export async function authorize(
+  mode: 'max' | 'console',
+): Promise<AuthorizationResult> {
+  const pkce = await generatePKCE()
+  const state = generateState()
+  const callbackServer = await createCallbackServer(state)
+
+  const url = new URL(AUTHORIZE_URLS[mode], import.meta.url)
+  url.searchParams.set('code', 'true')
+  url.searchParams.set('client_id', CLIENT_ID)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('redirect_uri', callbackServer.redirectUri)
+  url.searchParams.set('scope', OAUTH_SCOPES.join(' '))
+  url.searchParams.set('code_challenge', pkce.challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', state)
+
+  debug('authorize.created', {
+    mode,
+    authorizeUrl: AUTHORIZE_URLS[mode],
+    tokenUrl: TOKEN_URL,
+    redirectUri: callbackServer.redirectUri,
+    scopeCount: OAUTH_SCOPES.length,
+  })
+
+  return {
+    url: url.toString(),
+    redirectUri: callbackServer.redirectUri,
+    state,
+    callback: async () => {
+      try {
+        const callbackUrl = await callbackServer.waitForCallback()
+        debug('authorize.callback_url', {
+          redirectUri: callbackServer.redirectUri,
+          callbackUrl,
+        })
+        return await exchange(
+          callbackUrl,
+          pkce.verifier,
+          callbackServer.redirectUri,
+          state,
+        )
+      } catch (error) {
+        debug('authorize.callback_failed', {
+          message: error instanceof Error ? error.message : String(error),
+        })
+        return { type: 'failed' }
+      }
+    },
+  }
+}
+
+export type ExchangeResult =
+  | { type: 'success'; refresh: string; access: string; expires: number }
+  | { type: 'failed' }
+
+export async function exchange(
+  input: string,
+  verifier: string,
+  redirectUri: string,
+  expectedState?: string,
+): Promise<ExchangeResult> {
+  const callback = parseCallbackInput(input)
+  if (!callback) {
+    debug('exchange.parse_failed', {
+      inputPreview: input.slice(0, 200),
+    })
+    return {
+      type: 'failed',
+    }
+  }
+
+  if (expectedState && callback.state !== expectedState) {
+    debug('exchange.state_mismatch', {
+      expectedStateLength: expectedState.length,
+      actualStateLength: callback.state.length,
+    })
+    return {
+      type: 'failed',
+    }
+  }
+
+  return exchangeCode(callback, verifier, redirectUri)
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,16 +1,8 @@
-import { appendFile } from 'node:fs/promises'
 import { createServer, type Server } from 'node:http'
 import { generatePKCE } from '@openauthjs/openauth/pkce'
 import { AUTHORIZE_URLS, CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from './constants'
 
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
-const DEBUG_LOG_PATH = '/tmp/opencode-anthropic-auth.log'
-
-function debug(event: string, data?: Record<string, unknown>) {
-  const details = data ? ` ${JSON.stringify(data)}` : ''
-  const line = `[${new Date().toISOString()}] [anthropic-auth] ${event}${details}\n`
-  void appendFile(DEBUG_LOG_PATH, line)
-}
 
 type CallbackParams = {
   code: string
@@ -98,14 +90,6 @@ async function exchangeCode(
   verifier: string,
   redirectUri: string,
 ): Promise<ExchangeResult> {
-  debug('token.exchange.start', {
-    tokenUrl: TOKEN_URL,
-    redirectUri,
-    codeLength: callback.code.length,
-    stateLength: callback.state.length,
-    verifierLength: verifier.length,
-  })
-
   const result = await fetch(TOKEN_URL, {
     method: 'POST',
     headers: {
@@ -123,32 +107,17 @@ async function exchangeCode(
     }),
   })
 
-  const responseText = await result.text()
-
-  debug('token.exchange.response', {
-    ok: result.ok,
-    status: result.status,
-    statusText: result.statusText,
-    bodyPreview: responseText.slice(0, 500),
-  })
-
   if (!result.ok) {
     return {
       type: 'failed',
     }
   }
 
-  const json = JSON.parse(responseText) as {
+  const json = (await result.json()) as {
     refresh_token: string
     access_token: string
     expires_in: number
   }
-
-  debug('token.exchange.success', {
-    expiresIn: json.expires_in,
-    hasRefresh: Boolean(json.refresh_token),
-    hasAccess: Boolean(json.access_token),
-  })
 
   return {
     type: 'success',
@@ -180,22 +149,12 @@ async function createCallbackServer(expectedState: string) {
     const state = requestUrl.searchParams.get('state')
 
     if (!code || !state) {
-      debug('callback.invalid', {
-        pathname: requestUrl.pathname,
-        hasCode: Boolean(code),
-        hasState: Boolean(state),
-      })
       res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
       res.end('Missing code or state')
       return
     }
 
     if (state !== expectedState) {
-      debug('callback.state_mismatch', {
-        pathname: requestUrl.pathname,
-        expectedStateLength: expectedState.length,
-        actualStateLength: state.length,
-      })
       res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
       res.end('Invalid state')
       if (!settled) {
@@ -207,13 +166,6 @@ async function createCallbackServer(expectedState: string) {
 
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
     res.end(successPage())
-
-    debug('callback.received', {
-      pathname: requestUrl.pathname,
-      host: req.headers.host ?? null,
-      codeLength: code.length,
-      stateLength: state.length,
-    })
 
     if (!settled) {
       settled = true
@@ -244,10 +196,6 @@ async function createCallbackServer(expectedState: string) {
   return {
     redirectUri: `http://localhost:${address.port}/callback`,
     waitForCallback: async () => {
-      debug('callback.waiting', {
-        redirectUri: `http://localhost:${address.port}/callback`,
-      })
-
       try {
         return await callbackUrl
       } finally {
@@ -275,14 +223,6 @@ export async function authorize(
   url.searchParams.set('code_challenge_method', 'S256')
   url.searchParams.set('state', state)
 
-  debug('authorize.created', {
-    mode,
-    authorizeUrl: AUTHORIZE_URLS[mode],
-    tokenUrl: TOKEN_URL,
-    redirectUri: callbackServer.redirectUri,
-    scopeCount: OAUTH_SCOPES.length,
-  })
-
   return {
     url: url.toString(),
     redirectUri: callbackServer.redirectUri,
@@ -290,20 +230,13 @@ export async function authorize(
     callback: async () => {
       try {
         const callbackUrl = await callbackServer.waitForCallback()
-        debug('authorize.callback_url', {
-          redirectUri: callbackServer.redirectUri,
-          callbackUrl,
-        })
         return await exchange(
           callbackUrl,
           pkce.verifier,
           callbackServer.redirectUri,
           state,
         )
-      } catch (error) {
-        debug('authorize.callback_failed', {
-          message: error instanceof Error ? error.message : String(error),
-        })
+      } catch {
         return { type: 'failed' }
       }
     },
@@ -322,19 +255,12 @@ export async function exchange(
 ): Promise<ExchangeResult> {
   const callback = parseCallbackInput(input)
   if (!callback) {
-    debug('exchange.parse_failed', {
-      inputPreview: input.slice(0, 200),
-    })
     return {
       type: 'failed',
     }
   }
 
   if (expectedState && callback.state !== expectedState) {
-    debug('exchange.state_mismatch', {
-      expectedStateLength: expectedState.length,
-      actualStateLength: callback.state.length,
-    })
     return {
       type: 'failed',
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,21 @@
 export const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
 
+export const AUTHORIZE_URLS = {
+  console: 'https://platform.claude.com/oauth/authorize',
+  max: 'https://claude.ai/oauth/authorize',
+} as const
+
+export const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
+
+export const OAUTH_SCOPES = [
+  'org:create_api_key',
+  'user:profile',
+  'user:inference',
+  'user:sessions:claude_code',
+  'user:mcp_servers',
+  'user:file_upload',
+]
+
 export const TOOL_PREFIX = 'mcp_'
 
 export const REQUIRED_BETAS = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@opencode-ai/plugin'
-import { authorize, exchange } from './auth'
-import { CLIENT_ID } from './constants'
+import { authorize } from './auth'
+import { CLIENT_ID, TOKEN_URL } from './constants'
 import {
   createStrippedStream,
   mergeHeaders,
@@ -62,20 +62,19 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       await new Promise((resolve) => setTimeout(resolve, delay))
                     }
 
-                    const response = await fetch(
-                      'https://console.anthropic.com/v1/oauth/token',
-                      {
-                        method: 'POST',
-                        headers: {
-                          'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({
-                          grant_type: 'refresh_token',
-                          refresh_token: auth.refresh,
-                          client_id: CLIENT_ID,
-                        }),
+                    const response = await fetch(TOKEN_URL, {
+                      method: 'POST',
+                      headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json, text/plain, */*',
+                        'User-Agent': 'axios/1.13.6',
                       },
-                    )
+                      body: JSON.stringify({
+                        grant_type: 'refresh_token',
+                        refresh_token: auth.refresh,
+                        client_id: CLIENT_ID,
+                      }),
+                    })
 
                     if (!response.ok) {
                       if (response.status >= 500 && attempt < maxRetries) {
@@ -156,15 +155,12 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
           label: 'Claude Pro/Max',
           type: 'oauth',
           authorize: async () => {
-            const { url, verifier } = await authorize('max')
+            const result = await authorize('max')
             return {
-              url: url,
-              instructions: 'Paste the authorization code here: ',
-              method: 'code',
-              callback: async (code: string) => {
-                const credentials = await exchange(code, verifier)
-                return credentials
-              },
+              url: result.url,
+              instructions: 'Complete authorization in the browser.',
+              method: 'auto',
+              callback: result.callback,
             }
           },
         },
@@ -172,13 +168,13 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
           label: 'Create an API Key',
           type: 'oauth',
           authorize: async () => {
-            const { url, verifier } = await authorize('console')
+            const auth = await authorize('console')
             return {
-              url: url,
-              instructions: 'Paste the authorization code here: ',
-              method: 'code',
-              callback: async (code: string) => {
-                const credentials = await exchange(code, verifier)
+              url: auth.url,
+              instructions: 'Complete authorization in the browser.',
+              method: 'auto',
+              callback: async () => {
+                const credentials = await auth.callback()
                 if (credentials.type === 'failed') return credentials
                 const result = await fetch(
                   `https://api.anthropic.com/api/oauth/claude_cli/create_api_key`,

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,91 +1,141 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { authorize, exchange } from '../auth'
-import { CLIENT_ID } from '../constants'
+import { CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from '../constants'
+
+const originalFetch = globalThis.fetch
+
+function mockTokenEndpoint(onBody?: (body: string) => void) {
+  globalThis.fetch = mock((input: any, init?: RequestInit) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    if (url === TOKEN_URL) {
+      if (onBody && init?.body) onBody(init.body as string)
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            refresh_token: 'refresh_abc',
+            access_token: 'access_xyz',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    }
+
+    return originalFetch(input, init)
+  }) as unknown as typeof fetch
+}
 
 describe('authorize', () => {
-  test('returns a URL and verifier for max mode', async () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns a localhost callback URL for max mode', async () => {
+    mockTokenEndpoint()
     const result = await authorize('max')
 
     expect(result.url).toBeString()
-    expect(result.verifier).toBeString()
+    expect(result.redirectUri).toStartWith('http://localhost:')
 
     const url = new URL(result.url)
     expect(url.origin).toBe('https://claude.ai')
     expect(url.pathname).toBe('/oauth/authorize')
+    expect(url.searchParams.get('redirect_uri')).toBe(result.redirectUri)
+
+    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await result.callback()
   })
 
-  test('returns a URL and verifier for console mode', async () => {
+  test('returns a localhost callback URL for console mode', async () => {
+    mockTokenEndpoint()
     const result = await authorize('console')
 
     const url = new URL(result.url)
-    expect(url.origin).toBe('https://console.anthropic.com')
+    expect(url.origin).toBe('https://platform.claude.com')
     expect(url.pathname).toBe('/oauth/authorize')
+
+    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await result.callback()
   })
 
   test('sets required OAuth query params', async () => {
+    mockTokenEndpoint()
     const result = await authorize('max')
     const url = new URL(result.url)
 
     expect(url.searchParams.get('code')).toBe('true')
     expect(url.searchParams.get('client_id')).toBe(CLIENT_ID)
     expect(url.searchParams.get('response_type')).toBe('code')
-    expect(url.searchParams.get('redirect_uri')).toBe(
-      'https://console.anthropic.com/oauth/code/callback',
-    )
-    expect(url.searchParams.get('scope')).toBe(
-      'org:create_api_key user:profile user:inference',
-    )
+    expect(url.searchParams.get('redirect_uri')).toBe(result.redirectUri)
+    expect(url.searchParams.get('scope')).toBe(OAUTH_SCOPES.join(' '))
     expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+
+    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await result.callback()
   })
 
-  test('includes PKCE challenge and verifier as state', async () => {
+  test('captures the callback and exchanges the code', async () => {
+    let capturedBody: string | undefined
+    mockTokenEndpoint((body) => {
+      capturedBody = body
+    })
+
     const result = await authorize('max')
-    const url = new URL(result.url)
+    const callbackPromise = result.callback()
 
-    expect(url.searchParams.get('code_challenge')).toBeString()
-    expect(url.searchParams.get('state')).toBe(result.verifier)
+    const browserResponse = await originalFetch(
+      `${result.redirectUri}?code=mycode&state=${result.state}`,
+    )
+
+    expect(browserResponse.status).toBe(200)
+
+    const exchangeResult = await callbackPromise
+    expect(exchangeResult.type).toBe('success')
+
+    const body = JSON.parse(capturedBody!)
+    expect(body.code).toBe('mycode')
+    expect(body.state).toBe(result.state)
+    expect(body.redirect_uri).toBe(result.redirectUri)
   })
 
-  test('generates unique PKCE values per call', async () => {
-    const result1 = await authorize('max')
-    const result2 = await authorize('max')
+  test('fails on state mismatch', async () => {
+    const fetchMock = mock((input: any, init?: RequestInit) =>
+      originalFetch(input, init),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    expect(result1.verifier).not.toBe(result2.verifier)
+    const result = await authorize('max')
+    const callbackPromise = result.callback()
+
+    const browserResponse = await originalFetch(
+      `${result.redirectUri}?code=mycode&state=wrong-state`,
+    )
+
+    expect(browserResponse.status).toBe(400)
+    expect(await callbackPromise).toEqual({ type: 'failed' })
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })
 
 describe('exchange', () => {
-  const originalFetch = globalThis.fetch
-
   beforeEach(() => {
     globalThis.fetch = originalFetch
   })
 
-  test('returns success with tokens on HTTP 200', async () => {
-    const mockTokens = {
-      refresh_token: 'refresh_abc',
-      access_token: 'access_xyz',
-      expires_in: 3600,
-    }
-
-    globalThis.fetch = mock(() =>
-      Promise.resolve(
-        new Response(JSON.stringify(mockTokens), { status: 200 }),
-      ),
-    ) as unknown as typeof fetch
-
-    const before = Date.now()
-    const result = await exchange('code123#state456', 'verifier789')
-
-    expect(result.type).toBe('success')
-    if (result.type === 'success') {
-      expect(result.refresh).toBe('refresh_abc')
-      expect(result.access).toBe('access_xyz')
-      expect(result.expires).toBeGreaterThanOrEqual(before + 3600 * 1000)
-    }
+  afterEach(() => {
+    globalThis.fetch = originalFetch
   })
 
-  test('sends correct request body', async () => {
+  test('accepts a full localhost callback URL', async () => {
     let capturedBody: string | undefined
 
     globalThis.fetch = mock((input: any, init: any) => {
@@ -102,46 +152,42 @@ describe('exchange', () => {
       )
     }) as unknown as typeof fetch
 
-    await exchange('mycode#mystate', 'myverifier')
+    await exchange(
+      'http://localhost:59233/callback?code=mycode&state=mystate',
+      'myverifier',
+      'http://localhost:59233/callback',
+      'mystate',
+    )
 
     const body = JSON.parse(capturedBody!)
     expect(body.code).toBe('mycode')
     expect(body.state).toBe('mystate')
-    expect(body.grant_type).toBe('authorization_code')
-    expect(body.client_id).toBe(CLIENT_ID)
-    expect(body.redirect_uri).toBe(
-      'https://console.anthropic.com/oauth/code/callback',
+  })
+
+  test('returns failed on invalid callback input', async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(null)))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await exchange(
+      'not-a-callback',
+      'verifier',
+      'http://localhost:59233/callback',
     )
-    expect(body.code_verifier).toBe('myverifier')
-  })
-
-  test('returns failed on non-OK response', async () => {
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response('Unauthorized', { status: 401 })),
-    ) as unknown as typeof fetch
-
-    const result = await exchange('code#state', 'verifier')
     expect(result.type).toBe('failed')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  test('posts to the correct token endpoint', async () => {
-    let capturedUrl: string | undefined
+  test('returns failed on state mismatch', async () => {
+    const fetchMock = mock(() => Promise.resolve(new Response(null)))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    globalThis.fetch = mock((input: any) => {
-      capturedUrl = typeof input === 'string' ? input : input.url
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            refresh_token: 'r',
-            access_token: 'a',
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        ),
-      )
-    }) as unknown as typeof fetch
-
-    await exchange('c#s', 'v')
-    expect(capturedUrl).toBe('https://console.anthropic.com/v1/oauth/token')
+    const result = await exchange(
+      'code#wrong',
+      'verifier',
+      'http://localhost:59233/callback',
+      'expected',
+    )
+    expect(result.type).toBe('failed')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,11 +1,14 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { authorize, exchange } from '../auth'
 import { CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from '../constants'
 
-const originalFetch = globalThis.fetch
+const realFetch = globalThis.fetch
 
 function mockTokenEndpoint(onBody?: (body: string) => void) {
-  globalThis.fetch = mock((input: any, init?: RequestInit) => {
+  return spyOn(globalThis, 'fetch').mockImplementation(((
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
     const url =
       typeof input === 'string'
         ? input
@@ -26,19 +29,15 @@ function mockTokenEndpoint(onBody?: (body: string) => void) {
       )
     }
 
-    return originalFetch(input, init)
-  }) as unknown as typeof fetch
+    return realFetch(input, init)
+  }) as typeof fetch)
 }
 
+afterEach(() => {
+  mock.restore()
+})
+
 describe('authorize', () => {
-  beforeEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
   test('returns a localhost callback URL for max mode', async () => {
     mockTokenEndpoint()
     const result = await authorize('max')
@@ -51,7 +50,7 @@ describe('authorize', () => {
     expect(url.pathname).toBe('/oauth/authorize')
     expect(url.searchParams.get('redirect_uri')).toBe(result.redirectUri)
 
-    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await realFetch(`${result.redirectUri}?code=test&state=${result.state}`)
     await result.callback()
   })
 
@@ -63,7 +62,7 @@ describe('authorize', () => {
     expect(url.origin).toBe('https://platform.claude.com')
     expect(url.pathname).toBe('/oauth/authorize')
 
-    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await realFetch(`${result.redirectUri}?code=test&state=${result.state}`)
     await result.callback()
   })
 
@@ -79,7 +78,7 @@ describe('authorize', () => {
     expect(url.searchParams.get('scope')).toBe(OAUTH_SCOPES.join(' '))
     expect(url.searchParams.get('code_challenge_method')).toBe('S256')
 
-    await originalFetch(`${result.redirectUri}?code=test&state=${result.state}`)
+    await realFetch(`${result.redirectUri}?code=test&state=${result.state}`)
     await result.callback()
   })
 
@@ -92,7 +91,7 @@ describe('authorize', () => {
     const result = await authorize('max')
     const callbackPromise = result.callback()
 
-    const browserResponse = await originalFetch(
+    const browserResponse = await realFetch(
       `${result.redirectUri}?code=mycode&state=${result.state}`,
     )
 
@@ -108,38 +107,33 @@ describe('authorize', () => {
   })
 
   test('fails on state mismatch', async () => {
-    const fetchMock = mock((input: any, init?: RequestInit) =>
-      originalFetch(input, init),
-    )
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
+      input: string | URL | Request,
+      init?: RequestInit,
+    ) => realFetch(input, init)) as typeof fetch)
 
     const result = await authorize('max')
     const callbackPromise = result.callback()
 
-    const browserResponse = await originalFetch(
+    const browserResponse = await realFetch(
       `${result.redirectUri}?code=mycode&state=wrong-state`,
     )
 
     expect(browserResponse.status).toBe(400)
     expect(await callbackPromise).toEqual({ type: 'failed' })
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })
 
 describe('exchange', () => {
-  beforeEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
-  afterEach(() => {
-    globalThis.fetch = originalFetch
-  })
-
   test('accepts a full localhost callback URL', async () => {
     let capturedBody: string | undefined
 
-    globalThis.fetch = mock((input: any, init: any) => {
-      capturedBody = init?.body
+    spyOn(globalThis, 'fetch').mockImplementation(((
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as string
       return Promise.resolve(
         new Response(
           JSON.stringify({
@@ -150,7 +144,7 @@ describe('exchange', () => {
           { status: 200 },
         ),
       )
-    }) as unknown as typeof fetch
+    }) as typeof fetch)
 
     await exchange(
       'http://localhost:59233/callback?code=mycode&state=mystate',
@@ -165,8 +159,8 @@ describe('exchange', () => {
   })
 
   test('returns failed on invalid callback input', async () => {
-    const fetchMock = mock(() => Promise.resolve(new Response(null)))
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((() =>
+      Promise.resolve(new Response(null))) as unknown as typeof fetch)
 
     const result = await exchange(
       'not-a-callback',
@@ -174,12 +168,12 @@ describe('exchange', () => {
       'http://localhost:59233/callback',
     )
     expect(result.type).toBe('failed')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   test('returns failed on state mismatch', async () => {
-    const fetchMock = mock(() => Promise.resolve(new Response(null)))
-    globalThis.fetch = fetchMock as unknown as typeof fetch
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((() =>
+      Promise.resolve(new Response(null))) as unknown as typeof fetch)
 
     const result = await exchange(
       'code#wrong',
@@ -188,6 +182,6 @@ describe('exchange', () => {
       'expected',
     )
     expect(result.type).toBe('failed')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Anthropic just changed their Claude Code OAuth flow, this updates the plugin to use the new flow.

## Summary

- Replace the manual code-paste OAuth flow with an automatic localhost callback server that spins up a temporary HTTP server on a random port, captures the authorization code when the browser redirects back, and exchanges it for tokens automatically.
- Update OAuth URLs from `console.anthropic.com` to `platform.claude.com` and add new scopes (`user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload`).
- Extract shared OAuth constants (`AUTHORIZE_URLS`, `TOKEN_URL`, `OAUTH_SCOPES`) into `constants.ts`

## Details

The main change is in `src/auth.ts`, which now:

1. Creates a localhost HTTP server on a random port to serve as the OAuth `redirect_uri`
2. Returns `method: 'auto'` instead of `method: 'code'` so OpenCode uses the automatic callback flow rather than prompting the user to paste a code
3. Validates the OAuth `state` parameter on the callback to prevent CSRF
4. Serves a simple success HTML page when the callback is received
5. Has a 5-minute timeout for the callback server

Tests have been updated to exercise the new localhost callback flow, including testing the full authorize -> callback -> exchange cycle and state mismatch rejection. While I was in here I also switched the tests to use Bun's actual `spyOn` functionality for mocking rather than monkey-patching `globalThis.fetch`.