### PR TITLE
Replace localhost OAuth callback with hosted code-paste flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 
 # for now...
 .opencode/
+.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ex-machina/opencode-anthropic-auth",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,41 +1,22 @@
-import { createServer, type Server } from 'node:http'
 import { generatePKCE } from '@openauthjs/openauth/pkce'
-import { AUTHORIZE_URLS, CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from './constants'
-
-const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000
+import {
+  AUTHORIZE_URLS,
+  CLIENT_ID,
+  CODE_CALLBACK_URL,
+  OAUTH_SCOPES,
+  TOKEN_URL,
+} from './constants'
 
 type CallbackParams = {
   code: string
   state: string
 }
 
-type AuthorizationResult = {
+export type AuthorizationResult = {
   url: string
   redirectUri: string
   state: string
-  callback: () => Promise<ExchangeResult>
-}
-
-async function listen(server: Server) {
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', reject)
-    server.listen(0, '127.0.0.1', () => resolve())
-  })
-}
-
-async function close(server: Server) {
-  if (!server.listening) return
-
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error)
-        return
-      }
-
-      resolve()
-    })
-  })
+  verifier: string
 }
 
 function generateState() {
@@ -69,20 +50,6 @@ function parseCallbackInput(input: string) {
   }
 
   return null
-}
-
-function successPage() {
-  return `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Authorization complete</title>
-  </head>
-  <body>
-    <h1>Authorization complete</h1>
-    <p>You can close this window and return to OpenCode.</p>
-  </body>
-</html>`
 }
 
 async function exchangeCode(
@@ -127,97 +94,17 @@ async function exchangeCode(
   }
 }
 
