### PR TITLE
ci: harden workflows for fork safety and concurrency

### DIFF
--- a/.changeset/chatty-laws-listen.md
+++ b/.changeset/chatty-laws-listen.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+ci: harden workflows for fork safety and concurrency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,17 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+concurrency:
+  group: publish
 
 jobs:
   publish:
+    if: github.repository == 'ex-machina-co/opencode-anthropic-auth'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6


### PR DESCRIPTION
## Why

The publish workflow crashes on forks because it tries to generate a GitHub App token using `APP_PRIVATE_KEY`, a secret that only exists on the upstream repo. See [failed run](https://github.com/Thesam1798/opencode-anthropic-auth/actions/runs/23940405937/job/69825303543).

On top of fixing this, the workflows had no explicit security hardening for an open source context where anyone can open a PR from a fork.

## What changed

### `publish.yml`

| Change | Reason |
|--------|--------|
| Added `if: github.repository == 'ex-machina-co/opencode-anthropic-auth'` | Skips the entire job on forks, no more crashes on missing secrets |
| Moved `permissions` from workflow level to job level | Least privilege: future jobs won't inherit write permissions by default |
| Added `concurrency: group: publish` without `cancel-in-progress` | Prevents parallel publish runs that could race on npm release or changeset PR creation |

### `ci.yml`

| Change | Reason |
|--------|--------|
| Added `permissions: contents: read` | Locks the GITHUB_TOKEN to read only instead of inheriting repo defaults |
| Added `concurrency` group per PR with `cancel-in-progress: true` | Cancels outdated CI runs on rapid pushes, saves compute |
| Used `pull_request.number \|\| github.ref` in concurrency group | Fallback to branch ref if a push trigger is ever added later |

## Security audit

Both workflows were reviewed against common CI/CD attack vectors for open source projects:

| Vector | Status |
|--------|--------|
| Pwn request (`pull_request_target`) | Safe, uses `pull_request` |
| Script injection via PR metadata | Safe, no user input interpolated in `run:` blocks |
| Actions pinning | Safe, all pinned by SHA |
| Secret exposure on forks | Safe, publish is skipped and CI has no secrets |
| Cache and artifact poisoning | Safe, no explicit cache usage |
| Dependency confusion | Safe, scoped package `@ex-machina/*` |
| Concurrency race conditions | Fixed in this PR |