### PR TITLE
Add EXPERIMENTAL_KEEP_SYSTEM_PROMPT env var to skip system-to-user relocation

### DIFF
--- a/.changeset/brown-fans-clap.md
+++ b/.changeset/brown-fans-clap.md
@@ -1,0 +1,7 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Add in `EXPERIMENTAL_KEEP_SYSTEM_PROMPT` which allows users to
+keep the sanitized prompt as a system prompt, instead of changing
+it to a user propmt. 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ The plugin provides three authentication options:
 - **Create an API Key** - OAuth flow via `console.anthropic.com` that creates an API key on your behalf.
 - **Manually enter API Key** - Standard API key entry for users who already have one.
 
+## Configuration
+
+The plugin supports the following environment variables:
+
+| Variable                          | Description                                                                                                                                                                                 |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ANTHROPIC_BASE_URL`              | Override the API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL.                                                                                                             |
+| `ANTHROPIC_INSECURE`              | Set to `1` or `true` to skip TLS certificate verification. Only effective when `ANTHROPIC_BASE_URL` is also set.                                                                            |
+| `EXPERIMENTAL_KEEP_SYSTEM_PROMPT` | Set to `1` or `true` to keep the sanitized system prompt in the `system[]` field instead of relocating it to a user message. See [System Prompt Sanitization](#system-prompt-sanitization). |
+
 ## How It Works
 
 For Claude Pro/Max authentication, the plugin:
@@ -53,6 +63,9 @@ The Anthropic API for Max subscriptions has specific requirements for the system
 3. **Inline text replacements** — Short branded strings inside paragraphs we want to keep are replaced (e.g. "OpenCode" → "the assistant" in the professional objectivity section).
 
 Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The system prompt is then **split** and only the billing header and identity line are left in the system prompt. The remainder is moved into a user message to bypass system prompt checks.
+
+> [!NOTE]
+> Set `EXPERIMENTAL_KEEP_SYSTEM_PROMPT=1` to skip the relocation step. The sanitized system prompt will remain in `system[]` in its entirety. This may cause API rejections for OAuth-authenticated requests.
 
 ## Development
 

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../constants'
 import {
   createStrippedStream,
+  experimentalKeepSystemPrompt,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
@@ -407,6 +408,43 @@ describe('isInsecure', () => {
     process.env.ANTHROPIC_BASE_URL = 'https://proxy.local'
     process.env.ANTHROPIC_INSECURE = 'yes'
     expect(isInsecure()).toBe(false)
+  })
+})
+
+describe('experimentalKeepSystemPrompt', () => {
+  const originalKeep = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
+
+  afterEach(() => {
+    if (originalKeep === undefined) {
+      delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
+    } else {
+      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = originalKeep
+    }
+  })
+
+  test('returns false when env var is not set', () => {
+    delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
+    expect(experimentalKeepSystemPrompt()).toBe(false)
+  })
+
+  test('returns true when set to "1"', () => {
+    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
+    expect(experimentalKeepSystemPrompt()).toBe(true)
+  })
+
+  test('returns true when set to "true"', () => {
+    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = 'true'
+    expect(experimentalKeepSystemPrompt()).toBe(true)
+  })
+
+  test('returns false for other values like "yes"', () => {
+    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = 'yes'
+    expect(experimentalKeepSystemPrompt()).toBe(false)
+  })
+
+  test('trims whitespace', () => {
+    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '  true  '
+    expect(experimentalKeepSystemPrompt()).toBe(true)
   })
 })
 
@@ -847,6 +885,98 @@ describe('rewriteRequestBody', () => {
     expect(userContent).toContain('Second block')
     expect(userContent).toContain('Third block')
     expect(userContent).toContain('First block\n\nSecond block\n\nThird block')
+  })
+
+  describe('with EXPERIMENTAL_KEEP_SYSTEM_PROMPT=1', () => {
+    const originalKeep = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
+
+    afterEach(() => {
+      if (originalKeep === undefined) {
+        delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
+      } else {
+        process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = originalKeep
+      }
+    })
+
+    test('keeps non-core system blocks in system[] instead of relocating', () => {
+      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
+      const body = JSON.stringify({
+        system: [
+          { type: 'text', text: 'Block A instructions' },
+          { type: 'text', text: 'Block B instructions' },
+        ],
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'hello' }],
+          },
+        ],
+      })
+      const result = JSON.parse(rewriteRequestBody(body))
+
+      // System should retain all blocks (identity + sanitized blocks)
+      expect(result.system.length).toBeGreaterThan(1)
+      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+      expect(result.system[1].text).toBe('Block A instructions')
+      expect(result.system[2].text).toBe('Block B instructions')
+
+      // User message should NOT have system text prepended
+      expect(result.messages[0].content).toHaveLength(1)
+      expect(result.messages[0].content[0].text).toBe('hello')
+    })
+
+    test('still sanitizes system text', () => {
+      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
+      const body = JSON.stringify({
+        system: `${OPENCODE_IDENTITY}\n\nSome instructions.\n\nVisit github.com/anomalyco/opencode for help.`,
+        messages: [{ role: 'user', content: 'hello' }],
+      })
+      const result = JSON.parse(rewriteRequestBody(body))
+
+      // Identity block is Claude Code's
+      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+      // Sanitized: OpenCode identity removed, anchor paragraph removed
+      const allText = result.system
+        .map((b: { text: string }) => b.text)
+        .join(' ')
+      expect(allText).not.toContain(OPENCODE_IDENTITY)
+      expect(allText).not.toContain('github.com/anomalyco/opencode')
+      expect(allText).toContain('Some instructions.')
+    })
+
+    test('still adds billing header', () => {
+      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
+      const body = JSON.stringify({
+        system: 'Custom instructions.',
+        messages: [{ role: 'user', content: 'hello' }],
+      })
+      const result = JSON.parse(rewriteRequestBody(body))
+
+      expect(result.system[0].text).toContain('x-anthropic-billing-header')
+      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    })
+
+    test('still prefixes tool names', () => {
+      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
+      const body = JSON.stringify({
+        tools: [{ name: 'bash', type: 'function' }],
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'hello' }],
+          },
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', name: 'bash', id: '1' }],
+          },
+        ],
+        system: 'Instructions.',
+      })
+      const result = JSON.parse(rewriteRequestBody(body))
+
+      expect(result.tools[0].name).toBe('mcp_bash')
+      expect(result.messages[1].content[0].name).toBe('mcp_bash')
+    })
   })
 })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -145,6 +145,16 @@ export function isInsecure(): boolean {
 }
 
 /**
+ * Check if system prompt relocation should be skipped.
+ * When enabled, sanitized system blocks stay in system[] instead of
+ * being moved to the first user message.
+ */
+export function experimentalKeepSystemPrompt(): boolean {
+  const raw = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT?.trim()
+  return raw === '1' || raw === 'true'
+}
+
+/**
  * Parse ANTHROPIC_BASE_URL from the environment.
  * Returns a valid HTTP(S) URL or null if unset/invalid.
  */
@@ -350,7 +360,11 @@ export function rewriteRequestBody(body: string): string {
     // Third-party system prompts trigger a 400 rejection when they
     // appear in `system[]`. Keep only the identity block in `system[]`
     // and prepend everything else to the first user message.
-    if (Array.isArray(parsed.system) && parsed.system.length > 1) {
+    if (
+      !experimentalKeepSystemPrompt() &&
+      Array.isArray(parsed.system) &&
+      parsed.system.length > 1
+    ) {
       const kept = [parsed.system[0]] // identity block
       const movedTexts: string[] = []
 


### PR DESCRIPTION
The plugin currently relocates all non-identity system prompt blocks into the first user message to avoid Anthropic API rejections on OAuth requests. This is correct for most users, but some may want the sanitized prompt to remain in `system[]` — for example, to test whether Anthropic has relaxed their validation, or to use the plugin with non-OAuth auth methods where the restriction doesn't apply.

Setting `EXPERIMENTAL_KEEP_SYSTEM_PROMPT=1` (or `true`) skips the relocation step. All other transformations — sanitization, identity swap, billing header, tool prefixing — still run normally.

Also documents all three env vars (`ANTHROPIC_BASE_URL`, `ANTHROPIC_INSECURE`, `EXPERIMENTAL_KEEP_SYSTEM_PROMPT`) in a new Configuration section in the README, since none of them were previously documented there.