-async function createCallbackServer(expectedState: string) {
-  let settled = false
-  let cleanupTimer: ReturnType<typeof setTimeout> | undefined
-  let resolveResult: ((result: string) => void) | undefined
-  let rejectResult: ((error: Error) => void) | undefined
-
-  const server = createServer((req, res) => {
-    const requestUrl = new URL(
-      req.url ?? '/',
-      `http://${req.headers.host ?? 'localhost'}`,
-    )
-
-    if (requestUrl.pathname !== '/callback') {
-      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
-      res.end('Not found')
-      return
-    }
-
-    const code = requestUrl.searchParams.get('code')
-    const state = requestUrl.searchParams.get('state')
-
-    if (!code || !state) {
-      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
-      res.end('Missing code or state')
-      return
-    }
-
-    if (state !== expectedState) {
-      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' })
-      res.end('Invalid state')
-      if (!settled) {
-        settled = true
-        rejectResult?.(new Error('OAuth state mismatch'))
-      }
-      return
-    }
-
-    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
-    res.end(successPage())
-
-    if (!settled) {
-      settled = true
-      resolveResult?.(requestUrl.toString())
-    }
-  })
-
-  const callbackUrl = new Promise<string>((resolve, reject) => {
-    resolveResult = resolve
-    rejectResult = reject
-  })
-
-  await listen(server)
-
-  cleanupTimer = setTimeout(() => {
-    if (settled) return
-    settled = true
-    rejectResult?.(new Error('Timed out waiting for OAuth callback'))
-  }, CALLBACK_TIMEOUT_MS)
-
-  const address = server.address()
-  if (!address || typeof address === 'string') {
-    clearTimeout(cleanupTimer)
-    await close(server)
-    throw new Error('Failed to allocate localhost redirect port')
-  }
-
-  return {
-    redirectUri: `http://localhost:${address.port}/callback`,
-    waitForCallback: async () => {
-      try {
-        return await callbackUrl
-      } finally {
-        if (cleanupTimer) clearTimeout(cleanupTimer)
-        await close(server)
-      }
-    },
-  }
-}
-
 export async function authorize(
   mode: 'max' | 'console',
 ): Promise<AuthorizationResult> {
   const pkce = await generatePKCE()
   const state = generateState()
-  const callbackServer = await createCallbackServer(state)
 
   const url = new URL(AUTHORIZE_URLS[mode], import.meta.url)
   url.searchParams.set('code', 'true')
   url.searchParams.set('client_id', CLIENT_ID)
   url.searchParams.set('response_type', 'code')
-  url.searchParams.set('redirect_uri', callbackServer.redirectUri)
+  url.searchParams.set('redirect_uri', CODE_CALLBACK_URL)
   url.searchParams.set('scope', OAUTH_SCOPES.join(' '))
   url.searchParams.set('code_challenge', pkce.challenge)
   url.searchParams.set('code_challenge_method', 'S256')
@@ -225,21 +112,9 @@ export async function authorize(
 
   return {
     url: url.toString(),
-    redirectUri: callbackServer.redirectUri,
+    redirectUri: CODE_CALLBACK_URL,
     state,
-    callback: async () => {
-      try {
-        const callbackUrl = await callbackServer.waitForCallback()
-        return await exchange(
-          callbackUrl,
-          pkce.verifier,
-          callbackServer.redirectUri,
-          state,
-        )
-      } catch {
-        return { type: 'failed' }
-      }
-    },
+    verifier: pkce.verifier,
   }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,9 @@ export const AUTHORIZE_URLS = {
   max: 'https://claude.ai/oauth/authorize',
 } as const
 
+export const CODE_CALLBACK_URL =
+  'https://platform.claude.com/oauth/code/callback'
+
 export const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
 
 export const OAUTH_SCOPES = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from '@opencode-ai/plugin'
-import { authorize } from './auth'
+import { authorize, exchange } from './auth'
 import { CLIENT_ID, TOKEN_URL } from './constants'
 import {
   createStrippedStream,
@@ -158,9 +158,16 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
             const result = await authorize('max')
             return {
               url: result.url,
-              instructions: 'Complete authorization in the browser.',
-              method: 'auto',
-              callback: result.callback,
+              instructions: 'Paste the authorization code here:',
+              method: 'code',
+              callback: async (code: string) => {
+                return exchange(
+                  code,
+                  result.verifier,
+                  result.redirectUri,
+                  result.state,
+                )
+              },
             }
           },
         },
@@ -168,15 +175,20 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
           label: 'Create an API Key',
           type: 'oauth',
           authorize: async () => {
-            const auth = await authorize('console')
+            const result = await authorize('console')
             return {
-              url: auth.url,
-              instructions: 'Complete authorization in the browser.',
-              method: 'auto',
-              callback: async () => {
-                const credentials = await auth.callback()
+              url: result.url,
+              instructions: 'Paste the authorization code here:',
+              method: 'code',
+              callback: async (code: string) => {
+                const credentials = await exchange(
+                  code,
+                  result.verifier,
+                  result.redirectUri,
+                  result.state,
+                )
                 if (credentials.type === 'failed') return credentials
-                const result = await fetch(
+                const apiKey = await fetch(
                   `https://api.anthropic.com/api/oauth/claude_cli/create_api_key`,
                   {
                     method: 'POST',
@@ -186,7 +198,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                     },
                   },
                 ).then((r) => r.json() as Promise<{ raw_key: string }>)
-                return { type: 'success' as const, key: result.raw_key }
+                return { type: 'success' as const, key: apiKey.raw_key }
               },
             }
           },

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,134 +1,90 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { authorize, exchange } from '../auth'
-import { CLIENT_ID, OAUTH_SCOPES, TOKEN_URL } from '../constants'
-
-function browserFetch(input: string | URL | Request, init?: RequestInit) {
-  return Bun.fetch(input, init)
-}
-
-function mockTokenEndpoint(onBody?: (body: string) => void) {
-  return spyOn(globalThis, 'fetch').mockImplementation(((
-    input: string | URL | Request,
-    init?: RequestInit,
-  ) => {
-    const url =
-      typeof input === 'string'
-        ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url
-    if (url === TOKEN_URL) {
-      if (onBody && init?.body) onBody(init.body as string)
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            refresh_token: 'refresh_abc',
-            access_token: 'access_xyz',
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        ),
-      )
-    }
-
-    return browserFetch(input, init)
-  }) as typeof fetch)
-}
+import { CLIENT_ID, CODE_CALLBACK_URL, OAUTH_SCOPES } from '../constants'
 
 afterEach(() => {
   mock.restore()
 })
 
 describe('authorize', () => {
-  test('returns a localhost callback URL for max mode', async () => {
-    mockTokenEndpoint()
+  test('returns the hosted callback URL for max mode', async () => {
     const result = await authorize('max')
 
     expect(result.url).toBeString()
-    expect(result.redirectUri).toStartWith('http://localhost:')
+    expect(result.redirectUri).toBe(CODE_CALLBACK_URL)
+    expect(result.verifier).toBeString()
 
     const url = new URL(result.url)
     expect(url.origin).toBe('https://claude.ai')
     expect(url.pathname).toBe('/oauth/authorize')
-    expect(url.searchParams.get('redirect_uri')).toBe(result.redirectUri)
-
-    await browserFetch(`${result.redirectUri}?code=test&state=${result.state}`)
-    await result.callback()
+    expect(url.searchParams.get('redirect_uri')).toBe(CODE_CALLBACK_URL)
   })
 
-  test('returns a localhost callback URL for console mode', async () => {
-    mockTokenEndpoint()
+  test('returns the hosted callback URL for console mode', async () => {
     const result = await authorize('console')
 
     const url = new URL(result.url)
     expect(url.origin).toBe('https://platform.claude.com')
     expect(url.pathname).toBe('/oauth/authorize')
-
-    await browserFetch(`${result.redirectUri}?code=test&state=${result.state}`)
-    await result.callback()
+    expect(url.searchParams.get('redirect_uri')).toBe(CODE_CALLBACK_URL)
   })
 
   test('sets required OAuth query params', async () => {
-    mockTokenEndpoint()
     const result = await authorize('max')
     const url = new URL(result.url)
 
     expect(url.searchParams.get('code')).toBe('true')
     expect(url.searchParams.get('client_id')).toBe(CLIENT_ID)
     expect(url.searchParams.get('response_type')).toBe('code')
-    expect(url.searchParams.get('redirect_uri')).toBe(result.redirectUri)
+    expect(url.searchParams.get('redirect_uri')).toBe(CODE_CALLBACK_URL)
     expect(url.searchParams.get('scope')).toBe(OAUTH_SCOPES.join(' '))
     expect(url.searchParams.get('code_challenge_method')).toBe('S256')
-
-    await browserFetch(`${result.redirectUri}?code=test&state=${result.state}`)
-    await result.callback()
+    expect(url.searchParams.get('state')).toBe(result.state)
   })
 
-  test('captures the callback and exchanges the code', async () => {
-    let capturedBody: string | undefined
-    mockTokenEndpoint((body) => {
-      capturedBody = body
-    })
-
+  test('does not use localhost', async () => {
     const result = await authorize('max')
-    const callbackPromise = result.callback()
-
-    const browserResponse = await browserFetch(
-      `${result.redirectUri}?code=mycode&state=${result.state}`,
-    )
-
-    expect(browserResponse.status).toBe(200)
-
-    const exchangeResult = await callbackPromise
-    expect(exchangeResult.type).toBe('success')
-
-    const body = JSON.parse(capturedBody!)
-    expect(body.code).toBe('mycode')
-    expect(body.state).toBe(result.state)
-    expect(body.redirect_uri).toBe(result.redirectUri)
-  })
-
-  test('fails on state mismatch', async () => {
-    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
-      input: string | URL | Request,
-      init?: RequestInit,
-    ) => browserFetch(input, init)) as typeof fetch)
-
-    const result = await authorize('max')
-    const callbackPromise = result.callback()
-
-    const browserResponse = await browserFetch(
-      `${result.redirectUri}?code=mycode&state=wrong-state`,
-    )
-
-    expect(browserResponse.status).toBe(400)
-    expect(await callbackPromise).toEqual({ type: 'failed' })
-    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(result.redirectUri).not.toContain('localhost')
+    expect(result.url).not.toContain('localhost')
   })
 })
 
 describe('exchange', () => {
-  test('accepts a full localhost callback URL', async () => {
+  test('accepts code#state format', async () => {
+    let capturedBody: string | undefined
+
+    spyOn(globalThis, 'fetch').mockImplementation(((
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ) => {
+      capturedBody = init?.body as string
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            refresh_token: 'r',
+            access_token: 'a',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    }) as typeof fetch)
+
+    const result = await exchange(
+      'mycode#mystate',
+      'myverifier',
+      CODE_CALLBACK_URL,
+      'mystate',
+    )
+
+    expect(result.type).toBe('success')
+    const body = JSON.parse(capturedBody!)
+    expect(body.code).toBe('mycode')
+    expect(body.state).toBe('mystate')
+    expect(body.redirect_uri).toBe(CODE_CALLBACK_URL)
+  })
+
+  test('accepts a full callback URL', async () => {
     let capturedBody: string | undefined
 
     spyOn(globalThis, 'fetch').mockImplementation(((
@@ -149,9 +105,9 @@ describe('exchange', () => {
     }) as typeof fetch)
 
     await exchange(
-      'http://localhost:59233/callback?code=mycode&state=mystate',
+      'https://platform.claude.com/oauth/code/callback?code=mycode&state=mystate',
       'myverifier',
-      'http://localhost:59233/callback',
+      CODE_CALLBACK_URL,
       'mystate',
     )
 
@@ -167,7 +123,7 @@ describe('exchange', () => {
     const result = await exchange(
       'not-a-callback',
       'verifier',
-      'http://localhost:59233/callback',
+      CODE_CALLBACK_URL,
     )
     expect(result.type).toBe('failed')
     expect(fetchSpy).not.toHaveBeenCalled()
@@ -180,7 +136,7 @@ describe('exchange', () => {
     const result = await exchange(
       'code#wrong',
       'verifier',
-      'http://localhost:59233/callback',
+      CODE_CALLBACK_URL,
       'expected',
     )
     expect(result.type).toBe('failed')

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -68,7 +68,7 @@ describe('auth.methods', () => {
     expect(plugin.auth.methods).toHaveLength(3)
   })
 
-  test('first method is Claude Pro/Max OAuth', async () => {
+  test('first method is Claude Pro/Max OAuth with code flow', async () => {
     const plugin = await getPlugin()
     const method = plugin.auth.methods[0]
     expect(method.label).toBe('Claude Pro/Max')
@@ -76,11 +76,12 @@ describe('auth.methods', () => {
     expect(method.authorize).toBeFunction()
   })
 
-  test('second method is Create an API Key OAuth', async () => {
+  test('second method is Create an API Key OAuth with code flow', async () => {
     const plugin = await getPlugin()
     const method = plugin.auth.methods[1]
     expect(method.label).toBe('Create an API Key')
     expect(method.type).toBe('oauth')
+    expect(method.authorize).toBeFunction()
   })
 
   test('third method is manual API key', async () => {


### PR DESCRIPTION
Turns out Anthropic still supports the `code`-type flow we supported before #14, just on a different endpoint. This seems strictly better than the localhost oauth callback, since it works even on devices with no localhost access (remote servers etc.) and enabled a cross-device auth flow where the authenticating device doesn't need to be the same as the device running opencode.

Alternatively we could support both flows, e.g. call one "Claude Pro/Max (localhost OAuth)" and one "Claude Pro/Max (device code)". But that seems unnecessary to me.

(The rest of the PR description generated by Claude)

## Summary

- Replace the localhost HTTP callback server with Anthropic's hosted callback page (`platform.claude.com/oauth/code/callback`), which displays the authorization code for the user to copy and paste back into OpenCode
- Remove the `node:http` dependency and all callback server complexity (~150 lines)
- Bump version to 0.3.0

## Motivation

The localhost callback flow required the OAuth redirect to hit a local HTTP server on the same machine running OpenCode. This broke authentication for:
- Headless servers (no browser)
- SSH sessions
- Remote devices / containers
- Any environment where `localhost` isn't accessible from the browser completing the auth flow

The hosted callback page at `platform.claude.com/oauth/code/callback` displays the auth code as `{code}#{state}` with a "Copy Code" button, which the user pastes back into the terminal. This works from any device.

## Design note

We could support both flows (localhost `auto` + remote `code`) as separate auth method options if the smoother localhost UX is desired for local development. This PR opts to just use the code-paste flow everywhere since it's simpler to maintain and works universally.