### PR TITLE
Make dependabot respect the bun.lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Right now the dependabot updates aren't updating the `bun.lock`, which always forces CI to fail. Let's see if we can get it to work...