### PR TITLE
Fix: PascalCase tool names to match Claude Code convention

### DIFF
--- a/.changeset/modern-terms-peel.md
+++ b/.changeset/modern-terms-peel.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+PascalCase tool names after mcp_ prefix to match Claude Code convention

--- a/.changeset/modern-terms-peel.md
+++ b/.changeset/modern-terms-peel.md
@@ -1,5 +1,5 @@
 ---
-"@ex-machina/opencode-anthropic-auth": patch
+"@ex-machina/opencode-anthropic-auth": minor
 ---
 
 PascalCase tool names after mcp_ prefix to match Claude Code convention

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -292,15 +292,15 @@ You are a Claude agent, built on Anthropic's Claude Agent SDK."
   ],
   "tools": [
     {
-      "name": "mcp_bash",
+      "name": "mcp_Bash",
       "type": "function",
     },
     {
-      "name": "mcp_read",
+      "name": "mcp_Read",
       "type": "function",
     },
     {
-      "name": "mcp_edit",
+      "name": "mcp_Edit",
       "type": "function",
     },
   ],

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -206,7 +206,7 @@ describe('auth.loader', () => {
 
     const parsedBody = JSON.parse(capturedBody!)
     // Tool name should be prefixed
-    expect(parsedBody.tools[0].name).toBe('mcp_bash')
+    expect(parsedBody.tools[0].name).toBe('mcp_Bash')
     // After relocation, system should only contain the identity block
     expect(parsedBody.system).toHaveLength(1)
     expect(parsedBody.system[0].text).toBe(

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -147,8 +147,8 @@ describe('prefixToolNames', () => {
       ],
     })
     const result = JSON.parse(prefixToolNames(body))
-    expect(result.tools[0].name).toBe('mcp_read_file')
-    expect(result.tools[1].name).toBe('mcp_write_file')
+    expect(result.tools[0].name).toBe('mcp_Read_file')
+    expect(result.tools[1].name).toBe('mcp_Write_file')
   })
 
   test('prefixes tool_use block names in messages', () => {
@@ -164,7 +164,7 @@ describe('prefixToolNames', () => {
       ],
     })
     const result = JSON.parse(prefixToolNames(body))
-    expect(result.messages[0].content[0].name).toBe('mcp_bash')
+    expect(result.messages[0].content[0].name).toBe('mcp_Bash')
     expect(result.messages[0].content[1].type).toBe('text')
   })
 
@@ -670,7 +670,7 @@ describe('rewriteRequestBody', () => {
       system: 'You are a helpful assistant.',
     })
     const result = JSON.parse(rewriteRequestBody(body))
-    expect(result.tools[0].name).toBe('mcp_bash')
+    expect(result.tools[0].name).toBe('mcp_Bash')
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
   })
 
@@ -777,7 +777,7 @@ describe('rewriteRequestBody', () => {
           "content": [
             {
               "id": "tool_1",
-              "name": "mcp_bash",
+              "name": "mcp_Bash",
               "type": "tool_use",
             },
             {
@@ -974,8 +974,8 @@ describe('rewriteRequestBody', () => {
       })
       const result = JSON.parse(rewriteRequestBody(body))
 
-      expect(result.tools[0].name).toBe('mcp_bash')
-      expect(result.messages[1].content[0].name).toBe('mcp_bash')
+      expect(result.tools[0].name).toBe('mcp_Bash')
+      expect(result.messages[1].content[0].name).toBe('mcp_Bash')
     })
   })
 })

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -10,6 +10,22 @@ import {
   USER_AGENT,
 } from './constants'
 
