### PR TITLE
fix: sanitize anthropic system prompt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   mergeHeaders,
   prefixToolNames,
   rewriteUrl,
+  sanitizeSystemPrompt,
   setOAuthHeaders,
 } from './transform'
 
@@ -18,6 +19,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
     ) => {
       const prefix = "You are Claude Code, Anthropic's official CLI for Claude."
       if (input.model?.providerID === 'anthropic') {
+        output.system = output.system.map(sanitizeSystemPrompt).filter(Boolean)
         output.system.unshift(prefix)
         if (output.system[1])
           output.system[1] = `${prefix}\n\n${output.system[1]}`

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -60,6 +60,34 @@ describe('experimental.chat.system.transform', () => {
     expect(output.system[0]).toBe(PREFIX)
     expect(output.system).toHaveLength(1)
   })
+
+  test('strips OpenCode docs markers and rewrites Task tool directive', async () => {
+    const plugin = await getPlugin()
+    const hook = plugin['experimental.chat.system.transform']
+    const output = {
+      system: [
+        [
+          'You are an interactive CLI tool that helps users with software engineering tasks.',
+          'When the user directly asks about OpenCode (eg. "can OpenCode do..."), use the WebFetch tool to gather information to answer the question from OpenCode docs. The list of available docs is available at https://opencode.ai/docs',
+          '# Tool usage policy',
+          '- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.',
+          'Keep this instruction.',
+        ].join('\n\n'),
+      ],
+    }
+
+    hook({ model: { providerID: 'anthropic' } }, output)
+
+    expect(output.system[1]).toContain('You are an interactive CLI tool')
+    expect(output.system[1]).toContain('Keep this instruction.')
+    expect(output.system[1]).not.toContain('https://opencode.ai/docs')
+    expect(output.system[1]).toContain(
+      'use the Task tool instead of running search commands directly.',
+    )
+    expect(output.system[1]).not.toContain(
+      'it is CRITICAL that you use the Task tool instead of running search commands directly.',
+    )
+  })
 })
 
 describe('auth.methods', () => {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,6 +2,17 @@ import { REQUIRED_BETAS, TOOL_PREFIX, USER_AGENT } from './constants'
 
 export type FetchInput = string | URL | Request
 
+const SYSTEM_PROMPT_STRIP_PATTERNS = [
+  /\n\nWhen the user directly asks about OpenCode[\s\S]*?https:\/\/opencode\.ai\/docs\n*/g,
+  /https?:\/\/(?:www\.)?opencode\.ai\/docs\S*/g,
+]
+
+const TASK_TOOL_DIRECTIVE_PATTERN =
+  /- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file\/class\/function, it is CRITICAL that you use the Task tool instead of running search commands directly\./g
+
+const SAFE_TASK_TOOL_DIRECTIVE =
+  '- When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, use the Task tool instead of running search commands directly.'
+
 /**
  * Merge headers from a Request object and/or a RequestInit headers value
  * into a single Headers instance.
@@ -38,6 +49,17 @@ export function mergeHeaders(input: FetchInput, init?: RequestInit): Headers {
   }
 
   return headers
+}
+
+export function sanitizeSystemPrompt(text: string): string {
+  let sanitized = text.replace(
+    TASK_TOOL_DIRECTIVE_PATTERN,
+    SAFE_TASK_TOOL_DIRECTIVE,
+  )
+  for (const pattern of SYSTEM_PROMPT_STRIP_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '')
+  }
+  return sanitized.trim()
 }
 
 /**


### PR DESCRIPTION
## Summary
- strip OpenCode docs markers from the Anthropic-visible system prompt to avoid third-party harness classification
- rewrite the Task tool directive into equivalent safer wording so the behavior remains intact
- add regression coverage for the sanitized system prompt transform