### PR TITLE
Minimize prompt sanitization with anchor-based paragraph removal

### DIFF
--- a/.changeset/bold-garlics-call.md
+++ b/.changeset/bold-garlics-call.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+Use targeted anchor replacement

--- a/.changeset/bold-garlics-call.md
+++ b/.changeset/bold-garlics-call.md
@@ -2,4 +2,4 @@
 "@ex-machina/opencode-anthropic-auth": minor
 ---
 
-Replace region-based system prompt stripping with anchor-based paragraph removal. Instead of removing everything between the OpenCode identity and the first tail marker (~90 lines of useful behavioral guidance), the plugin now only removes paragraphs containing specific URL anchors (`github.com/anomalyco/opencode`, `opencode.ai/docs`) and the identity line itself. This preserves tone/style, task management, tool usage policy, and other generic instructions that were previously stripped.
+Minimize prompt sanitization reach with anchor-based paragraph removal, preserving behavioral guidance that was previously stripped.

--- a/.changeset/bold-garlics-call.md
+++ b/.changeset/bold-garlics-call.md
@@ -2,4 +2,4 @@
 "@ex-machina/opencode-anthropic-auth": minor
 ---
 
-Use targeted anchor replacement
+Replace region-based system prompt stripping with anchor-based paragraph removal. Instead of removing everything between the OpenCode identity and the first tail marker (~90 lines of useful behavioral guidance), the plugin now only removes paragraphs containing specific URL anchors (`github.com/anomalyco/opencode`, `opencode.ai/docs`) and the identity line itself. This preserves tone/style, task management, tool usage policy, and other generic instructions that were previously stripped.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,18 @@ For Claude Pro/Max authentication, the plugin:
 2. Exchanges the authorization code for access and refresh tokens
 3. Automatically refreshes expired tokens
 4. Injects the required OAuth headers and beta flags into API requests
-5. Zeros out model costs (since usage is covered by the subscription)
+5. Sanitizes the system prompt for compatibility (see below)
+6. Zeros out model costs (since usage is covered by the subscription)
+
+### System Prompt Sanitization
+
+The Anthropic API for Max subscriptions requires the system prompt to identify as Claude Code. The plugin rewrites the system prompt on each request using an **anchor-based** approach that minimizes what gets changed:
+
+1. **Identity swap** — The OpenCode identity line is removed and replaced with the Claude Code identity.
+2. **Paragraph removal by anchor** — Any paragraph containing a known URL anchor (e.g. `github.com/anomalyco/opencode`, `opencode.ai/docs`) is removed entirely. This is resilient to upstream rewording — as long as the anchor URL appears somewhere in the paragraph, the removal works regardless of surrounding text changes.
+3. **Inline text replacements** — Short branded strings inside paragraphs we want to keep are replaced (e.g. "OpenCode" → "the assistant" in the professional objectivity section).
+
+Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode".
 
 ## Development
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@opencode-ai/plugin": "1.3.13",
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.11",
+        "dedent": "^1.7.2",
         "lefthook": "2.1.4",
         "typescript": "6.0.2",
       },
@@ -116,6 +117,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "dataloader": ["dataloader@1.4.0", "", {}, "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="],
+
+    "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@opencode-ai/plugin": "1.3.13",
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.11",
+    "dedent": "^1.7.2",
     "lefthook": "2.1.4",
     "typescript": "6.0.2"
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,8 +33,27 @@ export const CLAUDE_CODE_IDENTITY =
 
 export const USER_AGENT = 'claude-cli/2.1.2 (external, cli)'
 
