### PR TITLE
fix: replace @openauthjs/openauth with native PKCE implementation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "opencode-anthropic-auth",
-      "dependencies": {
-        "@openauthjs/openauth": "^0.4.3",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
         "@opencode-ai/plugin": "^0.4.45",
@@ -36,23 +33,9 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.7", "", { "os": "win32", "cpu": "x64" }, "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ=="],
 
-    "@openauthjs/openauth": ["@openauthjs/openauth@0.4.3", "", { "dependencies": { "@standard-schema/spec": "1.0.0-beta.3", "aws4fetch": "1.0.20", "jose": "5.9.6" }, "peerDependencies": { "arctic": "^2.2.2", "hono": "^4.0.0" } }, "sha512-RlnjqvHzqcbFVymEwhlUEuac4utA5h4nhSK/i2szZuQmxTIqbGUxZ+nM+avM+VV4Ing+/ZaNLKILoXS3yrkOOw=="],
-
     "@opencode-ai/plugin": ["@opencode-ai/plugin@0.4.45", "", { "dependencies": { "@opencode-ai/sdk": "0.4.19" } }, "sha512-TuD+FNmA6vN+/B82qayCvOyTXRuAtfvU0U95UKSZoNrYgIBhpD/sW/oS65iUv5QwQqzO8BxI4DYWjmLIqCz8uw=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@0.4.19", "", {}, "sha512-7V+wDR1+m+TQZAraAh/bOSObiA/uysG1YIXZVe6gl1sQAXDtkG2FYCzs0gTZ/ORdkUKEnr3vyQIk895Mu0CC/w=="],
-
-    "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
-
-    "@oslojs/binary": ["@oslojs/binary@1.0.0", "", {}, "sha512-9RCU6OwXU6p67H4NODbuxv2S3eenuQ4/WFLrsq+K/k682xrznH5EVWA7N4VFk9VYVcbFtKqur5YQQZc0ySGhsQ=="],
-
-    "@oslojs/crypto": ["@oslojs/crypto@1.0.1", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0" } }, "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ=="],
-
-    "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
-
-    "@oslojs/jwt": ["@oslojs/jwt@0.2.0", "", { "dependencies": { "@oslojs/encoding": "0.4.1" } }, "sha512-bLE7BtHrURedCn4Mco3ma9L4Y1GR2SMBuIvjWr7rmQ4/W/4Jy70TIAgZ+0nIlk0xHz1vNP8x8DCns45Sb2XRbg=="],
-
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0-beta.3", "", {}, "sha512-0ifF3BjA1E8SY9C+nUew8RefNOIq0cDlYALPty4rhUm8Rrl6tCM8hBT4bhGhx7I7iXD0uAgt50lgo8dD73ACMw=="],
 
     "@tsconfig/bun": ["@tsconfig/bun@1.0.10", "", {}, "sha512-5AV5YknQjNyoYzZ/8NG0dawqew/wH+x7ANiCfCIn29qo0cdbd1EryvFD1k5NSZWLBMOI/fGqMIaxi58GPIP9Cg=="],
 
@@ -60,15 +43,7 @@
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
-    "arctic": ["arctic@2.3.4", "", { "dependencies": { "@oslojs/crypto": "1.0.1", "@oslojs/encoding": "1.1.0", "@oslojs/jwt": "0.2.0" } }, "sha512-+p30BOWsctZp+CVYCt7oAean/hWGW42sH5LAcRQX56ttEkFJWbzXBhmSpibbzwSJkRrotmsA+oAoJoVsU0f5xA=="],
-
-    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
-
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
-
-    "hono": ["hono@4.9.1", "", {}, "sha512-qfvdJ42t6CQE0N/iSCa8KsW8SQqYD67YB+TYbwPHlnALvX+s7ynh8otR1NEk5jXtUg73gpV/B82OSufDmwtX3w=="],
-
-    "jose": ["jose@5.9.6", "", {}, "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
 
@@ -95,7 +70,5 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
-
-    "@oslojs/jwt/@oslojs/encoding": ["@oslojs/encoding@0.4.1", "", {}, "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,19 @@
 {
   "name": "@ex-machina/opencode-anthropic-auth",
   "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ex-machina-co/opencode-anthropic-auth"
+  },
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.7",
+    "@opencode-ai/plugin": "^0.4.45",
+    "@tsconfig/bun": "^1.0.10",
+    "@types/bun": "^1.3.10",
+    "lefthook": "^2.1.4",
+    "typescript": "^5.9.3"
+  },
   "files": [
     "dist"
   ],
@@ -15,19 +26,5 @@
     "lint": "biome lint .",
     "bump": "bun script/bump.ts"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ex-machina-co/opencode-anthropic-auth"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.7",
-    "@opencode-ai/plugin": "^0.4.45",
-    "@tsconfig/bun": "^1.0.10",
-    "@types/bun": "^1.3.10",
-    "lefthook": "^2.1.4",
-    "typescript": "^5.9.3"
-  },
-  "dependencies": {
-    "@openauthjs/openauth": "^0.4.3"
-  }
+  "types": "./dist/index.d.ts"
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,3 @@
-import { generatePKCE } from '@openauthjs/openauth/pkce'
 import {
   AUTHORIZE_URLS,
   CLIENT_ID,
@@ -6,6 +5,7 @@ import {
   OAUTH_SCOPES,
   TOKEN_URL,
 } from './constants'
+import { generatePKCE } from './pkce'
 
 type CallbackParams = {
   code: string

--- a/src/pkce.ts
+++ b/src/pkce.ts
@@ -1,0 +1,24 @@
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = ''
+  for (const byte of bytes) bin += String.fromCharCode(byte)
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+export async function generatePKCE(): Promise<{
+  verifier: string
+  challenge: string
+  method: 'S256'
+}> {
+  const buf = new Uint8Array(64)
+  crypto.getRandomValues(buf)
+  const verifier = base64UrlEncode(buf)
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(verifier),
+  )
+  return {
+    verifier,
+    challenge: base64UrlEncode(new Uint8Array(digest)),
+    method: 'S256',
+  }
+}

--- a/src/tests/pkce.test.ts
+++ b/src/tests/pkce.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { generatePKCE } from '../pkce'
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe('generatePKCE', () => {
+  test('returns an object with verifier, challenge, and method', async () => {
+    const result = await generatePKCE()
+    expect(result).toHaveProperty('verifier')
+    expect(result).toHaveProperty('challenge')
+    expect(result).toHaveProperty('method')
+  })
+
+  test('method is S256', async () => {
+    const result = await generatePKCE()
+    expect(result.method).toBe('S256')
+  })
+
+  test('verifier is 86 characters (64 bytes base64url)', async () => {
+    const result = await generatePKCE()
+    expect(result.verifier.length).toBe(86)
+  })
+
+  test('challenge is 43 characters (SHA-256 base64url)', async () => {
+    const result = await generatePKCE()
+    expect(result.challenge.length).toBe(43)
+  })
+
+  test('verifier contains only base64url characters', async () => {
+    const result = await generatePKCE()
+    expect(result.verifier).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  test('challenge contains only base64url characters', async () => {
+    const result = await generatePKCE()
+    expect(result.challenge).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  test('verifier has no base64 padding or unsafe chars', async () => {
+    const result = await generatePKCE()
+    expect(result.verifier).not.toContain('+')
+    expect(result.verifier).not.toContain('/')
+    expect(result.verifier).not.toContain('=')
+  })
+
+  test('challenge has no base64 padding or unsafe chars', async () => {
+    const result = await generatePKCE()
+    expect(result.challenge).not.toContain('+')
+    expect(result.challenge).not.toContain('/')
+    expect(result.challenge).not.toContain('=')
+  })
+
+  test('challenge is SHA-256 of verifier (independent verification)', async () => {
+    const result = await generatePKCE()
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(result.verifier),
+    )
+    const hashBytes = new Uint8Array(digest)
+    let bin = ''
+    for (let i = 0; i < hashBytes.length; i++)
+      bin += String.fromCharCode(hashBytes[i])
+    const expected = btoa(bin)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '')
+    expect(result.challenge).toBe(expected)
+  })
+
+  test('consecutive calls produce different verifiers', async () => {
+    const a = await generatePKCE()
+    const b = await generatePKCE()
+    expect(a.verifier).not.toBe(b.verifier)
+  })
+
+  test('consecutive calls produce different challenges', async () => {
+    const a = await generatePKCE()
+    const b = await generatePKCE()
+    expect(a.challenge).not.toBe(b.challenge)
+  })
+
+  test('verifier is within RFC 7636 bounds (43-128 chars)', async () => {
+    const result = await generatePKCE()
+    expect(result.verifier.length).toBeGreaterThanOrEqual(43)
+    expect(result.verifier.length).toBeLessThanOrEqual(128)
+  })
+
+  test('deterministic output for known random bytes', async () => {
+    // Bytes 0-63 produce +, / and = in raw base64,
+    // pinning all three .replace() calls
+    const knownBytes = new Uint8Array(64)
+    for (let i = 0; i < 64; i++) knownBytes[i] = i
+
+    const original = crypto.getRandomValues
+    crypto.getRandomValues = (<T extends ArrayBufferView>(array: T): T => {
+      new Uint8Array(array.buffer, array.byteOffset, array.byteLength).set(
+        knownBytes,
+      )
+      return array
+    }) as typeof crypto.getRandomValues
+
+    try {
+      const result = await generatePKCE()
+
+      // Expected verifier: base64url(bytes 0..63)
+      let bin = ''
+      for (let i = 0; i < 64; i++) bin += String.fromCharCode(i)
+      const expectedVerifier = btoa(bin)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')
+      expect(result.verifier).toBe(expectedVerifier)
+
+      // Expected challenge: base64url(SHA-256(verifier))
+      const digest = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode(expectedVerifier),
+      )
+      const hashBytes = new Uint8Array(digest)
+      let hashBin = ''
+      for (let i = 0; i < hashBytes.length; i++)
+        hashBin += String.fromCharCode(hashBytes[i])
+      const expectedChallenge = btoa(hashBin)
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')
+      expect(result.challenge).toBe(expectedChallenge)
+    } finally {
+      crypto.getRandomValues = original
+    }
+  })
+})


### PR DESCRIPTION
Remove the only runtime dependency (2.4 MB, 11 transitive packages) by inlining PKCE S256 generation using Web Crypto APIs. The openauth package was pulled in solely for a 15-line generatePKCE function that uses crypto.getRandomValues + crypto.subtle.digest, both natively available.

This eliminates the barrel import of jose (550 KB) that was evaluated at plugin load time, which caused slow startup reported in #20.

- Add src/pkce.ts: native PKCE S256 with zero dependencies
- Add src/tests/pkce.test.ts: 13 unit tests (100% coverage, 100% mutation score)
- Update src/auth.ts: import from local ./pkce instead of @openauthjs/openauth/pkce
- Remove @openauthjs/openauth from dependencies (zero runtime deps)

Closes #20