### PR TITLE
feat: system prompt sanitization

### DIFF
--- a/.changeset/dark-baboons-pay.md
+++ b/.changeset/dark-baboons-pay.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+Add system prompt sanitization and CCH hash computation for Max subscription compatibility. Moves system prompt handling from the plugin hook into the request body layer, surgically removing the OpenCode identity section and prepending Claude Code identity. Computes a content-binding fingerprint (CCH) from the first user message to include in the cc_version string.

--- a/.changeset/dark-baboons-pay.md
+++ b/.changeset/dark-baboons-pay.md
@@ -2,4 +2,4 @@
 "@ex-machina/opencode-anthropic-auth": minor
 ---
 
-Add system prompt sanitization and CCH hash computation for Max subscription compatibility. Moves system prompt handling from the plugin hook into the request body layer, surgically removing the OpenCode identity section and prepending Claude Code identity. Computes a content-binding fingerprint (CCH) from the first user message to include in the cc_version string.
+Add system prompt sanitization for Max subscription compatibility. Moves system prompt handling from the plugin hook into the request body layer, surgically removing the OpenCode identity section and prepending Claude Code identity. Preserves user-configured instructions from config.json.

--- a/.changeset/light-berries-tickle.md
+++ b/.changeset/light-berries-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Minor bump to update README in npm with security suggestion

--- a/.changeset/light-berries-tickle.md
+++ b/.changeset/light-berries-tickle.md
@@ -1,5 +1,0 @@
----
-"@ex-machina/opencode-anthropic-auth": patch
----
-
-Minor bump to update README in npm with security suggestion

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,8 +31,10 @@ export const OPENCODE_IDENTITY =
 export const CLAUDE_CODE_IDENTITY =
   "You are Claude Code, Anthropic's official CLI for Claude."
 
-export const CCH_SALT = '59cf53e54c78'
-export const CCH_POSITIONS = [4, 7, 20]
-export const CLAUDE_CODE_VERSION = '2.1.2'
-
 export const USER_AGENT = 'claude-cli/2.1.2 (external, cli)'