-export const PRESERVED_TAIL_MARKERS = [
-  '\nInstructions from: ',
-  '\nInstructions from command: ',
-  '# Code References',
+/**
+ * Anchors that identify paragraphs to remove from the system prompt.
+ * Any paragraph (text between blank lines) containing one of these
+ * strings is removed entirely.
+ *
+ * This is resilient to upstream rewording — as long as the anchor
+ * string (typically a URL) still appears somewhere in the paragraph,
+ * the removal works regardless of how the surrounding text changes.
+ */
+export const PARAGRAPH_REMOVAL_ANCHORS = [
+  // Help/feedback block — references the OpenCode GitHub repo
+  'github.com/anomalyco/opencode',
+  // OpenCode docs guidance — references the OpenCode docs URL
+  'opencode.ai/docs',
+]
+
+/**
+ * Inline text replacements applied after paragraph removal.
+ * These handle cases where "OpenCode" appears inside a paragraph
+ * we want to keep (so we can't remove the whole paragraph).
+ */
+export const TEXT_REPLACEMENTS: { match: string; replacement: string }[] = [
+  { match: 'if OpenCode honestly', replacement: 'if the assistant honestly' },
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,9 +149,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                 ...init,
                 body,
                 headers: requestHeaders,
-                // biome-ignore lint/suspicious/noExplicitAny: tls option is Bun-specific, not in standard RequestInit
                 ...(isInsecure() && { tls: { rejectUnauthorized: false } }),
-              } as any)
+              })
 
               return createStrippedStream(response)
             },

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -1,0 +1,139 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`sanitizeSystemText – realistic prompt sanitizeSystemText output snapshot 1`] = `
+"You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+
+# Tone and style
+- Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+- Your output will be displayed on a command line interface. Your responses should be short and concise. You can use GitHub-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
+- NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
+
+# Professional objectivity
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if the assistant honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
+
+# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+
+Examples:
+
+<example>
+user: Run the build and fix any type errors
+assistant: I'm going to use the TodoWrite tool to write the following items to the todo list:
+- Run the build
+- Fix any type errors
+
+I'm now going to run the build using Bash.
+
+Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
+
+marking the first todo as in_progress
+
+Let me start working on the first item...
+
+The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
+..
+..
+</example>
+In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
+
+<example>
+user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
+assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
+Adding the following todos to the todo list:
+1. Research existing metrics tracking in the codebase
+2. Design the metrics collection system
+3. Implement core metrics tracking functionality
+4. Create export functionality for different formats
+
+Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
+
+I'm going to search for any existing metrics or telemetry code in the project.
+
+I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
+
+[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
+</example>
+
+# Doing tasks
+The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
+- 
+- Use the TodoWrite tool to plan the task if required
+
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.
+
+# Tool usage policy
+- When doing file search, prefer to use the Task tool in order to reduce context usage.
+- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.
+
+- When WebFetch returns a message about a redirect to a different host, you should immediately make a new WebFetch request with the redirect URL provided in the response.
+- You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.
+- If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
+- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
+- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.
+<example>
+user: Where are errors from the client handled?
+assistant: [Uses the Task tool to find the files that handle client errors instead of using Glob or Grep directly]
+</example>
+<example>
+user: What is the codebase structure?
+assistant: [Uses the Task tool]
+</example>
+
+IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
+
+# Code References
+
+When referencing specific functions or pieces of code include the pattern \`file_path:line_number\` to allow the user to easily navigate to the source code location.
+
+<example>
+user: Where are errors from the client handled?
+assistant: Clients are marked as failed in the \`connectToServer\` function in src/services/process.ts:712.
+</example>
+You are powered by the model named claude-sonnet-4-20250514. The exact model ID is anthropic/claude-sonnet-4-20250514
+Here is some useful information about the environment you are running in:
+<env>
+Working directory: /Users/user/project
+Workspace root folder: /Users/user/project
+Is directory a git repo: yes
+Platform: darwin
+Today's date: Mon Jan 01 2025
+</env>
+<directories>
+
+</directories>
+Skills provide specialized instructions and workflows for specific tasks.
+Use the skill tool to load a skill when a task matches its description.
+<available_skills>
+<skill>
+  <name>pr-descriptions</name>
+  <description>How to write good GitHub pull request titles and descriptions.</description>
+  <location>file:///Users/user/.agents/skills/pr-descriptions/SKILL.md</location>
+</skill>
+<skill>
+  <name>code-review</name>
+  <description>Guidelines for reviewing pull requests and providing feedback.</description>
+  <location>file:///Users/user/project/.opencode/skills/code-review/SKILL.md</location>
+</skill>
+</available_skills>
+Instructions from: /Users/user/.config/opencode/AGENTS.md
+# Global Agent Instructions
+
+These instructions apply to all agents.
+
+Always prefer TypeScript over JavaScript.
+Be concise in your responses.
+Instructions from: /Users/user/project/.opencode/AGENTS.md
+# Project Agent Instructions
+
+This project uses Bun as the runtime and test runner.
+Run \`bun test\` to execute tests.
+Run \`bun run build\` to compile."
+`;
+
+exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snapshot 1`] = `"{"system":[{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},{"type":"text","text":"You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.\\n\\nIMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.\\n\\n# Tone and style\\n- Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.\\n- Your output will be displayed on a command line interface. Your responses should be short and concise. You can use GitHub-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.\\n- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.\\n- NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.\\n\\n# Professional objectivity\\nPrioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if the assistant honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.\\n\\n# Task Management\\nYou have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.\\nThese tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.\\n\\nIt is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.\\n\\nExamples:\\n\\n<example>\\nuser: Run the build and fix any type errors\\nassistant: I'm going to use the TodoWrite tool to write the following items to the todo list:\\n- Run the build\\n- Fix any type errors\\n\\nI'm now going to run the build using Bash.\\n\\nLooks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.\\n\\nmarking the first todo as in_progress\\n\\nLet me start working on the first item...\\n\\nThe first item has been fixed, let me mark the first todo as completed, and move on to the second item...\\n..\\n..\\n</example>\\nIn the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.\\n\\n<example>\\nuser: Help me write a new feature that allows users to track their usage metrics and export them to various formats\\nassistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.\\nAdding the following todos to the todo list:\\n1. Research existing metrics tracking in the codebase\\n2. Design the metrics collection system\\n3. Implement core metrics tracking functionality\\n4. Create export functionality for different formats\\n\\nLet me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.\\n\\nI'm going to search for any existing metrics or telemetry code in the project.\\n\\nI've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...\\n\\n[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]\\n</example>\\n\\n# Doing tasks\\nThe user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:\\n- \\n- Use the TodoWrite tool to plan the task if required\\n\\n- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.\\n\\n# Tool usage policy\\n- When doing file search, prefer to use the Task tool in order to reduce context usage.\\n- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.\\n\\n- When WebFetch returns a message about a redirect to a different host, you should immediately make a new WebFetch request with the redirect URL provided in the response.\\n- You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.\\n- If the user specifies that they want you to run tools \\"in parallel\\", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.\\n- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.\\n- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.\\n<example>\\nuser: Where are errors from the client handled?\\nassistant: [Uses the Task tool to find the files that handle client errors instead of using Glob or Grep directly]\\n</example>\\n<example>\\nuser: What is the codebase structure?\\nassistant: [Uses the Task tool]\\n</example>\\n\\nIMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.\\n\\n# Code References\\n\\nWhen referencing specific functions or pieces of code include the pattern \`file_path:line_number\` to allow the user to easily navigate to the source code location.\\n\\n<example>\\nuser: Where are errors from the client handled?\\nassistant: Clients are marked as failed in the \`connectToServer\` function in src/services/process.ts:712.\\n</example>\\nYou are powered by the model named claude-sonnet-4-20250514. The exact model ID is anthropic/claude-sonnet-4-20250514\\nHere is some useful information about the environment you are running in:\\n<env>\\nWorking directory: /Users/user/project\\nWorkspace root folder: /Users/user/project\\nIs directory a git repo: yes\\nPlatform: darwin\\nToday's date: Mon Jan 01 2025\\n</env>\\n<directories>\\n\\n</directories>\\nSkills provide specialized instructions and workflows for specific tasks.\\nUse the skill tool to load a skill when a task matches its description.\\n<available_skills>\\n<skill>\\n  <name>pr-descriptions</name>\\n  <description>How to write good GitHub pull request titles and descriptions.</description>\\n  <location>file:///Users/user/.agents/skills/pr-descriptions/SKILL.md</location>\\n</skill>\\n<skill>\\n  <name>code-review</name>\\n  <description>Guidelines for reviewing pull requests and providing feedback.</description>\\n  <location>file:///Users/user/project/.opencode/skills/code-review/SKILL.md</location>\\n</skill>\\n</available_skills>\\nInstructions from: /Users/user/.config/opencode/AGENTS.md\\n# Global Agent Instructions\\n\\nThese instructions apply to all agents.\\n\\nAlways prefer TypeScript over JavaScript.\\nBe concise in your responses.\\nInstructions from: /Users/user/project/.opencode/AGENTS.md\\n# Project Agent Instructions\\n\\nThis project uses Bun as the runtime and test runner.\\nRun \`bun test\` to execute tests.\\nRun \`bun run build\` to compile."}],"messages":[{"role":"user","content":"Hello"}],"tools":[{"name":"mcp_bash","type":"function"},{"name":"mcp_read","type":"function"},{"name":"mcp_edit","type":"function"}]}"`;

