### PR TITLE
chore: harden supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.10
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - run: bun run types
       - run: bun run build
       - run: bun test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.10
       - run: bun install --frozen-lockfile
 
       - name: Build

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,15 @@
     "": {
       "name": "opencode-anthropic-auth",
       "dependencies": {
-        "@openauthjs/openauth": "^0.4.3",
+        "@openauthjs/openauth": "0.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.7",
-        "@opencode-ai/plugin": "^0.4.45",
-        "@tsconfig/bun": "^1.0.10",
-        "@types/bun": "^1.3.10",
-        "lefthook": "^2.1.4",
-        "typescript": "^5.9.3",
+        "@biomejs/biome": "2.4.7",
+        "@opencode-ai/plugin": "0.4.45",
+        "@tsconfig/bun": "1.0.10",
+        "@types/bun": "1.3.10",
+        "lefthook": "2.1.4",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "url": "https://github.com/ex-machina-co/opencode-anthropic-auth"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.7",
-    "@opencode-ai/plugin": "^0.4.45",
-    "@tsconfig/bun": "^1.0.10",
-    "@types/bun": "^1.3.10",
-    "lefthook": "^2.1.4",
-    "typescript": "^5.9.3"
+    "@biomejs/biome": "2.4.7",
+    "@opencode-ai/plugin": "0.4.45",
+    "@tsconfig/bun": "1.0.10",
+    "@types/bun": "1.3.10",
+    "lefthook": "2.1.4",
+    "typescript": "5.9.3"
   },
   "dependencies": {
-    "@openauthjs/openauth": "^0.4.3"
+    "@openauthjs/openauth": "0.4.3"
   }
 }


### PR DESCRIPTION
## Summary

Harden the CI/CD pipeline and dependency management against supply chain attacks.

## Changes

**Pin GitHub Actions to commit SHAs**
Tags like `@v6` are mutable. If an upstream Action repo is compromised, an attacker can republish the tag pointing to malicious code. All actions are now pinned to exact commit SHAs with the tag version in a comment for readability.

- `actions/checkout@de0fac2...` (v6)
- `actions/setup-node@53b839...` (v6)
- `oven-sh/setup-bun@0c5077...` (v2)

**Pin all dependency versions**
Replaced caret ranges (`^x.y.z`) with exact versions (`x.y.z`) in `package.json`. Combined with the lockfile, this prevents silent version drift across environments and makes upgrades explicit.

**Enforce lockfile in CI**
Both `ci.yml` and `publish.yml` now use `bun install --frozen-lockfile`. If a developer forgets to update `bun.lock` after changing dependencies, CI fails instead of silently resolving different versions.

**Add Dependabot**
Configured for both `npm` and `github-actions` ecosystems with weekly checks. This provides automated PRs for CVE alerts and dependency updates, including the SHA-pinned actions.
