### PR TITLE
fix: relocate non-core system entries to user message to avoid OAuth 400 rejection

### DIFF
--- a/.changeset/fiery-flowers-boil.md
+++ b/.changeset/fiery-flowers-boil.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+To bypass Anthropic's scans of the system prompts, move all but the identity marker into a user message

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -140,17 +140,7 @@ exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snaps
 {
   "messages": [
     {
-      "content": "Hello",
-      "role": "user",
-    },
-  ],
-  "system": [
-    {
-      "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-      "type": "text",
-    },
-    {
-      "text": 
+      "content": 
 "You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
@@ -283,8 +273,16 @@ Instructions from: /Users/user/project/.opencode/AGENTS.md
 
 This project uses Bun as the runtime and test runner.
 Run \`bun test\` to execute tests.
-Run \`bun run build\` to compile."
+Run \`bun run build\` to compile.
+
+Hello"
 ,
+      "role": "user",
+    },
+  ],
+  "system": [
+    {
+      "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
       "type": "text",
     },
   ],

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -207,18 +207,15 @@ describe('auth.loader', () => {
     const parsedBody = JSON.parse(capturedBody!)
     // Tool name should be prefixed
     expect(parsedBody.tools[0].name).toBe('mcp_bash')
-    expect(parsedBody.system).toMatchInlineSnapshot(`
-      [
-        {
-          "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
-          "type": "text",
-        },
-        {
-          "text": "You are a helpful assistant.",
-          "type": "text",
-        },
-      ]
-    `)
+    // After relocation, system should only contain the identity block
+    expect(parsedBody.system).toHaveLength(1)
+    expect(parsedBody.system[0].text).toBe(
+      "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+    )
+    // Non-core system text relocated to first user message
+    expect(parsedBody.messages[0].content).toContain(
+      'You are a helpful assistant.',
+    )
   })
 
   test('fetch wrapper refreshes expired token', async () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -665,10 +665,9 @@ describe('rewriteRequestBody', () => {
     //    [0] "You are OpenCode..." + generic content + "# Code References\n..."
     //    [1] "Additional context block"
     //
-    //  Expected output:
-    //    [0] Claude Code identity (prepended)
-    //    [1] Identity removed, generic content preserved, # Code References kept
-    //    [2] "Additional context block" (untouched)
+    //  Expected output after relocation:
+    //    system = [identity block only]
+    //    Non-core system text relocated to first user message
 
     const systemPrompt = [
       'You are OpenCode, the best coding agent on the planet.',
@@ -703,27 +702,138 @@ describe('rewriteRequestBody', () => {
 
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // System prompt rewritten
-    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
-    expect(result.system[1].text).not.toContain(OPENCODE_IDENTITY)
-    expect(result.system[1].text).toContain('You have access to tools.')
-    expect(result.system[1].text).toContain('# Code References')
-    expect(result.system[2].text).toBe('Additional context block')
+    // System should only contain the identity block
+    expect(result.system).toHaveLength(1)
+    expect(result.system).toMatchInlineSnapshot(`
+      [
+        {
+          "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+          "type": "text",
+        },
+      ]
+    `)
 
-    // Tool names prefixed
-    expect(result.tools[0].name).toBe('mcp_bash')
-    expect(result.tools[1].name).toBe('mcp_read_file')
+    // Non-core system text relocated to first user message
+    const userContent = result.messages
+    expect(userContent).toMatchInlineSnapshot(`
+      [
+        {
+          "content": 
+      "You have access to tools.
 
-    // tool_use blocks in messages prefixed, text untouched
-    expect(result.messages[1].content[0].name).toBe('mcp_bash')
-    expect(result.messages[1].content[1].text).toBe('Let me check')
-    expect(result.messages[0].content).toBe('Help me fix this bug')
+      # Code References
+
+      Here are some files.
+
+      Additional context block
+
+      Help me fix this bug"
+      ,
+          "role": "user",
+        },
+        {
+          "content": [
+            {
+              "id": "tool_1",
+              "name": "mcp_bash",
+              "type": "tool_use",
+            },
+            {
+              "text": "Let me check",
+              "type": "text",
+            },
+          ],
+          "role": "assistant",
+        },
+      ]
+    `)
   })
 
   test('handles body with no messages array', () => {
     const body = JSON.stringify({ model: 'claude-3' })
     const result = JSON.parse(rewriteRequestBody(body))
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+  })
+
+  test('relocates non-core system entries to first user message (string content)', () => {
+    const body = JSON.stringify({
+      system: 'Custom instructions for the assistant.',
+      messages: [{ role: 'user', content: 'hello' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+
+    // System should only contain the identity block
+    expect(result.system).toHaveLength(1)
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
+
+    // Non-core text relocated to first user message (string content)
+    expect(result.messages[0].content).toContain(
+      'Custom instructions for the assistant.',
+    )
+    // Original user content preserved
+    expect(result.messages[0].content).toContain('hello')
+  })
+
+  test('relocates non-core system entries to first user message (array content)', () => {
+    const body = JSON.stringify({
+      system: [
+        { type: 'text', text: 'Block A instructions' },
+        { type: 'text', text: 'Block B instructions' },
+      ],
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+
+    // System should only contain the identity block
+    expect(result.system).toHaveLength(1)
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
+
+    // Relocated content prepended as first content block
+    expect(result.messages[0].content[0].type).toBe('text')
+    expect(result.messages[0].content[0].text).toContain('Block A instructions')
+    expect(result.messages[0].content[0].text).toContain('Block B instructions')
+    // Original user content preserved
+    expect(result.messages[0].content[1].text).toBe('hello')
+  })
+
+  test('keeps system intact when no user messages exist', () => {
+    const body = JSON.stringify({
+      system: 'Some instructions',
+      messages: [],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+
+    // With no user messages to relocate into, system stays as-is
+    expect(result.system).toHaveLength(2)
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[1].text).toBe('Some instructions')
+  })
+
+  test('relocates multiple non-core entries joined with double newline', () => {
+    const body = JSON.stringify({
+      system: [
+        { type: 'text', text: 'First block' },
+        { type: 'text', text: 'Second block' },
+        { type: 'text', text: 'Third block' },
+      ],
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+
+    expect(result.system).toHaveLength(1)
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
+
+    // All three blocks joined with \n\n and prepended to user message
+    const userContent = result.messages[0].content
+    expect(userContent).toContain('First block')
+    expect(userContent).toContain('Second block')
+    expect(userContent).toContain('Third block')
+    expect(userContent).toContain('First block\n\nSecond block\n\nThird block')
   })
 })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -332,6 +332,39 @@ export function rewriteRequestBody(body: string): string {
     // Sanitize system prompt and prepend Claude Code identity
     parsed.system = prependClaudeCodeIdentity(parsed.system)
 
+    // --- Relocate non-core system entries to user messages ---
+    // Anthropic's API validates system[] content for OAuth requests.
+    // Third-party system prompts trigger a 400 rejection when they
+    // appear in `system[]`. Keep only the identity block in `system[]`
+    // and prepend everything else to the first user message.
+    if (Array.isArray(parsed.system) && parsed.system.length > 1) {
+      const kept = [parsed.system[0]] // identity block
+      const movedTexts: string[] = []
+
+      for (let i = 1; i < parsed.system.length; i++) {
+        const entry = parsed.system[i]
+        const txt = typeof entry === 'string' ? entry : (entry?.text ?? '')
+        if (txt.length > 0) movedTexts.push(txt)
+      }
+
+      if (movedTexts.length > 0 && Array.isArray(parsed.messages)) {
+        const firstUser = parsed.messages.find(
+          (m: { role?: string }) => m.role === 'user',
+        )
+
+        if (firstUser) {
+          parsed.system = kept
+          const prefix = movedTexts.join('\n\n')
+
+          if (typeof firstUser.content === 'string') {
+            firstUser.content = `${prefix}\n\n${firstUser.content}`
+          } else if (Array.isArray(firstUser.content)) {
+            firstUser.content.unshift({ type: 'text', text: prefix })
+          }
+        }
+      }
+    }
+
     // Prefix tool names
     if (parsed.tools && Array.isArray(parsed.tools)) {
       parsed.tools = parsed.tools.map(


### PR DESCRIPTION
Fixes #50

Anthropic's API now validates the `system[]` array content for OAuth-authenticated requests. When non-identity system entries (like OpenCode's ~30K-char system prompt) appear in `system[]`, the API returns a misleading 400 "out of extra usage" error — even on valid Max subscription accounts with plenty of remaining credits.

This was independently diagnosed and fixed in the upstream [griffinmartin/opencode-claude-auth PR #148](https://github.com/griffinmartin/opencode-claude-auth/pull/148). The root cause is content-based validation: the API distinguishes genuine Claude Code system prompts from third-party prompts and rejects the latter regardless of billing headers, betas, or user-agent strings.

## Approach

After the existing `prependClaudeCodeIdentity` step produces `[identity_block, ...sanitized_blocks]`, a new relocation step keeps only the identity block in `system[]` and prepends everything else to the first user message. This is functionally equivalent but avoids triggering the validation.

The relocation handles both string and array message content formats, and falls back to leaving `system[]` intact when no user messages exist.

## Known trade-off

Relocating system prompt content to a user message means it loses the architectural privilege that `system[]` entries have — system prompts are always attended to regardless of context length, while user messages are subject to "lost in the middle" effects in long conversations. This matches the upstream fix and unblocks users immediately; the quality regression can be addressed separately if reported (see [upstream #154](https://github.com/griffinmartin/opencode-claude-auth/issues/154)).