--- a/src/tests/fixtures/realistic-system-prompt.ts
+++ b/src/tests/fixtures/realistic-system-prompt.ts
@@ -1,0 +1,162 @@
+import dedent from 'dedent'
+
+/**
+ * A realistic fully assembled system prompt matching what OpenCode sends
+ * to the Anthropic API. This is the single joined string from llm.ts,
+ * composed of:
+ *
+ *   1. anthropic.txt          – SystemPrompt.provider() for Claude models
+ *   2. Environment block      – SystemPrompt.environment()
+ *   3. Skills block           – SystemPrompt.skills()
+ *   4. Global instructions    – InstructionPrompt.system() (user config)
+ *   5. Project instructions   – InstructionPrompt.system() (project config)
+ *
+ * The anthropic.txt portion (lines 1-105) is verbatim from the OpenCode
+ * source. The rest is synthesized from reading the assembly functions.
+ */
+export const REALISTIC_SYSTEM_PROMPT = dedent`
+You are OpenCode, the best coding agent on the planet.
+
+You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
+
+IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
+
+If the user asks for help or wants to give feedback inform them of the following:
+- ctrl+p to list available actions
+- To give feedback, users should report the issue at
+  https://github.com/anomalyco/opencode
+
+When the user directly asks about OpenCode (eg. "can OpenCode do...", "does OpenCode have..."), or asks in second person (eg. "are you able...", "can you do..."), or asks how to use a specific OpenCode feature (eg. implement a hook, write a slash command, or install an MCP server), use the WebFetch tool to gather information to answer the question from OpenCode docs. The list of available docs is available at https://opencode.ai/docs
+
+# Tone and style
+- Only use emojis if the user explicitly requests it. Avoid using emojis in all communication unless asked.
+- Your output will be displayed on a command line interface. Your responses should be short and concise. You can use GitHub-flavored markdown for formatting, and will be rendered in a monospace font using the CommonMark specification.
+- Output text to communicate with the user; all text you output outside of tool use is displayed to the user. Only use tools to complete tasks. Never use tools like Bash or code comments as means to communicate with the user during the session.
+- NEVER create files unless they're absolutely necessary for achieving your goal. ALWAYS prefer editing an existing file to creating a new one. This includes markdown files.
+
+# Professional objectivity
+Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. It is best for the user if OpenCode honestly applies the same rigorous standards to all ideas and disagrees when necessary, even if it may not be what the user wants to hear. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, it's best to investigate to find the truth first rather than instinctively confirming the user's beliefs.
+
+# Task Management
+You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
+These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.
+
+It is critical that you mark todos as completed as soon as you are done with a task. Do not batch up multiple tasks before marking them as completed.
+
+Examples:
+
+<example>
+user: Run the build and fix any type errors
+assistant: I'm going to use the TodoWrite tool to write the following items to the todo list:
+- Run the build
+- Fix any type errors
+
+I'm now going to run the build using Bash.
+
+Looks like I found 10 type errors. I'm going to use the TodoWrite tool to write 10 items to the todo list.
+
+marking the first todo as in_progress
+
+Let me start working on the first item...
+
+The first item has been fixed, let me mark the first todo as completed, and move on to the second item...
+..
+..
+</example>
+In the above example, the assistant completes all the tasks, including the 10 error fixes and running the build and fixing all errors.
+
+<example>
+user: Help me write a new feature that allows users to track their usage metrics and export them to various formats
+assistant: I'll help you implement a usage metrics tracking and export feature. Let me first use the TodoWrite tool to plan this task.
+Adding the following todos to the todo list:
+1. Research existing metrics tracking in the codebase
+2. Design the metrics collection system
+3. Implement core metrics tracking functionality
+4. Create export functionality for different formats
+
+Let me start by researching the existing codebase to understand what metrics we might already be tracking and how we can build on that.
+
+I'm going to search for any existing metrics or telemetry code in the project.
+
+I've found some existing telemetry code. Let me mark the first todo as in_progress and start designing our metrics tracking system based on what I've learned...
+
+[Assistant continues implementing the feature step by step, marking todos as in_progress and completed as they go]
+</example>
+
+
+# Doing tasks
+The user will primarily request you perform software engineering tasks. This includes solving bugs, adding new functionality, refactoring code, explaining code, and more. For these tasks the following steps are recommended:
+-${' '}
+- Use the TodoWrite tool to plan the task if required
+
+- Tool results and user messages may include <system-reminder> tags. <system-reminder> tags contain useful information and reminders. They are automatically added by the system, and bear no direct relation to the specific tool results or user messages in which they appear.
+
+
+# Tool usage policy
+- When doing file search, prefer to use the Task tool in order to reduce context usage.
+- You should proactively use the Task tool with specialized agents when the task at hand matches the agent's description.
+
+- When WebFetch returns a message about a redirect to a different host, you should immediately make a new WebFetch request with the redirect URL provided in the response.
+- You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead. Never use placeholders or guess missing parameters in tool calls.
+- If the user specifies that they want you to run tools "in parallel", you MUST send a single message with multiple tool use content blocks. For example, if you need to launch multiple agents in parallel, send a single message with multiple Task tool calls.
+- Use specialized tools instead of bash commands when possible, as this provides a better user experience. For file operations, use dedicated tools: Read for reading files instead of cat/head/tail, Edit for editing instead of sed/awk, and Write for creating files instead of cat with heredoc or echo redirection. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution. NEVER use bash echo or other command-line tools to communicate thoughts, explanations, or instructions to the user. Output all communication directly in your response text instead.
+- VERY IMPORTANT: When exploring the codebase to gather context or to answer a question that is not a needle query for a specific file/class/function, it is CRITICAL that you use the Task tool instead of running search commands directly.
+<example>
+user: Where are errors from the client handled?
+assistant: [Uses the Task tool to find the files that handle client errors instead of using Glob or Grep directly]
+</example>
+<example>
+user: What is the codebase structure?
+assistant: [Uses the Task tool]
+</example>
+
+IMPORTANT: Always use the TodoWrite tool to plan and track tasks throughout the conversation.
+
+# Code References
+
+When referencing specific functions or pieces of code include the pattern \`file_path:line_number\` to allow the user to easily navigate to the source code location.
+
+<example>
+user: Where are errors from the client handled?
+assistant: Clients are marked as failed in the \`connectToServer\` function in src/services/process.ts:712.
+</example>
+You are powered by the model named claude-sonnet-4-20250514. The exact model ID is anthropic/claude-sonnet-4-20250514
+Here is some useful information about the environment you are running in:
+<env>
+  Working directory: /Users/user/project
+  Workspace root folder: /Users/user/project
+  Is directory a git repo: yes
+  Platform: darwin
+  Today's date: Mon Jan 01 2025
+</env>
+<directories>
+${'  '}
+</directories>
+Skills provide specialized instructions and workflows for specific tasks.
+Use the skill tool to load a skill when a task matches its description.
+<available_skills>
+  <skill>
+    <name>pr-descriptions</name>
+    <description>How to write good GitHub pull request titles and descriptions.</description>
+    <location>file:///Users/user/.agents/skills/pr-descriptions/SKILL.md</location>
+  </skill>
+  <skill>
+    <name>code-review</name>
+    <description>Guidelines for reviewing pull requests and providing feedback.</description>
+    <location>file:///Users/user/project/.opencode/skills/code-review/SKILL.md</location>
+  </skill>
+</available_skills>
+Instructions from: /Users/user/.config/opencode/AGENTS.md
+# Global Agent Instructions
+
+These instructions apply to all agents.
+
+Always prefer TypeScript over JavaScript.
+Be concise in your responses.
+Instructions from: /Users/user/project/.opencode/AGENTS.md
+# Project Agent Instructions
+
+This project uses Bun as the runtime and test runner.
+Run \`bun test\` to execute tests.
+Run \`bun run build\` to compile.
+`

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -11,10 +11,10 @@ function createMockClient() {
 }
 
 async function getPlugin(client?: ReturnType<typeof createMockClient>) {
-  return AnthropicAuthPlugin({
+  return (await AnthropicAuthPlugin({
     // @ts-expect-error: minimal mock for testing
     client: client ?? createMockClient(),
-  }) as Promise<any>
+  })) as Promise<any>
 }
 
 describe('AnthropicAuthPlugin', () => {
@@ -228,7 +228,7 @@ describe('auth.loader', () => {
 
   test('fetch wrapper retries transient token refresh failures', async () => {
     let tokenRefreshCalls = 0
-    const setTimeoutMock = mock((handler: Function) => {
+    const setTimeoutMock = mock((handler: () => unknown) => {
       handler()
       return 0
     })
@@ -377,7 +377,7 @@ describe('auth.loader', () => {
     let tokenRefreshCount = 0
 
     // @ts-expect-error — mock override for testing
-    globalThis.setTimeout = mock((handler: Function) => {
+    globalThis.setTimeout = mock((handler: () => unknown) => {
       handler()
       return 0
     })
@@ -452,7 +452,7 @@ describe('auth.loader', () => {
     const usedRefreshTokens = new Set<string>()
 
     // @ts-expect-error — mock override for testing
-    globalThis.setTimeout = mock((handler: Function) => {
+    globalThis.setTimeout = mock((handler: () => unknown) => {
       handler()
       return 0
     })
@@ -565,7 +565,7 @@ describe('auth.loader', () => {
 
   test('concurrent refresh should persist tokens exactly once', async () => {
     // @ts-expect-error — mock override for testing
-    globalThis.setTimeout = mock((handler: Function) => {
+    globalThis.setTimeout = mock((handler: () => unknown) => {
       handler()
       return 0
     })

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
+import dedent from 'dedent'
 import {
   CLAUDE_CODE_IDENTITY,
   OPENCODE_IDENTITY,
@@ -462,121 +463,119 @@ describe('createStrippedStream', () => {
 })
 
 describe('sanitizeSystemText', () => {
-  // A realistic OpenCode system prompt showing what gets stripped vs preserved.
+  // Anchor-based sanitization. Three mechanisms:
   //
-  //   STRIPPED: everything from the identity line down to the first tail marker
-  //   KEPT:    everything before the identity + everything from the tail marker on
+  //   1. The OPENCODE_IDENTITY line is always removed.
+  //   2. Any paragraph containing a PARAGRAPH_REMOVAL_ANCHORS entry
+  //      (e.g. "github.com/anomalyco/opencode", "opencode.ai/docs")
+  //      is removed entirely.
+  //   3. TEXT_REPLACEMENTS are applied inline for short branded strings
+  //      inside paragraphs we want to keep (e.g. "if OpenCode honestly"
+  //      → "if the assistant honestly").
   //
-  //   ┌─────────────────────────────────────────────────────────────┐
-  //   │ You are OpenCode, the best coding agent on the planet.     │ ← STRIPPED
-  //   │                                                            │
-  //   │ OpenCode-specific instructions, tool docs, etc.            │ ← STRIPPED
-  //   │ All of this is removed.                                    │ ← STRIPPED
-  //   │                                                            │
-  //   │ Instructions from: ~/.config/opencode/preamble.md          │ ← KEPT
-  //   │ Be concise. Prefer TypeScript.                             │ ← KEPT
-  //   │                                                            │
-  //   │ # Code References                                          │ ← KEPT
-  //   │ src/index.ts ...                                           │ ← KEPT
-  //   └─────────────────────────────────────────────────────────────┘
-
-  const REALISTIC_PROMPT = [
-    'You are OpenCode, the best coding agent on the planet.',
-    '',
-    'You have access to tools for reading files, running commands,',
-    'and editing code. Always explain before acting.',
-    '',
-    'Instructions from: ~/.config/opencode/preamble.md',
-    'Be concise. Prefer TypeScript.',
-    '',
-    '# Code References',
-    'src/index.ts (1-50)',
-  ].join('\n')
-
-  test('strips OpenCode section, keeps user instructions and code refs', () => {
-    const result = sanitizeSystemText(REALISTIC_PROMPT)
-
-    // Stripped
-    expect(result).not.toContain('OpenCode')
-    expect(result).not.toContain('explain before acting')
-
-    // Kept
-    expect(result).toContain(
-      'Instructions from: ~/.config/opencode/preamble.md',
-    )
-    expect(result).toContain('Be concise. Prefer TypeScript.')
-    expect(result).toContain('# Code References')
-    expect(result).toContain('src/index.ts (1-50)')
-  })
+  // Everything else — generic instructions, tone/style, task management,
+  // tool policy, environment info, skills, user instructions, file paths
+  // containing "opencode", etc. — is preserved.
 
   test('returns text unchanged when OpenCode identity not present', () => {
     const text = 'Just a normal system prompt'
     expect(sanitizeSystemText(text)).toBe(text)
   })
 
-  test('calls onError when no preserved tail marker is found', () => {
+  test('removes identity, keeps generic content', () => {
+    const result = sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
+
+      You have access to tools for reading files.
+
+      Instructions from: ~/.config/opencode/preamble.md
+      Be concise. Prefer TypeScript.
+
+      # Code References
+      src/index.ts (1-50)
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      "You have access to tools for reading files.
+
+      Instructions from: ~/.config/opencode/preamble.md
+      Be concise. Prefer TypeScript.
+
+      # Code References
+      src/index.ts (1-50)"
+    `)
+  })
+
+  test('removes paragraph containing feedback URL anchor', () => {
+    const result = sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
+
+      Report issues at https://github.com/anomalyco/opencode please.
+
+      Generic instructions that stay.
+    `)
+    expect(result).toMatchInlineSnapshot(`"Generic instructions that stay."`)
+  })
+
+  test('removes paragraph containing docs URL anchor', () => {
+    const result = sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
+
+      Check out the docs at https://opencode.ai/docs for more info.
+
+      Other content preserved.
+    `)
+    expect(result).toMatchInlineSnapshot(`"Other content preserved."`)
+  })
+
+  test('applies inline text replacement', () => {
+    const result = sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
+
+      It is best if OpenCode honestly applies rigorous standards.
+    `)
+    expect(result).toMatchInlineSnapshot(
+      `"It is best if the assistant honestly applies rigorous standards."`,
+    )
+  })
+
+  test('preserves "opencode" in file paths and unrelated content', () => {
+    const result = sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
+
+      Instructions from: /Users/user/project/.opencode/AGENTS.md
+      Run opencode to start the CLI.
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      "Instructions from: /Users/user/project/.opencode/AGENTS.md
+      Run opencode to start the CLI."
+    `)
+  })
+
+  test('preserves content before and after identity', () => {
+    const result = sanitizeSystemText(dedent`
+      Some prefix content
+
+      You are OpenCode, the best coding agent on the planet.
+
+      # Code References
+      file contents
+    `)
+    expect(result).toMatchInlineSnapshot(`
+      "Some prefix content
+
+      # Code References
+      file contents"
+    `)
+  })
+
+  test('does not call onError when identity is present and removed', () => {
     const onError = mock(() => {})
-    const text = [
-      'You are OpenCode, the best coding agent on the planet.',
-      'No markers at all in this prompt.',
-    ].join('\n')
-    const result = sanitizeSystemText(text, onError)
-    expect(result).toBe(text)
-    expect(onError).toHaveBeenCalledTimes(1)
-  })
+    sanitizeSystemText(dedent`
+      You are OpenCode, the best coding agent on the planet.
 
-  test('preserves content before OpenCode identity', () => {
-    const text = [
-      'Some prefix content',
-      'You are OpenCode, the best coding agent on the planet.',
-      'OpenCode stuff to strip',
-      '# Code References',
-      'file contents',
-    ].join('\n')
-    const result = sanitizeSystemText(text)
-    expect(result).toBe('Some prefix content\n# Code References\nfile contents')
-  })
-
-  test('prefers earliest tail marker (instructions before code refs)', () => {
-    // "Instructions from:" appears before "# Code References",
-    // so we cut there — keeping the user's custom instructions.
-    const text = [
-      'You are OpenCode, the best coding agent on the planet.',
-      'OpenCode internal stuff',
-      'Instructions from: preamble.md',
-      'user-authored content',
-      '# Code References',
-      'files',
-    ].join('\n')
-    const result = sanitizeSystemText(text)
-    expect(result).not.toContain('OpenCode')
-    expect(result).toContain('Instructions from: preamble.md')
-    expect(result).toContain('user-authored content')
-    expect(result).toContain('# Code References')
-  })
-
-  test('preserves instructions from command', () => {
-    const text = [
-      'You are OpenCode, the best coding agent on the planet.',
-      'Internal details',
-      'Instructions from command: my-script',
-      'Script output here',
-      '# Code References',
-    ].join('\n')
-    const result = sanitizeSystemText(text)
-    expect(result).toContain('Instructions from command: my-script')
-    expect(result).toContain('Script output here')
-  })
-
-  test('falls back to # Code References when no instruction markers', () => {
-    const text = [
-      'You are OpenCode, the best coding agent on the planet.',
-      'Stuff to strip',
-      '# Code References',
-      'src/main.ts',
-    ].join('\n')
-    const result = sanitizeSystemText(text)
-    expect(result).toBe('# Code References\nsrc/main.ts')
+      Normal content.
+    `)
+    expect(onError).not.toHaveBeenCalled()
   })
 })
 
@@ -651,24 +650,24 @@ describe('rewriteRequestBody', () => {
     expect(rewriteRequestBody(body)).toBe(body)
   })
 
-  test('passes onError through to sanitization', () => {
+  test('does not call onError when identity is present (rules always match)', () => {
     const onError = mock(() => {})
     const body = JSON.stringify({
       messages: [],
-      system: `${OPENCODE_IDENTITY}\nno code refs marker here`,
+      system: `${OPENCODE_IDENTITY}\nsome other content`,
     })
-    rewriteRequestBody(body, onError)
-    expect(onError).toHaveBeenCalledTimes(1)
+    rewriteRequestBody(body)
+    expect(onError).not.toHaveBeenCalled()
   })
 
   test('rewrites realistic OpenCode request end-to-end', () => {
     //  Input system prompt (array of blocks):
-    //    [0] "You are OpenCode..." + internal stuff + "# Code References\n..."
+    //    [0] "You are OpenCode..." + generic content + "# Code References\n..."
     //    [1] "Additional context block"
     //
     //  Expected output:
     //    [0] Claude Code identity (prepended)
-    //    [1] "# Code References\n..." (OpenCode section stripped)
+    //    [1] Identity removed, generic content preserved, # Code References kept
     //    [2] "Additional context block" (untouched)
 
     const systemPrompt = [
@@ -706,8 +705,9 @@ describe('rewriteRequestBody', () => {
 
     // System prompt rewritten
     expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[1].text).not.toContain(OPENCODE_IDENTITY)
+    expect(result.system[1].text).toContain('You have access to tools.')
     expect(result.system[1].text).toContain('# Code References')
-    expect(result.system[1].text).not.toContain('OpenCode')
     expect(result.system[2].text).toBe('Additional context block')
 
     // Tool names prefixed
@@ -724,5 +724,32 @@ describe('rewriteRequestBody', () => {
     const body = JSON.stringify({ model: 'claude-3' })
     const result = JSON.parse(rewriteRequestBody(body))
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Realistic prompt – snapshot tests
+// ---------------------------------------------------------------------------
+
+import { REALISTIC_SYSTEM_PROMPT } from './fixtures/realistic-system-prompt'
+
+describe('sanitizeSystemText – realistic prompt', () => {
+  test('sanitizeSystemText output snapshot', () => {
+    const result = sanitizeSystemText(REALISTIC_SYSTEM_PROMPT)
+    expect(result).toMatchSnapshot()
+  })
+
+  test('rewriteRequestBody output snapshot', () => {
+    const body = JSON.stringify({
+      system: REALISTIC_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: 'Hello' }],
+      tools: [
+        { name: 'bash', type: 'function' },
+        { name: 'read', type: 'function' },
+        { name: 'edit', type: 'function' },
+      ],
+    })
+    const result = rewriteRequestBody(body)
+    expect(result).toMatchSnapshot()
   })
 })

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,8 +1,9 @@
 import {
   CLAUDE_CODE_IDENTITY,
   OPENCODE_IDENTITY,
-  PRESERVED_TAIL_MARKERS,
+  PARAGRAPH_REMOVAL_ANCHORS,
   REQUIRED_BETAS,
+  TEXT_REPLACEMENTS,
   TOOL_PREFIX,
   USER_AGENT,
 } from './constants'
@@ -213,38 +214,52 @@ export function rewriteUrl(input: FetchInput): {
 }
 
 /**
- * Remove the OpenCode identity section from system prompt text.
- * Finds the OpenCode identity marker, then removes everything up to
- * the earliest preserved tail marker (user instructions, code references, etc.).
- * This preserves user-configured instructions from config.json.
+ * Sanitize OpenCode-branded strings from the system prompt text.
+ *
+ * 1. Removes the OPENCODE_IDENTITY line.
+ * 2. Removes any paragraph (text between blank lines) that contains
+ *    one of the PARAGRAPH_REMOVAL_ANCHORS — typically URLs that
+ *    identify OpenCode-specific content.
+ * 3. Applies TEXT_REPLACEMENTS for inline occurrences of "OpenCode"
+ *    inside paragraphs we want to keep.
+ *
+ * This approach is resilient to upstream rewording of the OpenCode
+ * prompt — as long as the anchor strings (URLs, etc.) still appear
+ * somewhere in the paragraph, the removal works.
  */
-export function sanitizeSystemText(
-  text: string,
-  onError?: (msg: string) => void,
-): string {
-  const startIdx = text.indexOf(OPENCODE_IDENTITY)
-  if (startIdx === -1) return text
+export function sanitizeSystemText(text: string): string {
+  if (!text.includes(OPENCODE_IDENTITY)) return text
 
-  // Find the earliest preserved tail marker after the OpenCode identity
-  let endIdx = -1
-  for (const marker of PRESERVED_TAIL_MARKERS) {
-    const idx = text.indexOf(marker, startIdx)
-    if (idx !== -1 && (endIdx === -1 || idx < endIdx)) {
-      endIdx = idx
+  // Split into paragraphs (separated by one or more blank lines)
+  const paragraphs = text.split(/\n\n+/)
+
+  const filtered = paragraphs.filter((paragraph) => {
+    // Remove the identity line (may be its own paragraph or part of one)
+    if (paragraph.includes(OPENCODE_IDENTITY)) {
+      // If the paragraph is JUST the identity, drop it entirely
+      if (paragraph.trim() === OPENCODE_IDENTITY) return false
+      // Otherwise it's mixed — we'll handle inline below
     }
+
+    // Remove paragraphs containing any removal anchor
+    for (const anchor of PARAGRAPH_REMOVAL_ANCHORS) {
+      if (paragraph.includes(anchor)) return false
+    }
+
+    return true
+  })
+
+  let result = filtered.join('\n\n')
+
+  // Remove the identity line if it was part of a larger paragraph
+  result = result.replace(OPENCODE_IDENTITY, '').replace(/\n{3,}/g, '\n\n')
+
+  // Apply inline text replacements
+  for (const rule of TEXT_REPLACEMENTS) {
+    result = result.replace(rule.match, rule.replacement)
   }
 
-  if (endIdx === -1) {
-    onError?.(
-      'sanitizeSystemText: could not find any preserved tail marker after OpenCode identity',
-    )
-    return text
-  }
-
-  // Preserve content from the marker onwards (skip leading newline if present)
-  const tail =
-    text[endIdx] === '\n' ? text.slice(endIdx + 1) : text.slice(endIdx)
-  return text.slice(0, startIdx) + tail
+  return result.trim()
 }
 
 type SystemBlock = { type: string; text: string; [k: string]: unknown }
@@ -257,10 +272,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Sanitize system prompt and prepend Claude Code identity.
  * Handles all Anthropic API system formats: undefined, string, or array of text blocks.
  */
-export function prependClaudeCodeIdentity(
-  system: unknown,
-  onError?: (msg: string) => void,
-): SystemBlock[] {
+export function prependClaudeCodeIdentity(system: unknown): SystemBlock[] {
   const identityBlock: SystemBlock = {
     type: 'text',
     text: CLAUDE_CODE_IDENTITY,
@@ -269,7 +281,7 @@ export function prependClaudeCodeIdentity(
   if (system == null) return [identityBlock]
 
   if (typeof system === 'string') {
-    const sanitized = sanitizeSystemText(system, onError)
+    const sanitized = sanitizeSystemText(system)
     if (sanitized === CLAUDE_CODE_IDENTITY) return [identityBlock]
     return [identityBlock, { type: 'text', text: sanitized }]
   }
@@ -277,17 +289,14 @@ export function prependClaudeCodeIdentity(
   if (isRecord(system)) {
     const type = typeof system.type === 'string' ? system.type : 'text'
     const text = typeof system.text === 'string' ? system.text : ''
-    return [
-      identityBlock,
-      { ...system, type, text: sanitizeSystemText(text, onError) },
-    ]
+    return [identityBlock, { ...system, type, text: sanitizeSystemText(text) }]
   }
 
   if (!Array.isArray(system)) return [identityBlock]
 
   const sanitized: SystemBlock[] = system.map((item: unknown) => {
     if (typeof item === 'string') {
-      return { type: 'text', text: sanitizeSystemText(item, onError) }
+      return { type: 'text', text: sanitizeSystemText(item) }
     }
 
     if (
@@ -298,7 +307,7 @@ export function prependClaudeCodeIdentity(
       return {
         ...item,
         type: 'text',
-        text: sanitizeSystemText(item.text, onError),
+        text: sanitizeSystemText(item.text),
       }
     }
 
@@ -316,15 +325,12 @@ export function prependClaudeCodeIdentity(
 /**
  * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
-export function rewriteRequestBody(
-  body: string,
-  onError?: (msg: string) => void,
-): string {
+export function rewriteRequestBody(body: string): string {
   try {
     const parsed = JSON.parse(body)
 
     // Sanitize system prompt and prepend Claude Code identity
-    parsed.system = prependClaudeCodeIdentity(parsed.system, onError)
+    parsed.system = prependClaudeCodeIdentity(parsed.system)
 
     // Prefix tool names
     if (parsed.tools && Array.isArray(parsed.tools)) {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,5 +8,6 @@
     "noEmit": false,
     "allowImportingTsExtensions": false
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/tests/**"]
 }


### PR DESCRIPTION
Fixes #56 

## Why

The previous `sanitizeSystemText` stripped everything between the OpenCode identity line and the first "tail marker" (`# Code References` or `Instructions from:`). This removed ~90 lines of useful behavioral guidance from the system prompt — tone/style, task management, tool usage policy — just to get rid of a few OpenCode-branded strings.

## Approach

Replaced region-based stripping with **anchor-based paragraph removal**:

- The OpenCode identity line is removed (Claude Code identity prepended separately).
- Paragraphs containing known URL anchors (`github.com/anomalyco/opencode`, `opencode.ai/docs`) are removed entirely.
- Short branded strings inside kept paragraphs are replaced inline (`"if OpenCode honestly"` → `"if the assistant honestly"`).

This is resilient to upstream rewording of the OpenCode prompt — as long as the anchor URL still appears in a paragraph, the removal works regardless of how the surrounding text changes. No more brittle verbatim substring matching on multi-line blocks.

## Also in this PR

- **Realistic system prompt fixture** (`src/tests/fixtures/realistic-system-prompt.ts`) — a full assembled prompt matching what OpenCode actually sends, built with `dedent` for readability.
- **Snapshot tests** — inline snapshots for unit tests, external snapshot file for the full realistic prompt before/after.
- **Build fix** — excluded `src/tests/` from `tsconfig.build.json` so test files no longer compile into `dist/`.
- **README update** — documented the sanitization approach in the "How It Works" section.