+
+export const PRESERVED_TAIL_MARKERS = [
+  '\nInstructions from: ',
+  '\nInstructions from command: ',
+  '# Code References',
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,4 +26,13 @@ export const REQUIRED_BETAS = [
   'interleaved-thinking-2025-05-14',
 ]
 
+export const OPENCODE_IDENTITY =
+  'You are OpenCode, the best coding agent on the planet.'
+export const CLAUDE_CODE_IDENTITY =
+  "You are Claude Code, Anthropic's official CLI for Claude."
+
+export const CCH_SALT = '59cf53e54c78'
+export const CCH_POSITIONS = [4, 7, 20]
+export const CLAUDE_CODE_VERSION = '2.1.2'
+
 export const USER_AGENT = 'claude-cli/2.1.2 (external, cli)'

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,24 +5,13 @@ import {
   createStrippedStream,
   isInsecure,
   mergeHeaders,
-  prefixToolNames,
+  rewriteRequestBody,
   rewriteUrl,
   setOAuthHeaders,
 } from './transform'
 
 export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
   return {
-    'experimental.chat.system.transform': (
-      input: { model?: { providerID?: string } },
-      output: { system: string[] },
-    ) => {
-      const prefix = "You are Claude Code, Anthropic's official CLI for Claude."
-      if (input.model?.providerID === 'anthropic') {
-        output.system.unshift(prefix)
-        if (output.system[1])
-          output.system[1] = `${prefix}\n\n${output.system[1]}`
-      }
-    },
     auth: {
       provider: 'anthropic',
       async loader(
@@ -151,7 +140,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
 
               let body = init?.body
               if (body && typeof body === 'string') {
-                body = prefixToolNames(body)
+                body = rewriteRequestBody(body)
               }
 
               const rewritten = rewriteUrl(input)

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -7,58 +7,23 @@ function createMockClient() {
     auth: {
       set: mock(() => Promise.resolve()),
     },
-  } as any
+  }
 }
 
-async function getPlugin(client?: any) {
+async function getPlugin(client?: ReturnType<typeof createMockClient>) {
   return AnthropicAuthPlugin({
+    // @ts-expect-error: minimal mock for testing
     client: client ?? createMockClient(),
-    app: {} as any,
-    $: {} as any,
   }) as Promise<any>
 }
 
 describe('AnthropicAuthPlugin', () => {
-  test('returns an object with expected hook and auth properties', async () => {
+  test('returns an object with auth properties', async () => {
     const plugin = await getPlugin()
-    expect(plugin['experimental.chat.system.transform']).toBeFunction()
     expect(plugin.auth).toBeDefined()
     expect(plugin.auth.provider).toBe('anthropic')
     expect(plugin.auth.loader).toBeFunction()
     expect(plugin.auth.methods).toBeArray()
-  })
-})
-
-describe('experimental.chat.system.transform', () => {
-  const PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
-
-  test('prepends system prefix for anthropic provider', async () => {
-    const plugin = await getPlugin()
-    const hook = plugin['experimental.chat.system.transform']
-    const output = { system: ['Existing system prompt'] }
-    hook({ model: { providerID: 'anthropic' } }, output)
-
-    expect(output.system[0]).toBe(PREFIX)
-    expect(output.system[1]).toBe(`${PREFIX}\n\nExisting system prompt`)
-  })
-
-  test('does not modify system for non-anthropic providers', async () => {
-    const plugin = await getPlugin()
-    const hook = plugin['experimental.chat.system.transform']
-    const output = { system: ['Original prompt'] }
-    hook({ model: { providerID: 'openai' } }, output)
-
-    expect(output.system).toEqual(['Original prompt'])
-  })
-
-  test('handles empty system array for anthropic', async () => {
-    const plugin = await getPlugin()
-    const hook = plugin['experimental.chat.system.transform']
-    const output = { system: [] as string[] }
-    hook({ model: { providerID: 'anthropic' } }, output)
-
-    expect(output.system[0]).toBe(PREFIX)
-    expect(output.system).toHaveLength(1)
   })
 })
 
@@ -180,7 +145,8 @@ describe('auth.loader', () => {
 
     const body = JSON.stringify({
       tools: [{ name: 'bash', type: 'function' }],
-      messages: [],
+      messages: [{ role: 'user', content: 'hello world test message' }],
+      system: 'You are a helpful assistant.',
     })
 
     await result.fetch('https://api.anthropic.com/v1/messages', {
@@ -193,9 +159,15 @@ describe('auth.loader', () => {
     expect(capturedHeaders!.get('x-api-key')).toBeNull()
     expect(capturedHeaders!.get('anthropic-beta')).toContain('oauth-2025-04-20')
 
-    // Tool name should be prefixed
     const parsedBody = JSON.parse(capturedBody!)
+    // Tool name should be prefixed
     expect(parsedBody.tools[0].name).toBe('mcp_bash')
+    // System prompt should be rewritten with Claude Code identity
+    expect(parsedBody.system[0].text).toContain(
+      "You are Claude Code, Anthropic's official CLI for Claude.",
+    )
+    // Should include cc_version with CCH hash
+    expect(parsedBody.system[0].text).toMatch(/cc_version=[\d.]+\.[a-f0-9]{3}/)
   })
 
   test('fetch wrapper refreshes expired token', async () => {
@@ -258,13 +230,12 @@ describe('auth.loader', () => {
 
   test('fetch wrapper retries transient token refresh failures', async () => {
     let tokenRefreshCalls = 0
-    const setTimeoutMock = mock((handler: TimerHandler) => {
-      if (typeof handler === 'function') {
-        handler()
-      }
-      return 0 as ReturnType<typeof setTimeout>
-    }) as typeof setTimeout
+    const setTimeoutMock = mock((handler: Function) => {
+      handler()
+      return 0
+    })
 
+    // @ts-expect-error — mock override for testing
     globalThis.setTimeout = setTimeoutMock
 
     globalThis.fetch = mock((input: any) => {
@@ -407,10 +378,11 @@ describe('auth.loader', () => {
   test('concurrent expired token refresh should deduplicate to a single token request', async () => {
     let tokenRefreshCount = 0
 
-    globalThis.setTimeout = mock((handler: TimerHandler) => {
-      if (typeof handler === 'function') handler()
-      return 0 as ReturnType<typeof setTimeout>
-    }) as typeof setTimeout
+    // @ts-expect-error — mock override for testing
+    globalThis.setTimeout = mock((handler: Function) => {
+      handler()
+      return 0
+    })
 
     globalThis.fetch = mock((input: any, init: any) => {
       const url =
@@ -481,10 +453,11 @@ describe('auth.loader', () => {
   test('concurrent refresh with token rotation should not cause cascading failures', async () => {
     const usedRefreshTokens = new Set<string>()
 
-    globalThis.setTimeout = mock((handler: TimerHandler) => {
-      if (typeof handler === 'function') handler()
-      return 0 as ReturnType<typeof setTimeout>
-    }) as typeof setTimeout
+    // @ts-expect-error — mock override for testing
+    globalThis.setTimeout = mock((handler: Function) => {
+      handler()
+      return 0
+    })
 
     globalThis.fetch = mock((input: any, init: any) => {
       const url =
@@ -593,10 +566,11 @@ describe('auth.loader', () => {
   })
 
   test('concurrent refresh should persist tokens exactly once', async () => {
-    globalThis.setTimeout = mock((handler: TimerHandler) => {
-      if (typeof handler === 'function') handler()
-      return 0 as ReturnType<typeof setTimeout>
-    }) as typeof setTimeout
+    // @ts-expect-error — mock override for testing
+    globalThis.setTimeout = mock((handler: Function) => {
+      handler()
+      return 0
+    })
 
     globalThis.fetch = mock((input: any) => {
       const url =

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -166,8 +166,6 @@ describe('auth.loader', () => {
     expect(parsedBody.system[0].text).toContain(
       "You are Claude Code, Anthropic's official CLI for Claude.",
     )
-    // Should include cc_version with CCH hash
-    expect(parsedBody.system[0].text).toMatch(/cc_version=[\d.]+\.[a-f0-9]{3}/)
   })
 
   test('fetch wrapper refreshes expired token', async () => {

--- a/src/tests/pkce.test.ts
+++ b/src/tests/pkce.test.ts
@@ -60,8 +60,7 @@ describe('generatePKCE', () => {
     )
     const hashBytes = new Uint8Array(digest)
     let bin = ''
-    for (let i = 0; i < hashBytes.length; i++)
-      bin += String.fromCharCode(hashBytes[i])
+    for (const byte of hashBytes) bin += String.fromCharCode(byte)
     const expected = btoa(bin)
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
@@ -120,8 +119,7 @@ describe('generatePKCE', () => {
       )
       const hashBytes = new Uint8Array(digest)
       let hashBin = ''
-      for (let i = 0; i < hashBytes.length; i++)
-        hashBin += String.fromCharCode(hashBytes[i])
+      for (const byte of hashBytes) hashBin += String.fromCharCode(byte)
       const expectedChallenge = btoa(hashBin)
         .replace(/\+/g, '-')
         .replace(/\//g, '_')

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,12 +1,21 @@
-import { afterEach, describe, expect, test } from 'bun:test'
-import { REQUIRED_BETAS } from '../constants'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
 import {
+  CLAUDE_CODE_IDENTITY,
+  OPENCODE_IDENTITY,
+  REQUIRED_BETAS,
+} from '../constants'
+import {
+  computeCCH,
   createStrippedStream,
+  extractFirstUserMessage,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
   prefixToolNames,
+  prependClaudeCodeIdentity,
+  rewriteRequestBody,
   rewriteUrl,
+  sanitizeSystemText,
   setOAuthHeaders,
   stripToolPrefix,
 } from '../transform'
@@ -80,8 +89,9 @@ describe('mergeBetaHeaders', () => {
   })
 
   test('deduplicates betas', () => {
+    const beta = REQUIRED_BETAS[0] ?? ''
     const headers = new Headers({
-      'anthropic-beta': REQUIRED_BETAS[0],
+      'anthropic-beta': beta,
     })
     const result = mergeBetaHeaders(headers)
     const parts = result.split(',')
@@ -450,5 +460,340 @@ describe('createStrippedStream', () => {
     const original = new Response(null, { status: 204 })
     const result = createStrippedStream(original)
     expect(result).toBe(original)
+  })
+})
+
+describe('computeCCH', () => {
+  test('produces deterministic 3-char hex hash', () => {
+    const hash = computeCCH('hello world test message', '2.1.2')
+    expect(hash).toHaveLength(3)
+    expect(hash).toMatch(/^[a-f0-9]{3}$/)
+    // Same input should produce same output
+    expect(computeCCH('hello world test message', '2.1.2')).toBe(hash)
+  })
+
+  test('different messages produce different hashes', () => {
+    const hash1 = computeCCH('hello world test message', '2.1.2')
+    const hash2 = computeCCH('different text entirely', '2.1.2')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  test('different versions produce different hashes', () => {
+    const hash1 = computeCCH('hello world test message', '2.1.2')
+    const hash2 = computeCCH('hello world test message', '2.2.0')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  test('falls back to random hash for empty message', () => {
+    const hash = computeCCH('', '2.1.2')
+    expect(hash).toHaveLength(3)
+    expect(hash).toMatch(/^[a-f0-9]{3}$/)
+  })
+
+  test('random fallback produces different values each call', () => {
+    const hashes = new Set(
+      Array.from({ length: 20 }, () => computeCCH('', '2.1.2')),
+    )
+    // With 20 random 3-hex-char values, extremely unlikely to all be identical
+    expect(hashes.size).toBeGreaterThan(1)
+  })
+
+  test('handles message shorter than max position (20)', () => {
+    const hash = computeCCH('hi', '2.1.2')
+    expect(hash).toHaveLength(3)
+    expect(hash).toMatch(/^[a-f0-9]{3}$/)
+    // Should be deterministic — short chars replaced with '0'
+    expect(computeCCH('hi', '2.1.2')).toBe(hash)
+  })
+
+  test('uses characters at positions 4, 7, 20 from message', () => {
+    // Position:  0123456789...
+    // Message:   abcdeXfgYhijklmnopqrstUvw
+    //                 ^4  ^7              ^20 (0-indexed)
+    // Chars at 4='e', 7='Y' — but position 20 depends on length
+    const msg = 'abcdeXfgYhijklmnopqrstUvw'
+    const hash1 = computeCCH(msg, '2.1.2')
+    // Change char at position 4
+    const msg2 = 'abcdZXfgYhijklmnopqrstUvw'
+    const hash2 = computeCCH(msg2, '2.1.2')
+    expect(hash1).not.toBe(hash2)
+  })
+})
+
+describe('extractFirstUserMessage', () => {
+  test('extracts string content from first user message', () => {
+    const messages = [
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: 'hello world' },
+    ]
+    expect(extractFirstUserMessage(messages)).toBe('hello world')
+  })
+
+  test('extracts text block from array content', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'image', source: {} },
+          { type: 'text', text: 'describe this image' },
+        ],
+      },
+    ]
+    expect(extractFirstUserMessage(messages)).toBe('describe this image')
+  })
+
+  test('returns empty string when no user message', () => {
+    const messages = [{ role: 'assistant', content: 'hi' }]
+    expect(extractFirstUserMessage(messages)).toBe('')
+  })
+
+  test('returns empty string for non-array input', () => {
+    expect(extractFirstUserMessage('not an array' as any)).toBe('')
+  })
+
+  test('skips assistant messages to find first user', () => {
+    const messages = [
+      { role: 'assistant', content: 'I can help' },
+      { role: 'assistant', content: 'with that' },
+      { role: 'user', content: 'actual user message' },
+    ]
+    expect(extractFirstUserMessage(messages)).toBe('actual user message')
+  })
+
+  test('returns empty string when content has no text block', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'image', source: {} }] },
+    ]
+    expect(extractFirstUserMessage(messages)).toBe('')
+  })
+
+  test('returns empty string for empty messages array', () => {
+    expect(extractFirstUserMessage([])).toBe('')
+  })
+})
+
+describe('sanitizeSystemText', () => {
+  const SYSTEM_WITH_OPENCODE = `${OPENCODE_IDENTITY}\n\nSome OpenCode specific instructions\n\n# Code References\n\nActual content here`
+
+  test('removes section between OpenCode identity and Code References', () => {
+    const result = sanitizeSystemText(SYSTEM_WITH_OPENCODE)
+    expect(result).not.toContain(OPENCODE_IDENTITY)
+    expect(result).toContain('# Code References')
+    expect(result).toContain('Actual content here')
+  })
+
+  test('returns text unchanged when OpenCode identity not present', () => {
+    const text = 'Just a normal system prompt'
+    expect(sanitizeSystemText(text)).toBe(text)
+  })
+
+  test('calls onError when Code References marker is missing', () => {
+    const onError = mock(() => {})
+    const text = `${OPENCODE_IDENTITY}\n\nSome instructions without marker`
+    const result = sanitizeSystemText(text, onError)
+    expect(result).toBe(text) // unchanged
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  test('preserves content before OpenCode identity', () => {
+    const text = `Prefix content\n${OPENCODE_IDENTITY}\nstuff\n# Code References\nrest`
+    const result = sanitizeSystemText(text)
+    expect(result).toBe('Prefix content\n# Code References\nrest')
+  })
+
+  test('handles identity at the very start of text', () => {
+    const text = `${OPENCODE_IDENTITY}\n# Code References\nrest`
+    const result = sanitizeSystemText(text)
+    expect(result).toBe('# Code References\nrest')
+  })
+
+  test('only processes first occurrence of OpenCode identity', () => {
+    const text = `${OPENCODE_IDENTITY}\nfirst\n# Code References\nmiddle\n${OPENCODE_IDENTITY}\nsecond`
+    const result = sanitizeSystemText(text)
+    // First occurrence removed, second stays
+    expect(result).toBe(
+      `# Code References\nmiddle\n${OPENCODE_IDENTITY}\nsecond`,
+    )
+  })
+})
+
+describe('prependClaudeCodeIdentity', () => {
+  test('returns identity block for undefined system', () => {
+    const result = prependClaudeCodeIdentity(undefined)
+    expect(result).toEqual([{ type: 'text', text: CLAUDE_CODE_IDENTITY }])
+  })
+
+  test('sanitizes and prepends for string system', () => {
+    const result = prependClaudeCodeIdentity('Some assistant prompt')
+    expect(result).toHaveLength(2)
+    expect(result[0]?.text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result[1]?.text).toBe('Some assistant prompt')
+  })
+
+  test('sanitizes array of text blocks', () => {
+    const system = [
+      {
+        type: 'text',
+        text: `${OPENCODE_IDENTITY}\nstuff\n# Code References\nrest`,
+      },
+      { type: 'text', text: 'other block' },
+    ]
+    const result = prependClaudeCodeIdentity(system)
+    expect(result[0]?.text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result[1]?.text).not.toContain(OPENCODE_IDENTITY)
+    expect(result[1]?.text).toContain('# Code References')
+  })
+
+  test('does not double-prepend if identity already present', () => {
+    const system = [
+      { type: 'text', text: CLAUDE_CODE_IDENTITY },
+      { type: 'text', text: 'other' },
+    ]
+    const result = prependClaudeCodeIdentity(system)
+    expect(result).toHaveLength(2)
+    expect(result[0]?.text).toBe(CLAUDE_CODE_IDENTITY)
+  })
+
+  test('handles string elements in array', () => {
+    const system = ['some text', 'more text']
+    const result = prependClaudeCodeIdentity(system)
+    expect(result[0]?.text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result[1]).toEqual({ type: 'text', text: 'some text' })
+  })
+})
+
+describe('rewriteRequestBody', () => {
+  test('prefixes tool names and rewrites system prompt', () => {
+    const body = JSON.stringify({
+      tools: [{ name: 'bash', type: 'function' }],
+      messages: [{ role: 'user', content: 'hello world test message' }],
+      system: 'You are a helpful assistant.',
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.tools[0].name).toBe('mcp_bash')
+    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    expect(result.system[0].text).toMatch(/cc_version=[\d.]+\.[a-f0-9]{3}/)
+  })
+
+  test('injects CCH hash into identity block', () => {
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'test content here for hashing' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.system[0].text).toMatch(/cc_version=2\.1\.2\.[a-f0-9]{3}/)
+  })
+
+  test('handles missing system field', () => {
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.system).toHaveLength(1)
+    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+  })
+
+  test('returns original string on invalid JSON', () => {
+    const body = 'not valid json'
+    expect(rewriteRequestBody(body)).toBe(body)
+  })
+
+  test('passes onError through to sanitization', () => {
+    const onError = mock(() => {})
+    const body = JSON.stringify({
+      messages: [],
+      system: `${OPENCODE_IDENTITY}\nno code refs marker here`,
+    })
+    rewriteRequestBody(body, onError)
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  test('rewrites realistic OpenCode system prompt end-to-end', () => {
+    const body = JSON.stringify({
+      tools: [
+        { name: 'bash', type: 'function' },
+        { name: 'read_file', type: 'function' },
+      ],
+      messages: [
+        { role: 'user', content: 'Help me fix this bug in main.ts' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', name: 'bash', id: 'tool_1' },
+            { type: 'text', text: 'Let me check' },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool_1',
+              content: 'output',
+            },
+          ],
+        },
+      ],
+      system: [
+        {
+          type: 'text',
+          text: `${OPENCODE_IDENTITY}\n\nYou have access to tools.\n\n# Code References\n\nHere are some files.`,
+        },
+        { type: 'text', text: 'Additional context block' },
+      ],
+    })
+
+    const result = JSON.parse(rewriteRequestBody(body))
+
+    // System: identity prepended, OpenCode section removed
+    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    expect(result.system[0].text).toMatch(/cc_version=/)
+    expect(result.system[1].text).toContain('# Code References')
+    expect(result.system[1].text).not.toContain(OPENCODE_IDENTITY)
+    expect(result.system[1].text).not.toContain('You have access to tools')
+    expect(result.system[2].text).toBe('Additional context block')
+
+    // Tools: prefixed
+    expect(result.tools[0].name).toBe('mcp_bash')
+    expect(result.tools[1].name).toBe('mcp_read_file')
+
+    // Messages: tool_use blocks prefixed
+    expect(result.messages[1].content[0].name).toBe('mcp_bash')
+    // Text blocks untouched
+    expect(result.messages[1].content[1].text).toBe('Let me check')
+    // User messages untouched
+    expect(result.messages[0].content).toBe('Help me fix this bug in main.ts')
+  })
+
+  test('CCH hash is deterministic for same message', () => {
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'consistent message content' }],
+    })
+    const result1 = JSON.parse(rewriteRequestBody(body))
+    const result2 = JSON.parse(rewriteRequestBody(body))
+    expect(result1.system[0].text).toBe(result2.system[0].text)
+  })
+
+  test('CCH hash differs for different messages', () => {
+    const body1 = JSON.stringify({
+      messages: [{ role: 'user', content: 'first message here' }],
+    })
+    const body2 = JSON.stringify({
+      messages: [{ role: 'user', content: 'different message' }],
+    })
+    const result1 = JSON.parse(rewriteRequestBody(body1))
+    const result2 = JSON.parse(rewriteRequestBody(body2))
+    const hash1 = result1.system[0].text.match(
+      /cc_version=[\d.]+\.([a-f0-9]{3})/,
+    )?.[1]
+    const hash2 = result2.system[0].text.match(
+      /cc_version=[\d.]+\.([a-f0-9]{3})/,
+    )?.[1]
+    expect(hash1).not.toBe(hash2)
+  })
+
+  test('handles body with no messages array', () => {
+    const body = JSON.stringify({ model: 'claude-3' })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
   })
 })

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -462,13 +462,51 @@ describe('createStrippedStream', () => {
 })
 
 describe('sanitizeSystemText', () => {
-  const SYSTEM_WITH_OPENCODE = `${OPENCODE_IDENTITY}\n\nSome OpenCode specific instructions\n\n# Code References\n\nActual content here`
+  // A realistic OpenCode system prompt showing what gets stripped vs preserved.
+  //
+  //   STRIPPED: everything from the identity line down to the first tail marker
+  //   KEPT:    everything before the identity + everything from the tail marker on
+  //
+  //   ┌─────────────────────────────────────────────────────────────┐
+  //   │ You are OpenCode, the best coding agent on the planet.     │ ← STRIPPED
+  //   │                                                            │
+  //   │ OpenCode-specific instructions, tool docs, etc.            │ ← STRIPPED
+  //   │ All of this is removed.                                    │ ← STRIPPED
+  //   │                                                            │
+  //   │ Instructions from: ~/.config/opencode/preamble.md          │ ← KEPT
+  //   │ Be concise. Prefer TypeScript.                             │ ← KEPT
+  //   │                                                            │
+  //   │ # Code References                                          │ ← KEPT
+  //   │ src/index.ts ...                                           │ ← KEPT
+  //   └─────────────────────────────────────────────────────────────┘
 
-  test('removes section between OpenCode identity and Code References', () => {
-    const result = sanitizeSystemText(SYSTEM_WITH_OPENCODE)
-    expect(result).not.toContain(OPENCODE_IDENTITY)
+  const REALISTIC_PROMPT = [
+    'You are OpenCode, the best coding agent on the planet.',
+    '',
+    'You have access to tools for reading files, running commands,',
+    'and editing code. Always explain before acting.',
+    '',
+    'Instructions from: ~/.config/opencode/preamble.md',
+    'Be concise. Prefer TypeScript.',
+    '',
+    '# Code References',
+    'src/index.ts (1-50)',
+  ].join('\n')
+
+  test('strips OpenCode section, keeps user instructions and code refs', () => {
+    const result = sanitizeSystemText(REALISTIC_PROMPT)
+
+    // Stripped
+    expect(result).not.toContain('OpenCode')
+    expect(result).not.toContain('explain before acting')
+
+    // Kept
+    expect(result).toContain(
+      'Instructions from: ~/.config/opencode/preamble.md',
+    )
+    expect(result).toContain('Be concise. Prefer TypeScript.')
     expect(result).toContain('# Code References')
-    expect(result).toContain('Actual content here')
+    expect(result).toContain('src/index.ts (1-50)')
   })
 
   test('returns text unchanged when OpenCode identity not present', () => {
@@ -478,80 +516,67 @@ describe('sanitizeSystemText', () => {
 
   test('calls onError when no preserved tail marker is found', () => {
     const onError = mock(() => {})
-    const text = `${OPENCODE_IDENTITY}\n\nSome instructions without any marker`
+    const text = [
+      'You are OpenCode, the best coding agent on the planet.',
+      'No markers at all in this prompt.',
+    ].join('\n')
     const result = sanitizeSystemText(text, onError)
-    expect(result).toBe(text) // unchanged
+    expect(result).toBe(text)
     expect(onError).toHaveBeenCalledTimes(1)
   })
 
   test('preserves content before OpenCode identity', () => {
-    const text = `Prefix content\n${OPENCODE_IDENTITY}\nstuff\n# Code References\nrest`
-    const result = sanitizeSystemText(text)
-    expect(result).toBe('Prefix content\n# Code References\nrest')
-  })
-
-  test('handles identity at the very start of text', () => {
-    const text = `${OPENCODE_IDENTITY}\n# Code References\nrest`
-    const result = sanitizeSystemText(text)
-    expect(result).toBe('# Code References\nrest')
-  })
-
-  test('only processes first occurrence of OpenCode identity', () => {
-    const text = `${OPENCODE_IDENTITY}\nfirst\n# Code References\nmiddle\n${OPENCODE_IDENTITY}\nsecond`
-    const result = sanitizeSystemText(text)
-    // First occurrence removed, second stays
-    expect(result).toBe(
-      `# Code References\nmiddle\n${OPENCODE_IDENTITY}\nsecond`,
-    )
-  })
-
-  test('preserves user instructions from config', () => {
     const text = [
-      OPENCODE_IDENTITY,
-      '',
-      'Some OpenCode specific stuff',
-      'Instructions from: /home/user/.config/opencode/preamble.md',
-      'My custom instructions here',
+      'Some prefix content',
+      'You are OpenCode, the best coding agent on the planet.',
+      'OpenCode stuff to strip',
       '# Code References',
       'file contents',
     ].join('\n')
     const result = sanitizeSystemText(text)
-    expect(result).not.toContain(OPENCODE_IDENTITY)
-    expect(result).not.toContain('OpenCode specific stuff')
-    expect(result).toContain(
-      'Instructions from: /home/user/.config/opencode/preamble.md',
-    )
-    expect(result).toContain('My custom instructions here')
+    expect(result).toBe('Some prefix content\n# Code References\nfile contents')
+  })
+
+  test('prefers earliest tail marker (instructions before code refs)', () => {
+    // "Instructions from:" appears before "# Code References",
+    // so we cut there — keeping the user's custom instructions.
+    const text = [
+      'You are OpenCode, the best coding agent on the planet.',
+      'OpenCode internal stuff',
+      'Instructions from: preamble.md',
+      'user-authored content',
+      '# Code References',
+      'files',
+    ].join('\n')
+    const result = sanitizeSystemText(text)
+    expect(result).not.toContain('OpenCode')
+    expect(result).toContain('Instructions from: preamble.md')
+    expect(result).toContain('user-authored content')
     expect(result).toContain('# Code References')
   })
 
   test('preserves instructions from command', () => {
     const text = [
-      OPENCODE_IDENTITY,
-      '',
-      'OpenCode stuff',
+      'You are OpenCode, the best coding agent on the planet.',
+      'Internal details',
       'Instructions from command: my-script',
-      'Command output here',
+      'Script output here',
       '# Code References',
     ].join('\n')
     const result = sanitizeSystemText(text)
     expect(result).toContain('Instructions from command: my-script')
-    expect(result).toContain('Command output here')
+    expect(result).toContain('Script output here')
   })
 
-  test('picks earliest preserved marker', () => {
+  test('falls back to # Code References when no instruction markers', () => {
     const text = [
-      OPENCODE_IDENTITY,
-      'OpenCode stuff',
-      'Instructions from: preamble.md',
-      'user content',
+      'You are OpenCode, the best coding agent on the planet.',
+      'Stuff to strip',
       '# Code References',
-      'files',
+      'src/main.ts',
     ].join('\n')
     const result = sanitizeSystemText(text)
-    // Should cut at "Instructions from:" since it comes before "# Code References"
-    expect(result).toContain('Instructions from: preamble.md')
-    expect(result).toContain('user content')
+    expect(result).toBe('# Code References\nsrc/main.ts')
   })
 })
 
@@ -636,14 +661,33 @@ describe('rewriteRequestBody', () => {
     expect(onError).toHaveBeenCalledTimes(1)
   })
 
-  test('rewrites realistic OpenCode system prompt end-to-end', () => {
+  test('rewrites realistic OpenCode request end-to-end', () => {
+    //  Input system prompt (array of blocks):
+    //    [0] "You are OpenCode..." + internal stuff + "# Code References\n..."
+    //    [1] "Additional context block"
+    //
+    //  Expected output:
+    //    [0] Claude Code identity (prepended)
+    //    [1] "# Code References\n..." (OpenCode section stripped)
+    //    [2] "Additional context block" (untouched)
+
+    const systemPrompt = [
+      'You are OpenCode, the best coding agent on the planet.',
+      '',
+      'You have access to tools.',
+      '',
+      '# Code References',
+      '',
+      'Here are some files.',
+    ].join('\n')
+
     const body = JSON.stringify({
       tools: [
         { name: 'bash', type: 'function' },
         { name: 'read_file', type: 'function' },
       ],
       messages: [
-        { role: 'user', content: 'Help me fix this bug in main.ts' },
+        { role: 'user', content: 'Help me fix this bug' },
         {
           role: 'assistant',
           content: [
@@ -651,45 +695,29 @@ describe('rewriteRequestBody', () => {
             { type: 'text', text: 'Let me check' },
           ],
         },
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'tool_1',
-              content: 'output',
-            },
-          ],
-        },
       ],
       system: [
-        {
-          type: 'text',
-          text: `${OPENCODE_IDENTITY}\n\nYou have access to tools.\n\n# Code References\n\nHere are some files.`,
-        },
+        { type: 'text', text: systemPrompt },
         { type: 'text', text: 'Additional context block' },
       ],
     })
 
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // System: identity prepended, OpenCode section removed
-    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    // System prompt rewritten
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
     expect(result.system[1].text).toContain('# Code References')
-    expect(result.system[1].text).not.toContain(OPENCODE_IDENTITY)
-    expect(result.system[1].text).not.toContain('You have access to tools')
+    expect(result.system[1].text).not.toContain('OpenCode')
     expect(result.system[2].text).toBe('Additional context block')
 
-    // Tools: prefixed
+    // Tool names prefixed
     expect(result.tools[0].name).toBe('mcp_bash')
     expect(result.tools[1].name).toBe('mcp_read_file')
 
-    // Messages: tool_use blocks prefixed
+    // tool_use blocks in messages prefixed, text untouched
     expect(result.messages[1].content[0].name).toBe('mcp_bash')
-    // Text blocks untouched
     expect(result.messages[1].content[1].text).toBe('Let me check')
-    // User messages untouched
-    expect(result.messages[0].content).toBe('Help me fix this bug in main.ts')
+    expect(result.messages[0].content).toBe('Help me fix this bug')
   })
 
   test('handles body with no messages array', () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -5,9 +5,7 @@ import {
   REQUIRED_BETAS,
 } from '../constants'
 import {
-  computeCCH,
   createStrippedStream,
-  extractFirstUserMessage,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
@@ -463,115 +461,6 @@ describe('createStrippedStream', () => {
   })
 })
 
-describe('computeCCH', () => {
-  test('produces deterministic 3-char hex hash', () => {
-    const hash = computeCCH('hello world test message', '2.1.2')
-    expect(hash).toHaveLength(3)
-    expect(hash).toMatch(/^[a-f0-9]{3}$/)
-    // Same input should produce same output
-    expect(computeCCH('hello world test message', '2.1.2')).toBe(hash)
-  })
-
-  test('different messages produce different hashes', () => {
-    const hash1 = computeCCH('hello world test message', '2.1.2')
-    const hash2 = computeCCH('different text entirely', '2.1.2')
-    expect(hash1).not.toBe(hash2)
-  })
-
-  test('different versions produce different hashes', () => {
-    const hash1 = computeCCH('hello world test message', '2.1.2')
-    const hash2 = computeCCH('hello world test message', '2.2.0')
-    expect(hash1).not.toBe(hash2)
-  })
-
-  test('falls back to random hash for empty message', () => {
-    const hash = computeCCH('', '2.1.2')
-    expect(hash).toHaveLength(3)
-    expect(hash).toMatch(/^[a-f0-9]{3}$/)
-  })
-
-  test('random fallback produces different values each call', () => {
-    const hashes = new Set(
-      Array.from({ length: 20 }, () => computeCCH('', '2.1.2')),
-    )
-    // With 20 random 3-hex-char values, extremely unlikely to all be identical
-    expect(hashes.size).toBeGreaterThan(1)
-  })
-
-  test('handles message shorter than max position (20)', () => {
-    const hash = computeCCH('hi', '2.1.2')
-    expect(hash).toHaveLength(3)
-    expect(hash).toMatch(/^[a-f0-9]{3}$/)
-    // Should be deterministic — short chars replaced with '0'
-    expect(computeCCH('hi', '2.1.2')).toBe(hash)
-  })
-
-  test('uses characters at positions 4, 7, 20 from message', () => {
-    // Position:  0123456789...
-    // Message:   abcdeXfgYhijklmnopqrstUvw
-    //                 ^4  ^7              ^20 (0-indexed)
-    // Chars at 4='e', 7='Y' — but position 20 depends on length
-    const msg = 'abcdeXfgYhijklmnopqrstUvw'
-    const hash1 = computeCCH(msg, '2.1.2')
-    // Change char at position 4
-    const msg2 = 'abcdZXfgYhijklmnopqrstUvw'
-    const hash2 = computeCCH(msg2, '2.1.2')
-    expect(hash1).not.toBe(hash2)
-  })
-})
-
-describe('extractFirstUserMessage', () => {
-  test('extracts string content from first user message', () => {
-    const messages = [
-      { role: 'system', content: 'system prompt' },
-      { role: 'user', content: 'hello world' },
-    ]
-    expect(extractFirstUserMessage(messages)).toBe('hello world')
-  })
-
-  test('extracts text block from array content', () => {
-    const messages = [
-      {
-        role: 'user',
-        content: [
-          { type: 'image', source: {} },
-          { type: 'text', text: 'describe this image' },
-        ],
-      },
-    ]
-    expect(extractFirstUserMessage(messages)).toBe('describe this image')
-  })
-
-  test('returns empty string when no user message', () => {
-    const messages = [{ role: 'assistant', content: 'hi' }]
-    expect(extractFirstUserMessage(messages)).toBe('')
-  })
-
-  test('returns empty string for non-array input', () => {
-    expect(extractFirstUserMessage('not an array' as any)).toBe('')
-  })
-
-  test('skips assistant messages to find first user', () => {
-    const messages = [
-      { role: 'assistant', content: 'I can help' },
-      { role: 'assistant', content: 'with that' },
-      { role: 'user', content: 'actual user message' },
-    ]
-    expect(extractFirstUserMessage(messages)).toBe('actual user message')
-  })
-
-  test('returns empty string when content has no text block', () => {
-    const messages = [
-      { role: 'user', content: [{ type: 'image', source: {} }] },
-    ]
-    expect(extractFirstUserMessage(messages)).toBe('')
-  })
-
-  test('returns empty string for empty messages array', () => {
-    expect(extractFirstUserMessage([])).toBe('')
-  })
-})
-
 describe('sanitizeSystemText', () => {
   const SYSTEM_WITH_OPENCODE = `${OPENCODE_IDENTITY}\n\nSome OpenCode specific instructions\n\n# Code References\n\nActual content here`
 
@@ -587,9 +476,9 @@ describe('sanitizeSystemText', () => {
     expect(sanitizeSystemText(text)).toBe(text)
   })
 
-  test('calls onError when Code References marker is missing', () => {
+  test('calls onError when no preserved tail marker is found', () => {
     const onError = mock(() => {})
-    const text = `${OPENCODE_IDENTITY}\n\nSome instructions without marker`
+    const text = `${OPENCODE_IDENTITY}\n\nSome instructions without any marker`
     const result = sanitizeSystemText(text, onError)
     expect(result).toBe(text) // unchanged
     expect(onError).toHaveBeenCalledTimes(1)
@@ -614,6 +503,55 @@ describe('sanitizeSystemText', () => {
     expect(result).toBe(
       `# Code References\nmiddle\n${OPENCODE_IDENTITY}\nsecond`,
     )
+  })
+
+  test('preserves user instructions from config', () => {
+    const text = [
+      OPENCODE_IDENTITY,
+      '',
+      'Some OpenCode specific stuff',
+      'Instructions from: /home/user/.config/opencode/preamble.md',
+      'My custom instructions here',
+      '# Code References',
+      'file contents',
+    ].join('\n')
+    const result = sanitizeSystemText(text)
+    expect(result).not.toContain(OPENCODE_IDENTITY)
+    expect(result).not.toContain('OpenCode specific stuff')
+    expect(result).toContain(
+      'Instructions from: /home/user/.config/opencode/preamble.md',
+    )
+    expect(result).toContain('My custom instructions here')
+    expect(result).toContain('# Code References')
+  })
+
+  test('preserves instructions from command', () => {
+    const text = [
+      OPENCODE_IDENTITY,
+      '',
+      'OpenCode stuff',
+      'Instructions from command: my-script',
+      'Command output here',
+      '# Code References',
+    ].join('\n')
+    const result = sanitizeSystemText(text)
+    expect(result).toContain('Instructions from command: my-script')
+    expect(result).toContain('Command output here')
+  })
+
+  test('picks earliest preserved marker', () => {
+    const text = [
+      OPENCODE_IDENTITY,
+      'OpenCode stuff',
+      'Instructions from: preamble.md',
+      'user content',
+      '# Code References',
+      'files',
+    ].join('\n')
+    const result = sanitizeSystemText(text)
+    // Should cut at "Instructions from:" since it comes before "# Code References"
+    expect(result).toContain('Instructions from: preamble.md')
+    expect(result).toContain('user content')
   })
 })
 
@@ -672,15 +610,6 @@ describe('rewriteRequestBody', () => {
     const result = JSON.parse(rewriteRequestBody(body))
     expect(result.tools[0].name).toBe('mcp_bash')
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
-    expect(result.system[0].text).toMatch(/cc_version=[\d.]+\.[a-f0-9]{3}/)
-  })
-
-  test('injects CCH hash into identity block', () => {
-    const body = JSON.stringify({
-      messages: [{ role: 'user', content: 'test content here for hashing' }],
-    })
-    const result = JSON.parse(rewriteRequestBody(body))
-    expect(result.system[0].text).toMatch(/cc_version=2\.1\.2\.[a-f0-9]{3}/)
   })
 
   test('handles missing system field', () => {
@@ -746,7 +675,6 @@ describe('rewriteRequestBody', () => {
 
     // System: identity prepended, OpenCode section removed
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
-    expect(result.system[0].text).toMatch(/cc_version=/)
     expect(result.system[1].text).toContain('# Code References')
     expect(result.system[1].text).not.toContain(OPENCODE_IDENTITY)
     expect(result.system[1].text).not.toContain('You have access to tools')
@@ -762,33 +690,6 @@ describe('rewriteRequestBody', () => {
     expect(result.messages[1].content[1].text).toBe('Let me check')
     // User messages untouched
     expect(result.messages[0].content).toBe('Help me fix this bug in main.ts')
-  })
-
-  test('CCH hash is deterministic for same message', () => {
-    const body = JSON.stringify({
-      messages: [{ role: 'user', content: 'consistent message content' }],
-    })
-    const result1 = JSON.parse(rewriteRequestBody(body))
-    const result2 = JSON.parse(rewriteRequestBody(body))
-    expect(result1.system[0].text).toBe(result2.system[0].text)
-  })
-
-  test('CCH hash differs for different messages', () => {
-    const body1 = JSON.stringify({
-      messages: [{ role: 'user', content: 'first message here' }],
-    })
-    const body2 = JSON.stringify({
-      messages: [{ role: 'user', content: 'different message' }],
-    })
-    const result1 = JSON.parse(rewriteRequestBody(body1))
-    const result2 = JSON.parse(rewriteRequestBody(body2))
-    const hash1 = result1.system[0].text.match(
-      /cc_version=[\d.]+\.([a-f0-9]{3})/,
-    )?.[1]
-    const hash2 = result2.system[0].text.match(
-      /cc_version=[\d.]+\.([a-f0-9]{3})/,
-    )?.[1]
-    expect(hash1).not.toBe(hash2)
   })
 
   test('handles body with no messages array', () => {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,12 +1,10 @@
-import { createHash, randomBytes } from 'node:crypto'
 import {
-  CCH_POSITIONS,
-  CCH_SALT,
   CLAUDE_CODE_IDENTITY,
-  CLAUDE_CODE_VERSION,
   OPENCODE_IDENTITY,
+  PRESERVED_TAIL_MARKERS,
   REQUIRED_BETAS,
-  TOOL_PREFIX, USER_AGENT,
+  TOOL_PREFIX,
+  USER_AGENT,
 } from './constants'
 
 export type FetchInput = string | URL | Request
@@ -215,48 +213,10 @@ export function rewriteUrl(input: FetchInput): {
 }
 
 /**
- * Compute a 3-character content-binding hash (CCH) from the first user message.
- * Algorithm reverse-engineered from Claude Code CLI.
- */
-export function computeCCH(
-  firstUserMessageText: string,
-  version: string,
-): string {
-  if (!firstUserMessageText) {
-    return randomBytes(2).toString('hex').slice(0, 3)
-  }
-  const chars = CCH_POSITIONS.map((i) => firstUserMessageText[i] || '0').join(
-    '',
-  )
-  return createHash('sha256')
-    .update(`${CCH_SALT}${chars}${version}`)
-    .digest('hex')
-    .slice(0, 3)
-}
-
-/**
- * Extract text from the first user message in an API messages array.
- */
-export function extractFirstUserMessage(messages: unknown[]): string {
-  if (!Array.isArray(messages)) return ''
-  const firstUser = messages.find(
-    (m: any) => m && typeof m === 'object' && m.role === 'user',
-  ) as { content?: unknown } | undefined
-  if (!firstUser) return ''
-  if (typeof firstUser.content === 'string') return firstUser.content
-  if (Array.isArray(firstUser.content)) {
-    const textBlock = firstUser.content.find(
-      (b: any) => b && typeof b === 'object' && b.type === 'text',
-    ) as { text?: string } | undefined
-    if (textBlock?.text) return textBlock.text
-  }
-  return ''
-}
-
-/**
  * Remove the OpenCode identity section from system prompt text.
  * Finds the OpenCode identity marker, then removes everything up to
- * (but not including) the '# Code References' marker.
+ * the earliest preserved tail marker (user instructions, code references, etc.).
+ * This preserves user-configured instructions from config.json.
  */
 export function sanitizeSystemText(
   text: string,
@@ -264,15 +224,27 @@ export function sanitizeSystemText(
 ): string {
   const startIdx = text.indexOf(OPENCODE_IDENTITY)
   if (startIdx === -1) return text
-  const codeRefsMarker = '# Code References'
-  const endIdx = text.indexOf(codeRefsMarker, startIdx)
+
+  // Find the earliest preserved tail marker after the OpenCode identity
+  let endIdx = -1
+  for (const marker of PRESERVED_TAIL_MARKERS) {
+    const idx = text.indexOf(marker, startIdx)
+    if (idx !== -1 && (endIdx === -1 || idx < endIdx)) {
+      endIdx = idx
+    }
+  }
+
   if (endIdx === -1) {
     onError?.(
-      `sanitizeSystemText: could not find '# Code References' after OpenCode identity`,
+      'sanitizeSystemText: could not find any preserved tail marker after OpenCode identity',
     )
     return text
   }
-  return text.slice(0, startIdx) + text.slice(endIdx)
+
+  // Preserve content from the marker onwards (skip leading newline if present)
+  const tail =
+    text[endIdx] === '\n' ? text.slice(endIdx + 1) : text.slice(endIdx)
+  return text.slice(0, startIdx) + tail
 }
 
 type SystemBlock = { type: string; text: string; [k: string]: unknown }
@@ -289,7 +261,10 @@ export function prependClaudeCodeIdentity(
   system: unknown,
   onError?: (msg: string) => void,
 ): SystemBlock[] {
-  const identityBlock: SystemBlock = { type: 'text', text: CLAUDE_CODE_IDENTITY }
+  const identityBlock: SystemBlock = {
+    type: 'text',
+    text: CLAUDE_CODE_IDENTITY,
+  }
 
   if (system == null) return [identityBlock]
 
@@ -302,7 +277,10 @@ export function prependClaudeCodeIdentity(
   if (isRecord(system)) {
     const type = typeof system.type === 'string' ? system.type : 'text'
     const text = typeof system.text === 'string' ? system.text : ''
-    return [identityBlock, { ...system, type, text: sanitizeSystemText(text, onError) }]
+    return [
+      identityBlock,
+      { ...system, type, text: sanitizeSystemText(text, onError) },
+    ]
   }
 
   if (!Array.isArray(system)) return [identityBlock]
@@ -312,8 +290,16 @@ export function prependClaudeCodeIdentity(
       return { type: 'text', text: sanitizeSystemText(item, onError) }
     }
 
-    if (isRecord(item) && item.type === 'text' && typeof item.text === 'string') {
-      return { ...item, type: 'text', text: sanitizeSystemText(item.text, onError) }
+    if (
+      isRecord(item) &&
+      item.type === 'text' &&
+      typeof item.text === 'string'
+    ) {
+      return {
+        ...item,
+        type: 'text',
+        text: sanitizeSystemText(item.text, onError),
+      }
     }
 
     return { type: 'text', text: String(item) }
@@ -328,8 +314,7 @@ export function prependClaudeCodeIdentity(
 }
 
 /**
- * Rewrite the full request body: sanitize system prompt, prefix tool names,
- * and inject CCH hash.
+ * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
 export function rewriteRequestBody(
   body: string,
@@ -338,20 +323,8 @@ export function rewriteRequestBody(
   try {
     const parsed = JSON.parse(body)
 
-    // Compute CCH from first user message
-    const firstUserText = extractFirstUserMessage(parsed.messages)
-    const cch = computeCCH(firstUserText, CLAUDE_CODE_VERSION)
-
     // Sanitize system prompt and prepend Claude Code identity
     parsed.system = prependClaudeCodeIdentity(parsed.system, onError)
-
-    // Inject cc_version with CCH hash into the identity block
-    if (Array.isArray(parsed.system) && parsed.system.length > 0) {
-      const first = parsed.system[0]
-      if (first?.type === 'text' && first.text === CLAUDE_CODE_IDENTITY) {
-        first.text = `${CLAUDE_CODE_IDENTITY}\n\ncc_version=${CLAUDE_CODE_VERSION}.${cch}`
-      }
-    }
 
     // Prefix tool names
     if (parsed.tools && Array.isArray(parsed.tools)) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,13 @@
-import { REQUIRED_BETAS, TOOL_PREFIX, USER_AGENT } from './constants'
+import { createHash, randomBytes } from 'node:crypto'
+import {
+  CCH_POSITIONS,
+  CCH_SALT,
+  CLAUDE_CODE_IDENTITY,
+  CLAUDE_CODE_VERSION,
+  OPENCODE_IDENTITY,
+  REQUIRED_BETAS,
+  TOOL_PREFIX, USER_AGENT,
+} from './constants'
 
 export type FetchInput = string | URL | Request
 
@@ -203,6 +212,184 @@ export function rewriteUrl(input: FetchInput): {
       ? new Request(requestUrl.toString(), input)
       : requestUrl
   return { input: newInput, url: requestUrl }
+}
+
+/**
+ * Compute a 3-character content-binding hash (CCH) from the first user message.
+ * Algorithm reverse-engineered from Claude Code CLI.
+ */
+export function computeCCH(
+  firstUserMessageText: string,
+  version: string,
+): string {
+  if (!firstUserMessageText) {
+    return randomBytes(2).toString('hex').slice(0, 3)
+  }
+  const chars = CCH_POSITIONS.map((i) => firstUserMessageText[i] || '0').join(
+    '',
+  )
+  return createHash('sha256')
+    .update(`${CCH_SALT}${chars}${version}`)
+    .digest('hex')
+    .slice(0, 3)
+}
+
+/**
+ * Extract text from the first user message in an API messages array.
+ */
+export function extractFirstUserMessage(messages: unknown[]): string {
+  if (!Array.isArray(messages)) return ''
+  const firstUser = messages.find(
+    (m: any) => m && typeof m === 'object' && m.role === 'user',
+  ) as { content?: unknown } | undefined
+  if (!firstUser) return ''
+  if (typeof firstUser.content === 'string') return firstUser.content
+  if (Array.isArray(firstUser.content)) {
+    const textBlock = firstUser.content.find(
+      (b: any) => b && typeof b === 'object' && b.type === 'text',
+    ) as { text?: string } | undefined
+    if (textBlock?.text) return textBlock.text
+  }
+  return ''
+}
+
+/**
+ * Remove the OpenCode identity section from system prompt text.
+ * Finds the OpenCode identity marker, then removes everything up to
+ * (but not including) the '# Code References' marker.
+ */
+export function sanitizeSystemText(
+  text: string,
+  onError?: (msg: string) => void,
+): string {
+  const startIdx = text.indexOf(OPENCODE_IDENTITY)
+  if (startIdx === -1) return text
+  const codeRefsMarker = '# Code References'
+  const endIdx = text.indexOf(codeRefsMarker, startIdx)
+  if (endIdx === -1) {
+    onError?.(
+      `sanitizeSystemText: could not find '# Code References' after OpenCode identity`,
+    )
+    return text
+  }
+  return text.slice(0, startIdx) + text.slice(endIdx)
+}
+
+type SystemBlock = { type: string; text: string; [k: string]: unknown }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Sanitize system prompt and prepend Claude Code identity.
+ * Handles all Anthropic API system formats: undefined, string, or array of text blocks.
+ */
+export function prependClaudeCodeIdentity(
+  system: unknown,
+  onError?: (msg: string) => void,
+): SystemBlock[] {
+  const identityBlock: SystemBlock = { type: 'text', text: CLAUDE_CODE_IDENTITY }
+
+  if (system == null) return [identityBlock]
+
+  if (typeof system === 'string') {
+    const sanitized = sanitizeSystemText(system, onError)
+    if (sanitized === CLAUDE_CODE_IDENTITY) return [identityBlock]
+    return [identityBlock, { type: 'text', text: sanitized }]
+  }
+
+  if (isRecord(system)) {
+    const type = typeof system.type === 'string' ? system.type : 'text'
+    const text = typeof system.text === 'string' ? system.text : ''
+    return [identityBlock, { ...system, type, text: sanitizeSystemText(text, onError) }]
+  }
+
+  if (!Array.isArray(system)) return [identityBlock]
+
+  const sanitized: SystemBlock[] = system.map((item: unknown) => {
+    if (typeof item === 'string') {
+      return { type: 'text', text: sanitizeSystemText(item, onError) }
+    }
+
+    if (isRecord(item) && item.type === 'text' && typeof item.text === 'string') {
+      return { ...item, type: 'text', text: sanitizeSystemText(item.text, onError) }
+    }
+
+    return { type: 'text', text: String(item) }
+  })
+
+  // Idempotency: don't double-prepend if first block already has the identity
+  if (sanitized[0]?.text === CLAUDE_CODE_IDENTITY) {
+    return sanitized
+  }
+
+  return [identityBlock, ...sanitized]
+}
+
+/**
+ * Rewrite the full request body: sanitize system prompt, prefix tool names,
+ * and inject CCH hash.
+ */
+export function rewriteRequestBody(
+  body: string,
+  onError?: (msg: string) => void,
+): string {
+  try {
+    const parsed = JSON.parse(body)
+
+    // Compute CCH from first user message
+    const firstUserText = extractFirstUserMessage(parsed.messages)
+    const cch = computeCCH(firstUserText, CLAUDE_CODE_VERSION)
+
+    // Sanitize system prompt and prepend Claude Code identity
+    parsed.system = prependClaudeCodeIdentity(parsed.system, onError)
+
+    // Inject cc_version with CCH hash into the identity block
+    if (Array.isArray(parsed.system) && parsed.system.length > 0) {
+      const first = parsed.system[0]
+      if (first?.type === 'text' && first.text === CLAUDE_CODE_IDENTITY) {
+        first.text = `${CLAUDE_CODE_IDENTITY}\n\ncc_version=${CLAUDE_CODE_VERSION}.${cch}`
+      }
+    }
+
+    // Prefix tool names
+    if (parsed.tools && Array.isArray(parsed.tools)) {
+      parsed.tools = parsed.tools.map(
+        (tool: { name?: string; [k: string]: unknown }) => ({
+          ...tool,
+          name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
+        }),
+      )
+    }
+
+    if (parsed.messages && Array.isArray(parsed.messages)) {
+      parsed.messages = parsed.messages.map(
+        (msg: {
+          content?: Array<{
+            type: string
+            name?: string
+            [k: string]: unknown
+          }>
+          [k: string]: unknown
+        }) => {
+          if (msg.content && Array.isArray(msg.content)) {
+            msg.content = msg.content.map((block) => {
+              if (block.type === 'tool_use' && block.name) {
+                return { ...block, name: `${TOOL_PREFIX}${block.name}` }
+              }
+              return block
+            })
+          }
+          return msg
+        },
+      )
+    }
+
+    return JSON.stringify(parsed)
+  } catch {
+    return body
+  }
 }
 
 /**

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,6 +8,5 @@
     "noEmit": false,
     "allowImportingTsExtensions": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,5 @@
     "types": ["bun-types"],
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "script/**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "include": ["src/**/*.ts", "script/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Moves system prompt handling from `experimental.chat.system.transform` hook into request body rewriting layer
- Surgically removes the OpenCode identity section and prepends Claude Code identity
- Preserves user-configured instructions from `config.json` (uses earliest tail marker instead of only `# Code References`)
- Fixes pre-existing type errors across test files

## Test plan

- [x] `bun test` — 108 tests passing
- [x] `bun types` — zero errors
- [x] `bun run build` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)