### PR TITLE
fix: deduplicate concurrent OAuth token refreshes

### DIFF
--- a/.changeset/eighty-bees-smoke.md
+++ b/.changeset/eighty-bees-smoke.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+fix: deduplicate concurrent OAuth token refreshes

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,84 +46,99 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               },
             }
           }
+
+          // Shared inflight refresh promise — prevents concurrent token refreshes
+          // from racing against each other (and causing 401 cascades with token rotation)
+          let refreshPromise: Promise<string> | null = null
+
           return {
             apiKey: '',
             async fetch(input: string | URL | Request, init?: RequestInit) {
               const auth = await getAuth()
               if (auth.type !== 'oauth') return fetch(input, init)
               if (!auth.access || !auth.expires || auth.expires < Date.now()) {
-                const maxRetries = 2
-                const baseDelayMs = 500
+                if (!refreshPromise) {
+                  refreshPromise = (async () => {
+                    const maxRetries = 2
+                    const baseDelayMs = 500
 
-                for (let attempt = 0; attempt <= maxRetries; attempt++) {
-                  try {
-                    if (attempt > 0) {
-                      const delay = baseDelayMs * 2 ** (attempt - 1)
-                      await new Promise((resolve) => setTimeout(resolve, delay))
-                    }
+                    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                      try {
+                        if (attempt > 0) {
+                          const delay = baseDelayMs * 2 ** (attempt - 1)
+                          await new Promise((resolve) =>
+                            setTimeout(resolve, delay),
+                          )
+                        }
 
-                    const response = await fetch(TOKEN_URL, {
-                      method: 'POST',
-                      headers: {
-                        'Content-Type': 'application/json',
-                        Accept: 'application/json, text/plain, */*',
-                        'User-Agent': 'axios/1.13.6',
-                      },
-                      body: JSON.stringify({
-                        grant_type: 'refresh_token',
-                        refresh_token: auth.refresh,
-                        client_id: CLIENT_ID,
-                      }),
-                    })
+                        const response = await fetch(TOKEN_URL, {
+                          method: 'POST',
+                          headers: {
+                            'Content-Type': 'application/json',
+                            Accept: 'application/json, text/plain, */*',
+                            'User-Agent': 'axios/1.13.6',
+                          },
+                          body: JSON.stringify({
+                            grant_type: 'refresh_token',
+                            refresh_token: auth.refresh,
+                            client_id: CLIENT_ID,
+                          }),
+                        })
 
-                    if (!response.ok) {
-                      if (response.status >= 500 && attempt < maxRetries) {
-                        await response.body?.cancel()
-                        continue
+                        if (!response.ok) {
+                          if (response.status >= 500 && attempt < maxRetries) {
+                            await response.body?.cancel()
+                            continue
+                          }
+
+                          throw new Error(
+                            `Token refresh failed: ${response.status}`,
+                          )
+                        }
+
+                        const json = (await response.json()) as {
+                          refresh_token: string
+                          access_token: string
+                          expires_in: number
+                        }
+
+                        // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
+                        await (client as any).auth.set({
+                          path: {
+                            id: 'anthropic',
+                          },
+                          body: {
+                            type: 'oauth',
+                            refresh: json.refresh_token,
+                            access: json.access_token,
+                            expires: Date.now() + json.expires_in * 1000,
+                          },
+                        })
+
+                        return json.access_token
+                      } catch (error) {
+                        const isNetworkError =
+                          error instanceof Error &&
+                          (error.message.includes('fetch failed') ||
+                            ('code' in error &&
+                              (error.code === 'ECONNRESET' ||
+                                error.code === 'ECONNREFUSED' ||
+                                error.code === 'ETIMEDOUT' ||
+                                error.code === 'UND_ERR_CONNECT_TIMEOUT')))
+
+                        if (attempt < maxRetries && isNetworkError) {
+                          continue
+                        }
+
+                        throw error
                       }
-
-                      throw new Error(
-                        `Token refresh failed: ${response.status}`,
-                      )
                     }
-
-                    const json = (await response.json()) as {
-                      refresh_token: string
-                      access_token: string
-                      expires_in: number
-                    }
-
-                    // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
-                    await (client as any).auth.set({
-                      path: {
-                        id: 'anthropic',
-                      },
-                      body: {
-                        type: 'oauth',
-                        refresh: json.refresh_token,
-                        access: json.access_token,
-                        expires: Date.now() + json.expires_in * 1000,
-                      },
-                    })
-                    auth.access = json.access_token
-                    break
-                  } catch (error) {
-                    const isNetworkError =
-                      error instanceof Error &&
-                      (error.message.includes('fetch failed') ||
-                        ('code' in error &&
-                          (error.code === 'ECONNRESET' ||
-                            error.code === 'ECONNREFUSED' ||
-                            error.code === 'ETIMEDOUT' ||
-                            error.code === 'UND_ERR_CONNECT_TIMEOUT')))
-
-                    if (attempt < maxRetries && isNetworkError) {
-                      continue
-                    }
-
-                    throw error
-                  }
+                    throw new Error('Token refresh exhausted all retries')
+                  })().finally(() => {
+                    refreshPromise = null
+                  })
                 }
+                auth.access = await refreshPromise
               }
 
               const requestHeaders = mergeHeaders(input, init)

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                         throw error
                       }
                     }
+                    // Unreachable — each iteration either returns or throws.
+                    // Kept as a TypeScript exhaustiveness guard.
                     throw new Error('Token refresh exhausted all retries')
                   })().finally(() => {
                     refreshPromise = null

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -404,6 +404,265 @@ describe('auth.loader', () => {
     expect(text).not.toContain('mcp_bash')
   })
 
+  test('concurrent expired token refresh should deduplicate to a single token request', async () => {
+    let tokenRefreshCount = 0
+
+    globalThis.setTimeout = mock((handler: TimerHandler) => {
+      if (typeof handler === 'function') handler()
+      return 0 as ReturnType<typeof setTimeout>
+    }) as typeof setTimeout
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+
+      if (url.includes('/v1/oauth/token')) {
+        tokenRefreshCount++
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'new-refresh',
+              access_token: 'new-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'expired-token',
+          refresh: 'old-refresh',
+          expires: Date.now() - 1000,
+        }),
+      { models: {} },
+    )
+
+    // Fire 5 concurrent requests, all with expired token
+    await Promise.all([
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+    ])
+
+    // With deduplication, only ONE refresh request should be made, not 5
+    expect(tokenRefreshCount).toBe(1)
+  })
+
+  test('concurrent refresh with token rotation should not cause cascading failures', async () => {
+    const usedRefreshTokens = new Set<string>()
+
+    globalThis.setTimeout = mock((handler: TimerHandler) => {
+      if (typeof handler === 'function') handler()
+      return 0 as ReturnType<typeof setTimeout>
+    }) as typeof setTimeout
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+
+      if (url.includes('/v1/oauth/token')) {
+        const body = JSON.parse(init?.body)
+        const refreshToken = body.refresh_token
+
+        // Simulate refresh token rotation: first use succeeds, subsequent uses
+        // return 401 because the old token has been invalidated
+        if (usedRefreshTokens.has(refreshToken)) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: 'invalid_grant' }), {
+              status: 401,
+            }),
+          )
+        }
+
+        usedRefreshTokens.add(refreshToken)
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'rotated-refresh',
+              access_token: 'new-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'expired-token',
+          refresh: 'old-refresh',
+          expires: Date.now() - 1000,
+        }),
+      { models: {} },
+    )
+
+    // Fire 5 concurrent requests — ALL should succeed because only one refresh
+    // fires and the rest reuse its result
+    const outcomes = await Promise.all([
+      result
+        .fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        })
+        .then(
+          () => 'ok' as const,
+          () => 'fail' as const,
+        ),
+      result
+        .fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        })
+        .then(
+          () => 'ok' as const,
+          () => 'fail' as const,
+        ),
+      result
+        .fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        })
+        .then(
+          () => 'ok' as const,
+          () => 'fail' as const,
+        ),
+      result
+        .fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        })
+        .then(
+          () => 'ok' as const,
+          () => 'fail' as const,
+        ),
+      result
+        .fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        })
+        .then(
+          () => 'ok' as const,
+          () => 'fail' as const,
+        ),
+    ])
+
+    // With deduplication, all callers share the single successful refresh.
+    // Without it, 4 out of 5 get 401 from the rotated-away token → cascading failures.
+    expect(outcomes).toEqual(['ok', 'ok', 'ok', 'ok', 'ok'])
+  })
+
+  test('concurrent refresh should persist tokens exactly once', async () => {
+    globalThis.setTimeout = mock((handler: TimerHandler) => {
+      if (typeof handler === 'function') handler()
+      return 0 as ReturnType<typeof setTimeout>
+    }) as typeof setTimeout
+
+    globalThis.fetch = mock((input: any) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'new-refresh',
+              access_token: 'new-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth',
+          access: 'expired-token',
+          refresh: 'old-refresh',
+          expires: Date.now() - 1000,
+        }),
+      { models: {} },
+    )
+
+    await Promise.all([
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+      result.fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        body: '{}',
+      }),
+    ])
+
+    // With deduplication, client.auth.set should be called exactly once.
+    // Without it, each concurrent refresh calls auth.set independently → 5 calls.
+    expect(mockClient.auth.set).toHaveBeenCalledTimes(1)
+  })
+
   test('fetch wrapper adds beta=true to /v1/messages URL', async () => {
     let capturedUrl: string | undefined
 


### PR DESCRIPTION
## Summary

Fixes a race condition where multiple simultaneous requests hitting an expired OAuth token would each fire independent refresh requests to the token endpoint.

## Problem
The `fetch` wrapper in `auth.loader` had no deduplication mechanism. When N concurrent requests detected an expired token:
- **N refresh requests** fired instead of 1
- With OAuth servers that rotate refresh tokens, the first refresh invalidated the old token — causing **N-1 cascading 401 failures**
- `client.auth.set()` was called N times with potentially conflicting values (last-write-wins)
 
## Solution
Added a shared `refreshPromise` variable in the `auth.loader` closure scope. When a refresh is needed:
- If no refresh is in-flight → create one and store the promise
- If a refresh is already in-flight → all concurrent callers `await` the same promise
- `finally` block clears the promise so future requests can retry if needed

The existing retry + exponential backoff logic is unchanged — it runs inside the shared promise.

## Tests
3 new tests added:

| Test | Asserts |
|---|---|
| `concurrent expired token refresh should deduplicate to a single token request` | 5 concurrent calls → only 1 refresh request |
| `concurrent refresh with token rotation should not cause cascading failures` | All 5 callers succeed when server rotates tokens |
| `concurrent refresh should persist tokens exactly once` | `client.auth.set` called exactly 1 time |

Ref: ex-machina-co/opencode-anthropic-auth#40