### PR TITLE
fix: surface token refresh error body; add prepare script for github installs

### DIFF
--- a/.changeset/improve-auth-diagnostics-and-betas.md
+++ b/.changeset/improve-auth-diagnostics-and-betas.md
@@ -2,4 +2,4 @@
 '@ex-machina/opencode-anthropic-auth': patch
 ---
 
-Surface token refresh error body for easier diagnosis; update beta flags and user-agent to match Claude CLI v2.1.80
+Surface token refresh error body for easier diagnosis; add prepare script for github installs

--- a/.changeset/improve-auth-diagnostics-and-betas.md
+++ b/.changeset/improve-auth-diagnostics-and-betas.md
@@ -1,0 +1,5 @@
+---
+'@ex-machina/opencode-anthropic-auth': patch
+---
+
+Surface token refresh error body for easier diagnosis; update beta flags and user-agent to match Claude CLI v2.1.80

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "tsc -p tsconfig.build.json",
     "build": "tsc -p tsconfig.build.json",
     "test": "bun test",
     "types": "tsc",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,5 @@ export const REQUIRED_BETAS = [
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
 ]
+
+export const USER_AGENT = 'claude-cli/2.1.2 (external, cli)'

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,8 +92,9 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                             continue
                           }
 
+                          const body = await response.text().catch(() => '')
                           throw new Error(
-                            `Token refresh failed: ${response.status}`,
+                            `Token refresh failed: ${response.status} — ${body}`,
                           )
                         }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,4 @@
-import { REQUIRED_BETAS, TOOL_PREFIX } from './constants'
+import { REQUIRED_BETAS, TOOL_PREFIX, USER_AGENT } from './constants'
 
 export type FetchInput = string | URL | Request
 
@@ -63,7 +63,7 @@ export function setOAuthHeaders(
 ): Headers {
   headers.set('authorization', `Bearer ${accessToken}`)
   headers.set('anthropic-beta', mergeBetaHeaders(headers))
-  headers.set('user-agent', 'claude-cli/2.1.2 (external, cli)')
+  headers.set('user-agent', USER_AGENT)
   headers.delete('x-api-key')
   return headers
 }


### PR DESCRIPTION
## Summary

- **Surface token refresh error body** — previously the Anthropic error response (e.g. `{"error":"invalid_grant"}`) was discarded on non-5xx failures, leaving users with an opaque error message. The response text is now included so failures are diagnosable without a proxy.

- **Extract `USER_AGENT` to `constants.ts`** — moves the hardcoded user-agent string out of `transform.ts` and into `constants.ts` alongside the other identity constants. No behaviour change.

- **Add `prepare` script** — when installed via a `github:` ref (e.g. for testing a branch), bun/npm runs `prepare` which compiles `src/` → `dist/`. Without this, `package.json` points to `./dist/index.js` which doesn't exist in the repo, the plugin silently fails to load, and requests reach Anthropic unauthenticated.

## Testing

- All 91 existing tests pass (`bun test`)
- Type-check clean (`bunx tsc --noEmit`)
- Biome lint clean on changed files