### PR TITLE
feat: support ANTHROPIC_BASE_URL env var for custom API endpoint

### DIFF
--- a/.changeset/bright-tools-warn.md
+++ b/.changeset/bright-tools-warn.md
@@ -1,5 +1,5 @@
 ---
-"@ex-machina/opencode-anthropic-auth": patch
+"@ex-machina/opencode-anthropic-auth": minor
 ---
 
 feat: support ANTHROPIC_BASE_URL env var for custom API endpoint

--- a/.changeset/bright-tools-warn.md
+++ b/.changeset/bright-tools-warn.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+feat: support ANTHROPIC_BASE_URL env var for custom API endpoint

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { authorize, exchange } from './auth'
 import { CLIENT_ID, TOKEN_URL } from './constants'
 import {
   createStrippedStream,
+  isInsecure,
   mergeHeaders,
   prefixToolNames,
   rewriteUrl,
@@ -141,7 +142,9 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                 ...init,
                 body,
                 headers: requestHeaders,
-              })
+                // biome-ignore lint/suspicious/noExplicitAny: tls option is Bun-specific, not in standard RequestInit
+                ...(isInsecure() && { tls: { rejectUnauthorized: false } }),
+              } as any)
 
               return createStrippedStream(response)
             },

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
 import { REQUIRED_BETAS } from '../constants'
 import {
   createStrippedStream,
@@ -218,6 +218,16 @@ describe('stripToolPrefix', () => {
 })
 
 describe('rewriteUrl', () => {
+  const originalEnv = process.env.ANTHROPIC_BASE_URL
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalEnv
+    }
+  })
+
   test('adds beta=true to /v1/messages URL string', () => {
     const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
     const url = new URL(input.toString())
@@ -251,6 +261,62 @@ describe('rewriteUrl', () => {
     const { input } = rewriteUrl(original)
     const url = new URL(input.toString())
     expect(url.searchParams.has('beta')).toBe(false)
+  })
+
+  test('overrides origin when ANTHROPIC_BASE_URL is set', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('http://localhost:8080')
+    expect(url.pathname).toBe('/v1/messages')
+  })
+
+  test('preserves beta=true when ANTHROPIC_BASE_URL is set', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.searchParams.get('beta')).toBe('true')
+  })
+
+  test('preserves existing query params when ANTHROPIC_BASE_URL is set', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080'
+    const { input } = rewriteUrl(
+      'https://api.anthropic.com/v1/messages?foo=bar',
+    )
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('http://localhost:8080')
+    expect(url.searchParams.get('foo')).toBe('bar')
+  })
+
+  test('handles ANTHROPIC_BASE_URL with trailing slash', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080/'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.pathname).toBe('/v1/messages')
+    expect(url.origin).toBe('http://localhost:8080')
+  })
+
+  test('ignores invalid ANTHROPIC_BASE_URL', () => {
+    process.env.ANTHROPIC_BASE_URL = 'not-a-url'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('https://api.anthropic.com')
+  })
+
+  test('ignores empty ANTHROPIC_BASE_URL', () => {
+    process.env.ANTHROPIC_BASE_URL = ''
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('https://api.anthropic.com')
+  })
+
+  test('overrides origin for Request input when ANTHROPIC_BASE_URL is set', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080'
+    const request = new Request('https://api.anthropic.com/v1/messages')
+    const { input } = rewriteUrl(request)
+    const url = new URL((input as Request).url)
+    expect(url.origin).toBe('http://localhost:8080')
+    expect(url.pathname).toBe('/v1/messages')
   })
 })
 

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 import { REQUIRED_BETAS } from '../constants'
 import {
   createStrippedStream,
+  isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
   prefixToolNames,
@@ -310,6 +311,32 @@ describe('rewriteUrl', () => {
     expect(url.origin).toBe('https://api.anthropic.com')
   })
 
+  test('rejects file: scheme in ANTHROPIC_BASE_URL', () => {
+    process.env.ANTHROPIC_BASE_URL = 'file:///etc/passwd'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('https://api.anthropic.com')
+  })
+
+  test('rejects ANTHROPIC_BASE_URL with embedded credentials', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://user:pass@localhost:8080'
+    const { input } = rewriteUrl('https://api.anthropic.com/v1/messages')
+    const url = new URL(input.toString())
+    expect(url.origin).toBe('https://api.anthropic.com')
+  })
+
+  test('returns original input when no URL changes are needed', () => {
+    const original = 'https://api.anthropic.com/v1/complete'
+    const { input } = rewriteUrl(original)
+    expect(input).toBe(original)
+  })
+
+  test('returns original Request when no URL changes are needed', () => {
+    const request = new Request('https://api.anthropic.com/v1/complete')
+    const { input } = rewriteUrl(request)
+    expect(input).toBe(request)
+  })
+
   test('overrides origin for Request input when ANTHROPIC_BASE_URL is set', () => {
     process.env.ANTHROPIC_BASE_URL = 'http://localhost:8080'
     const request = new Request('https://api.anthropic.com/v1/messages')
@@ -317,6 +344,60 @@ describe('rewriteUrl', () => {
     const url = new URL((input as Request).url)
     expect(url.origin).toBe('http://localhost:8080')
     expect(url.pathname).toBe('/v1/messages')
+  })
+})
+
+describe('isInsecure', () => {
+  const originalBaseUrl = process.env.ANTHROPIC_BASE_URL
+  const originalInsecure = process.env.ANTHROPIC_INSECURE
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalBaseUrl
+    }
+    if (originalInsecure === undefined) {
+      delete process.env.ANTHROPIC_INSECURE
+    } else {
+      process.env.ANTHROPIC_INSECURE = originalInsecure
+    }
+  })
+
+  test('returns false when neither env var is set', () => {
+    delete process.env.ANTHROPIC_BASE_URL
+    delete process.env.ANTHROPIC_INSECURE
+    expect(isInsecure()).toBe(false)
+  })
+
+  test('returns false when only ANTHROPIC_INSECURE is set (no base URL)', () => {
+    delete process.env.ANTHROPIC_BASE_URL
+    process.env.ANTHROPIC_INSECURE = '1'
+    expect(isInsecure()).toBe(false)
+  })
+
+  test('returns false when ANTHROPIC_BASE_URL is set but ANTHROPIC_INSECURE is not', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.local'
+    delete process.env.ANTHROPIC_INSECURE
+    expect(isInsecure()).toBe(false)
+  })
+
+  test('returns true when both are set and ANTHROPIC_INSECURE is "1"', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.local'
+    process.env.ANTHROPIC_INSECURE = '1'
+    expect(isInsecure()).toBe(true)
+  })
+
+  test('returns true when ANTHROPIC_INSECURE is "true"', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.local'
+    process.env.ANTHROPIC_INSECURE = 'true'
+    expect(isInsecure()).toBe(true)
+  })
+
+  test('returns false for other ANTHROPIC_INSECURE values', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://proxy.local'
+    process.env.ANTHROPIC_INSECURE = 'yes'
+    expect(isInsecure()).toBe(false)
   })
 })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -125,14 +125,32 @@ export function stripToolPrefix(text: string): string {
 }
 
 /**
+ * Check if TLS verification should be skipped for custom API endpoints.
+ * Only effective when ANTHROPIC_BASE_URL is also set.
+ */
+export function isInsecure(): boolean {
+  if (!process.env.ANTHROPIC_BASE_URL?.trim()) return false
+  const raw = process.env.ANTHROPIC_INSECURE?.trim()
+  return raw === '1' || raw === 'true'
+}
+
+/**
  * Parse ANTHROPIC_BASE_URL from the environment.
- * Returns a valid URL or null if unset/invalid.
+ * Returns a valid HTTP(S) URL or null if unset/invalid.
  */
 function resolveBaseUrl(): URL | null {
   const raw = process.env.ANTHROPIC_BASE_URL?.trim()
   if (!raw) return null
   try {
-    return new URL(raw)
+    const baseUrl = new URL(raw)
+    if (
+      (baseUrl.protocol !== 'http:' && baseUrl.protocol !== 'https:') ||
+      baseUrl.username ||
+      baseUrl.password
+    ) {
+      return null
+    }
+    return baseUrl
   } catch {
     return null
   }
@@ -140,7 +158,8 @@ function resolveBaseUrl(): URL | null {
 
 /**
  * Rewrite the request URL to add ?beta=true for /v1/messages requests.
- * When ANTHROPIC_BASE_URL is set, also overrides the origin (protocol + host).
+ * When ANTHROPIC_BASE_URL is set, overrides the origin (protocol + host)
+ * for all API requests flowing through the fetch wrapper.
  * Returns the modified input and URL (if applicable).
  */
 export function rewriteUrl(input: FetchInput): {
@@ -160,6 +179,8 @@ export function rewriteUrl(input: FetchInput): {
 
   if (!requestUrl) return { input, url: null }
 
+  const originalHref = requestUrl.href
+
   const baseUrl = resolveBaseUrl()
   if (baseUrl) {
     requestUrl.protocol = baseUrl.protocol
@@ -171,6 +192,10 @@ export function rewriteUrl(input: FetchInput): {
     !requestUrl.searchParams.has('beta')
   ) {
     requestUrl.searchParams.set('beta', 'true')
+  }
+
+  if (requestUrl.href === originalHref) {
+    return { input, url: requestUrl }
   }
 
   const newInput =

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -125,7 +125,22 @@ export function stripToolPrefix(text: string): string {
 }
 
 /**
+ * Parse ANTHROPIC_BASE_URL from the environment.
+ * Returns a valid URL or null if unset/invalid.
+ */
+function resolveBaseUrl(): URL | null {
+  const raw = process.env.ANTHROPIC_BASE_URL?.trim()
+  if (!raw) return null
+  try {
+    return new URL(raw)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Rewrite the request URL to add ?beta=true for /v1/messages requests.
+ * When ANTHROPIC_BASE_URL is set, also overrides the origin (protocol + host).
  * Returns the modified input and URL (if applicable).
  */
 export function rewriteUrl(input: FetchInput): {
@@ -143,20 +158,26 @@ export function rewriteUrl(input: FetchInput): {
     requestUrl = null
   }
 
+  if (!requestUrl) return { input, url: null }
+
+  const baseUrl = resolveBaseUrl()
+  if (baseUrl) {
+    requestUrl.protocol = baseUrl.protocol
+    requestUrl.host = baseUrl.host
+  }
+
   if (
-    requestUrl &&
     requestUrl.pathname === '/v1/messages' &&
     !requestUrl.searchParams.has('beta')
   ) {
     requestUrl.searchParams.set('beta', 'true')
-    const newInput =
-      input instanceof Request
-        ? new Request(requestUrl.toString(), input)
-        : requestUrl
-    return { input: newInput, url: requestUrl }
   }
 
-  return { input, url: requestUrl }
+  const newInput =
+    input instanceof Request
+      ? new Request(requestUrl.toString(), input)
+      : requestUrl
+  return { input: newInput, url: requestUrl }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for the `ANTHROPIC_BASE_URL` environment variable to route `/v1/messages` API requests through a custom proxy or local server.

## Motivation

Enables use cases like:
- Local development with a mock API server
- Routing through proxies (LiteLLM, OpenRouter, etc.)
- Any server that speaks the Anthropic API protocol

Inspired by the emulator routing concept in ex-machina-co/opencode-anthropic-auth#40, but implemented as a generic base URL override rather than tied to a specific (now deprecated) project.

## How it works

When `ANTHROPIC_BASE_URL` is set:
- The origin (protocol + host) of API requests is replaced with the provided URL
- Path, query parameters, and `?beta=true` logic are preserved
- Invalid or empty values are silently ignored (falls back to default behavior)

OAuth token refresh is **not affected** — it always targets `platform.claude.com` directly via the hardcoded `TOKEN_URL` constant.

### Usage

```bash
ANTHROPIC_BASE_URL=http://localhost:8080 opencode
```

## Tests

7 new tests added:

| Test | Asserts |
|---|---|
| `overrides origin when ANTHROPIC_BASE_URL is set` | Origin swapped, path preserved |
| `preserves beta=true when set` | `?beta=true` still appended |
| `preserves existing query params` | Existing params not lost |
| `handles trailing slash` | No double-slash in path |
| `ignores invalid ANTHROPIC_BASE_URL` | Falls back to original URL |
| `ignores empty ANTHROPIC_BASE_URL` | Falls back to original URL |
| `overrides origin for Request input` | Works with `Request` objects too |

Ref: ex-machina-co/opencode-anthropic-auth#40
