### PR TITLE
Add dev script for local plugin testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ For Claude Pro/Max authentication, the plugin:
 
 ## Development
 
+### Local Testing
+
+Use `bun run dev` to test plugin changes locally without publishing to npm:
+
+```bash
+bun run dev
+```
+
+This does three things:
+
+1. Builds the plugin
+2. Symlinks the build output into `.opencode/plugins/` so OpenCode loads it as a local plugin
+3. Starts `tsc --watch` for automatic rebuilds on source changes
+
+After starting the dev script, restart OpenCode in this project directory to pick up the local build. Any edits to `src/` will trigger a rebuild — restart OpenCode again to load the new version.
+
+Ctrl+C stops the watcher and cleans up the symlink. If the process was killed without cleanup (e.g. `kill -9`), you can manually remove the symlink:
+
+```bash
+bun run dev:clean
+```
+
+> [!NOTE]
+> If you have the npm version of this plugin in your global OpenCode config, both will load. The local version takes precedence for auth handling.
+
 ### Publishing
 
 This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing. See the [changeset README](.changeset/README.md) for more details.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "tsc -p tsconfig.build.json",
     "build": "tsc -p tsconfig.build.json",
     "dev": "bun scripts/dev.ts",
-    "dev:clean": "rm -f .opencode/plugins/anthropic-auth.js && echo 'Symlink removed'",
+    "dev:clean": "bun scripts/dev-clean.ts",
     "test": "bun test",
     "types": "tsc",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "prepare": "tsc -p tsconfig.build.json",
     "build": "tsc -p tsconfig.build.json",
+    "dev": "bun scripts/dev.ts",
     "test": "bun test",
     "types": "tsc",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare": "tsc -p tsconfig.build.json",
     "build": "tsc -p tsconfig.build.json",
     "dev": "bun scripts/dev.ts",
+    "dev:clean": "rm -f .opencode/plugins/anthropic-auth.js && echo 'Symlink removed'",
     "test": "bun test",
     "types": "tsc",
     "format": "biome format --write .",

--- a/scripts/dev-clean.ts
+++ b/scripts/dev-clean.ts
@@ -1,0 +1,11 @@
+import { existsSync, unlinkSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const SYMLINK_PATH = resolve(import.meta.dirname, '..', '.opencode', 'plugins', 'anthropic-auth.js')
+
+if (existsSync(SYMLINK_PATH)) {
+  unlinkSync(SYMLINK_PATH)
+  console.log('[dev:clean] Removed symlink')
+} else {
+  console.log('[dev:clean] No symlink found, nothing to clean')
+}

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,76 @@
+import {
+  existsSync,
+  mkdirSync,
+  readlinkSync,
+  symlinkSync,
+  unlinkSync,
+} from 'node:fs'
+import { resolve } from 'node:path'
+
+const PROJECT_ROOT = resolve(import.meta.dirname!, '..')
+const PLUGINS_DIR = resolve(PROJECT_ROOT, '.opencode', 'plugins')
+const SYMLINK_PATH = resolve(PLUGINS_DIR, 'anthropic-auth.js')
+const TARGET = '../../dist/index.js' // relative from .opencode/plugins/
+
+function createSymlink() {
+  mkdirSync(PLUGINS_DIR, { recursive: true })
+
+  if (existsSync(SYMLINK_PATH)) {
+    try {
+      const current = readlinkSync(SYMLINK_PATH)
+      if (current === TARGET) {
+        console.log(`[dev] Symlink already exists: ${SYMLINK_PATH} -> ${TARGET}`)
+        return
+      }
+    } catch {}
+    unlinkSync(SYMLINK_PATH)
+  }
+
+  symlinkSync(TARGET, SYMLINK_PATH)
+  console.log(`[dev] Created symlink: ${SYMLINK_PATH} -> ${TARGET}`)
+}
+
+function removeSymlink() {
+  try {
+    unlinkSync(SYMLINK_PATH)
+    console.log('[dev] Removed symlink')
+  } catch {}
+}
+
+// --- Main ---
+
+// 1. Build first
+console.log('[dev] Running initial build...')
+const build = Bun.spawnSync(['tsc', '-p', 'tsconfig.build.json'], {
+  cwd: PROJECT_ROOT,
+  stdout: 'inherit',
+  stderr: 'inherit',
+})
+if (build.exitCode !== 0) {
+  console.error('[dev] Build failed, aborting')
+  process.exit(1)
+}
+
+// 2. Create symlink
+createSymlink()
+
+// 3. Start tsc --watch
+console.log('[dev] Starting tsc --watch...')
+console.log('[dev] Restart OpenCode to pick up the linked plugin.')
+const child = Bun.spawn(['tsc', '-p', 'tsconfig.build.json', '--watch', '--preserveWatchOutput'], {
+  cwd: PROJECT_ROOT,
+  stdout: 'inherit',
+  stderr: 'inherit',
+})
+
+function cleanup() {
+  console.log('\n[dev] Cleaning up...')
+  child.kill()
+  removeSymlink()
+  process.exit(0)
+}
+
+process.on('SIGINT', cleanup)
+process.on('SIGTERM', cleanup)
+
+await child.exited

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,5 @@
     "types": ["bun-types"],
     "noEmit": true
   },
-  "include": ["src/**/*.ts", "script/**/*.ts"]
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Adds a `bun run dev` workflow for testing plugin changes locally without publishing to npm.

The dev script builds the plugin, symlinks `dist/index.js` into `.opencode/plugins/` so OpenCode loads the local build as a project-level plugin, and starts `tsc --watch` for automatic rebuilds on source changes. On exit (Ctrl+C), the symlink is cleaned up.

## Usage

```sh
bun run dev
# In another terminal, restart OpenCode — it picks up the local build
# Edit src/ — tsc rebuilds automatically
# Restart OpenCode again to pick up the new build
```