+/**
+ * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
+ * Claude Code uses PascalCase tool names (e.g. mcp_Bash, mcp_Read);
+ * lowercase names (mcp_bash, mcp_read) are flagged as non-Claude-Code clients.
+ */
+function prefixName(name: string): string {
+  return `${TOOL_PREFIX}${name.charAt(0).toUpperCase()}${name.slice(1)}`
+}
+
+/**
+ * Reverse prefixName: strip TOOL_PREFIX and restore the original leading case.
+ */
+function unprefixName(name: string): string {
+  return `${name.charAt(0).toLowerCase()}${name.slice(1)}`
+}
+
 export type FetchInput = string | URL | Request
 
 /**
@@ -90,7 +106,7 @@ export function prefixToolNames(body: string): string {
       parsed.tools = parsed.tools.map(
         (tool: { name?: string; [k: string]: unknown }) => ({
           ...tool,
-          name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
+          name: tool.name ? prefixName(tool.name) : tool.name,
         }),
       )
     }
@@ -108,10 +124,7 @@ export function prefixToolNames(body: string): string {
           if (msg.content && Array.isArray(msg.content)) {
             msg.content = msg.content.map((block) => {
               if (block.type === 'tool_use' && block.name) {
-                return {
-                  ...block,
-                  name: `${TOOL_PREFIX}${block.name}`,
-                }
+                return { ...block, name: prefixName(block.name) }
               }
               return block
             })
@@ -131,7 +144,10 @@ export function prefixToolNames(body: string): string {
  * Strip TOOL_PREFIX from tool names in streaming response text.
  */
 export function stripToolPrefix(text: string): string {
-  return text.replace(/"name"\s*:\s*"mcp_([^"]+)"/g, '"name": "$1"')
+  return text.replace(
+    /"name"\s*:\s*"mcp_([^"]+)"/g,
+    (_match, name: string) => `"name": "${unprefixName(name)}"`,
+  )
 }
 
 /**
@@ -406,7 +422,7 @@ export function rewriteRequestBody(body: string): string {
       parsed.tools = parsed.tools.map(
         (tool: { name?: string; [k: string]: unknown }) => ({
           ...tool,
-          name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
+          name: tool.name ? prefixName(tool.name) : tool.name,
         }),
       )
     }
@@ -424,7 +440,7 @@ export function rewriteRequestBody(body: string): string {
           if (msg.content && Array.isArray(msg.content)) {
             msg.content = msg.content.map((block) => {
               if (block.type === 'tool_use' && block.name) {
-                return { ...block, name: `${TOOL_PREFIX}${block.name}` }
+                return { ...block, name: prefixName(block.name) }
               }
               return block
             })


### PR DESCRIPTION
## Problem

As of today (April 14), Anthropic added a new check that validates tool name casing. Claude Code sends PascalCase names (`mcp_Bash`, `mcp_Read`) while the current plugin produces lowercase (`mcp_bash`, `mcp_read`). Having 2+ lowercase `mcp_`-prefixed tools triggers the "extra usage" 400 rejection.

## Root Cause

The `mcp_` prefix was prepended verbatim without adjusting casing:

```
bash  → mcp_bash   ← blocked
bash  → mcp_Bash   ← passes
```

This was confirmed by A/B testing the exact same request body against the API — only changing tool name casing. Minimal reproduction: just 2 tools with `mcp_` + lowercase is enough to trigger the block.

## What was ruled out

Captured the actual blocked request via mitmproxy and isolated each variable:

| Variable | Result |
|---|---|
| System prompt content/location | Not the cause |
| `OpenCode`/`OhMyOpenCode` strings in body | Not the cause |
| Billing header presence/absence | Not the cause |
| Tool definitions with `mcp_` + lowercase names | **Triggers the block** |
| Same tools with PascalCase names | **Passes** |

## Changes

- Uppercase the first character after the `mcp_` prefix (`bash` → `mcp_Bash`)
- Restore original casing when stripping the prefix from responses (`mcp_Bash` → `bash`)
- Extract shared `prefixName`/`unprefixName` helpers to keep the logic in one place
- Update tests and snapshots

## Testing

- `bun test` — 126/126 pass
- Verified with `opencode run` against both `claude-sonnet-4-6` and `claude-opus-4-6`

Closes #80