### PR TITLE
Remove  tool prefixing and rewrite TodoWrite tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist/
 .opencode/
 .claude/
 
+mise.local.toml
+
 # mitmproxy capture files (binary, large)
 *.flow
 *.flow.log

--- a/.idea/biome.xml
+++ b/.idea/biome.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="BiomeSettings">
+    <option name="applySafeFixesOnSave" value="true" />
+    <option name="enableLspFormat" value="true" />
+    <option name="formatOnSave" value="true" />
+    <option name="sortImportOnSave" value="true" />
+  </component>
+</project>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,8 +19,6 @@ export const OAUTH_SCOPES = [
   'user:file_upload',
 ]
 
-export const TOOL_PREFIX = 'mcp_'
-
 export const REQUIRED_BETAS = [
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -292,15 +292,15 @@ You are a Claude agent, built on Anthropic's Claude Agent SDK."
   ],
   "tools": [
     {
-      "name": "mcp_bash",
+      "name": "bash",
       "type": "function",
     },
     {
-      "name": "mcp_read",
+      "name": "read",
       "type": "function",
     },
     {
-      "name": "mcp_edit",
+      "name": "edit",
       "type": "function",
     },
   ],

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -166,7 +166,7 @@ describe('auth.loader', () => {
     expect(result.fetch).toBeFunction()
   })
 
-  test('fetch wrapper sets OAuth headers and prefixes tools', async () => {
+  test('fetch wrapper sets OAuth headers and keeps non-blocked tool names', async () => {
     let capturedHeaders: Headers | undefined
     let capturedBody: string | undefined
 
@@ -205,8 +205,8 @@ describe('auth.loader', () => {
     expect(capturedHeaders!.get('anthropic-beta')).toContain('oauth-2025-04-20')
 
     const parsedBody = JSON.parse(capturedBody!)
-    // Tool name should be prefixed
-    expect(parsedBody.tools[0].name).toBe('mcp_bash')
+    // Non-blocked tool names should pass through unchanged
+    expect(parsedBody.tools[0].name).toBe('bash')
     // After relocation, system should only contain the identity block
     expect(parsedBody.system).toHaveLength(1)
     expect(parsedBody.system[0].text).toBe(
@@ -372,7 +372,7 @@ describe('auth.loader', () => {
       start(controller) {
         controller.enqueue(
           encoder.encode(
-            'data: {"content_block":{"type":"tool_use","name":"mcp_bash"}}\n\n',
+            'data: {"content_block":{"type":"tool_use","name":"TodoWrite"}}\n\n',
           ),
         )
         controller.close()
@@ -404,8 +404,8 @@ describe('auth.loader', () => {
     )
 
     const text = await response.text()
-    expect(text).toContain('"name": "bash"')
-    expect(text).not.toContain('mcp_bash')
+    expect(text).toContain('"name":"todowrite"')
+    expect(text).not.toContain('TodoWrite')
   })
 
   test('concurrent expired token refresh should deduplicate to a single token request', async () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -11,7 +11,6 @@ import {
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
-  prefixToolNames,
   prependClaudeCodeIdentity,
   rewriteRequestBody,
   rewriteUrl,
@@ -138,93 +137,26 @@ describe('setOAuthHeaders', () => {
   })
 })
 
-describe('prefixToolNames', () => {
-  test('prefixes tool definition names', () => {
-    const body = JSON.stringify({
-      tools: [
-        { name: 'read_file', type: 'function' },
-        { name: 'write_file', type: 'function' },
-      ],
-    })
-    const result = JSON.parse(prefixToolNames(body))
-    expect(result.tools[0].name).toBe('mcp_read_file')
-    expect(result.tools[1].name).toBe('mcp_write_file')
-  })
-
-  test('prefixes tool_use block names in messages', () => {
-    const body = JSON.stringify({
-      messages: [
-        {
-          role: 'assistant',
-          content: [
-            { type: 'tool_use', name: 'bash', id: '1' },
-            { type: 'text', text: 'hello' },
-          ],
-        },
-      ],
-    })
-    const result = JSON.parse(prefixToolNames(body))
-    expect(result.messages[0].content[0].name).toBe('mcp_bash')
-    expect(result.messages[0].content[1].type).toBe('text')
-  })
-
-  test('does not prefix non-tool_use blocks', () => {
-    const body = JSON.stringify({
-      messages: [
-        {
-          role: 'user',
-          content: [{ type: 'text', text: 'hello' }],
-        },
-      ],
-    })
-    const result = JSON.parse(prefixToolNames(body))
-    expect(result.messages[0].content[0]).toEqual({
-      type: 'text',
-      text: 'hello',
-    })
-  })
-
-  test('handles missing tools and messages gracefully', () => {
-    const body = JSON.stringify({ model: 'claude-3' })
-    const result = JSON.parse(prefixToolNames(body))
-    expect(result.model).toBe('claude-3')
-  })
-
-  test('returns original string on invalid JSON', () => {
-    const body = 'not valid json'
-    expect(prefixToolNames(body)).toBe(body)
-  })
-
-  test('handles tools without names', () => {
-    const body = JSON.stringify({
-      tools: [{ type: 'function' }],
-    })
-    const result = JSON.parse(prefixToolNames(body))
-    expect(result.tools[0].name).toBeUndefined()
-  })
-})
-
 describe('stripToolPrefix', () => {
-  test('strips mcp_ prefix from tool names', () => {
-    const text = '{"name": "mcp_read_file"}'
-    expect(stripToolPrefix(text)).toBe('{"name": "read_file"}')
+  test('normalizes TodoWrite to todowrite', () => {
+    const text = '{"name": "TodoWrite"}'
+    expect(stripToolPrefix(text)).toBe('{"name":"todowrite"}')
   })
 
-  test('strips multiple prefixed names', () => {
-    const text = '{"name": "mcp_tool_a"} and {"name": "mcp_tool_b"}'
+  test('normalizes multiple TodoWrite names', () => {
+    const text = '{"name": "TodoWrite"} and {"name": "TodoWrite"}'
     const result = stripToolPrefix(text)
-    expect(result).toContain('"name": "tool_a"')
-    expect(result).toContain('"name": "tool_b"')
+    expect(result).toContain('"name":"todowrite"')
   })
 
-  test('does not strip names without mcp_ prefix', () => {
+  test('does not rewrite non-blocked names', () => {
     const text = '{"name": "regular_tool"}'
     expect(stripToolPrefix(text)).toBe(text)
   })
 
   test('handles whitespace variations in JSON', () => {
-    const text = '{"name"  :  "mcp_tool"}'
-    expect(stripToolPrefix(text)).toBe('{"name": "tool"}')
+    const text = '{"name"  :  "TodoWrite"}'
+    expect(stripToolPrefix(text)).toBe('{"name":"todowrite"}')
   })
 })
 
@@ -449,10 +381,10 @@ describe('experimentalKeepSystemPrompt', () => {
 })
 
 describe('createStrippedStream', () => {
-  test('strips tool prefixes from streamed response body', async () => {
+  test('normalizes blocked tool names from streamed response body', async () => {
     const chunks = [
-      'data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"mcp_bash"}}\n\n',
-      'data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"mcp_read"}}\n\n',
+      'data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"TodoWrite"}}\n\n',
+      'data: {"type":"content_block_start","content_block":{"type":"tool_use","name":"bash"}}\n\n',
     ]
 
     const stream = new ReadableStream({
@@ -469,10 +401,9 @@ describe('createStrippedStream', () => {
     const stripped = createStrippedStream(original)
 
     const text = await stripped.text()
-    expect(text).toContain('"name": "bash"')
-    expect(text).toContain('"name": "read"')
-    expect(text).not.toContain('mcp_bash')
-    expect(text).not.toContain('mcp_read')
+    expect(text).toContain('"name":"todowrite"')
+    expect(text).toContain('"name":"bash"')
+    expect(text).not.toContain('TodoWrite')
   })
 
   test('preserves response status and headers', async () => {
@@ -663,15 +594,32 @@ describe('prependClaudeCodeIdentity', () => {
 })
 
 describe('rewriteRequestBody', () => {
-  test('prefixes tool names and rewrites system prompt', () => {
+  test('rewrites system prompt without renaming non-blocked tools', () => {
     const body = JSON.stringify({
       tools: [{ name: 'bash', type: 'function' }],
       messages: [{ role: 'user', content: 'hello world test message' }],
       system: 'You are a helpful assistant.',
     })
     const result = JSON.parse(rewriteRequestBody(body))
-    expect(result.tools[0].name).toBe('mcp_bash')
+    expect(result.tools[0].name).toBe('bash')
     expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+  })
+
+  test('renames blocked todowrite tool names in tools and tool_use blocks', () => {
+    const body = JSON.stringify({
+      tools: [{ name: 'todowrite', type: 'function' }],
+      messages: [
+        { role: 'user', content: 'hello' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', name: 'todowrite', id: 'tool_1' }],
+        },
+      ],
+    })
+
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.tools[0].name).toBe('TodoWrite')
+    expect(result.messages[1].content[0].name).toBe('TodoWrite')
   })
 
   test('handles missing system field', () => {
@@ -777,7 +725,7 @@ describe('rewriteRequestBody', () => {
           "content": [
             {
               "id": "tool_1",
-              "name": "mcp_bash",
+              "name": "bash",
               "type": "tool_use",
             },
             {
@@ -956,10 +904,13 @@ describe('rewriteRequestBody', () => {
       expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
     })
 
-    test('still prefixes tool names', () => {
+    test('still renames blocked tool names only', () => {
       process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
       const body = JSON.stringify({
-        tools: [{ name: 'bash', type: 'function' }],
+        tools: [
+          { name: 'todowrite', type: 'function' },
+          { name: 'bash', type: 'function' },
+        ],
         messages: [
           {
             role: 'user',
@@ -967,15 +918,20 @@ describe('rewriteRequestBody', () => {
           },
           {
             role: 'assistant',
-            content: [{ type: 'tool_use', name: 'bash', id: '1' }],
+            content: [
+              { type: 'tool_use', name: 'todowrite', id: '1' },
+              { type: 'tool_use', name: 'bash', id: '2' },
+            ],
           },
         ],
         system: 'Instructions.',
       })
       const result = JSON.parse(rewriteRequestBody(body))
 
-      expect(result.tools[0].name).toBe('mcp_bash')
-      expect(result.messages[1].content[0].name).toBe('mcp_bash')
+      expect(result.tools[0].name).toBe('TodoWrite')
+      expect(result.tools[1].name).toBe('bash')
+      expect(result.messages[1].content[0].name).toBe('TodoWrite')
+      expect(result.messages[1].content[1].name).toBe('bash')
     })
   })
 })

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -6,11 +6,14 @@ import {
   PARAGRAPH_REMOVAL_ANCHORS,
   REQUIRED_BETAS,
   TEXT_REPLACEMENTS,
-  TOOL_PREFIX,
   USER_AGENT,
 } from './constants'
 
 export type FetchInput = string | URL | Request
+
+const OUTBOUND_TOOL_NAME_RENAMES: Record<string, string> = {
+  todowrite: 'TodoWrite',
+}
 
 /**
  * Merge headers from a Request object and/or a RequestInit headers value
@@ -79,59 +82,15 @@ export function setOAuthHeaders(
 }
 
 /**
- * Add TOOL_PREFIX to tool names in the request body.
- * Prefixes both tool definitions and tool_use blocks in messages.
- */
-export function prefixToolNames(body: string): string {
-  try {
-    const parsed = JSON.parse(body)
-
-    if (parsed.tools && Array.isArray(parsed.tools)) {
-      parsed.tools = parsed.tools.map(
-        (tool: { name?: string; [k: string]: unknown }) => ({
-          ...tool,
-          name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
-        }),
-      )
-    }
-
-    if (parsed.messages && Array.isArray(parsed.messages)) {
-      parsed.messages = parsed.messages.map(
-        (msg: {
-          content?: Array<{
-            type: string
-            name?: string
-            [k: string]: unknown
-          }>
-          [k: string]: unknown
-        }) => {
-          if (msg.content && Array.isArray(msg.content)) {
-            msg.content = msg.content.map((block) => {
-              if (block.type === 'tool_use' && block.name) {
-                return {
-                  ...block,
-                  name: `${TOOL_PREFIX}${block.name}`,
-                }
-              }
-              return block
-            })
-          }
-          return msg
-        },
-      )
-    }
-
-    return JSON.stringify(parsed)
-  } catch {
-    return body
-  }
-}
-
-/**
- * Strip TOOL_PREFIX from tool names in streaming response text.
+ * Normalize renamed tool names in streaming response text.
  */
 export function stripToolPrefix(text: string): string {
-  return text.replace(/"name"\s*:\s*"mcp_([^"]+)"/g, '"name": "$1"')
+  let result = text
+  for (const [name, renamed] of Object.entries(OUTBOUND_TOOL_NAME_RENAMES)) {
+    const pattern = new RegExp(`"name"\\s*:\\s*"${renamed}"`, 'g')
+    result = result.replace(pattern, `"name":"${name}"`)
+  }
+  return result
 }
 
 /**
@@ -335,7 +294,7 @@ export function prependClaudeCodeIdentity(system: unknown): SystemBlock[] {
 }
 
 /**
- * Rewrite the full request body: sanitize system prompt and prefix tool names.
+ * Rewrite the full request body: sanitize system prompt and normalize tool names.
  */
 export function rewriteRequestBody(body: string): string {
   try {
@@ -401,12 +360,15 @@ export function rewriteRequestBody(body: string): string {
       identityBlock.text = `${billingHeader}\n\n${CLAUDE_CODE_IDENTITY}`
     }
 
-    // Prefix tool names
+    // Normalize blocked tool names for outbound requests.
     if (parsed.tools && Array.isArray(parsed.tools)) {
       parsed.tools = parsed.tools.map(
         (tool: { name?: string; [k: string]: unknown }) => ({
           ...tool,
-          name: tool.name ? `${TOOL_PREFIX}${tool.name}` : tool.name,
+          name:
+            typeof tool.name === 'string'
+              ? (OUTBOUND_TOOL_NAME_RENAMES[tool.name] ?? tool.name)
+              : tool.name,
         }),
       )
     }
@@ -424,7 +386,10 @@ export function rewriteRequestBody(body: string): string {
           if (msg.content && Array.isArray(msg.content)) {
             msg.content = msg.content.map((block) => {
               if (block.type === 'tool_use' && block.name) {
-                return { ...block, name: `${TOOL_PREFIX}${block.name}` }
+                return {
+                  ...block,
+                  name: OUTBOUND_TOOL_NAME_RENAMES[block.name] ?? block.name,
+                }
               }
               return block
             })


### PR DESCRIPTION
This pull request replaces the generic tool name prefixing system with a targeted tool name normalization approach. 

**Key Changes:**

- Removes the `TOOL_PREFIX` constant and `prefixToolNames` function that added "mcp_" prefixes to all tools
- Introduces `OUTBOUND_TOOL_NAME_RENAMES` mapping to handle specific tool name transformations (currently maps "todowrite" to "TodoWrite")
- Updates `stripToolPrefix` to normalize specific blocked tool names back to their original form in responses
- Modifies `rewriteRequestBody` to only rename tools that exist in the rename mapping, leaving other tools unchanged
- Adds `mise.local.toml` to `.gitignore`
- Configures Biome IDE settings for automatic formatting and import sorting

The new approach allows selective tool name handling rather than applying a blanket prefix to all MCP tools, providing more granular control over which tools need name transformation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request/response rewriting for tool names in the OAuth fetch wrapper, which could break tool invocation if name normalization is incomplete or mismatched. Scope is contained and covered by updated unit/snapshot tests.
> 
> **Overview**
> Replaces the blanket `mcp_` tool name prefixing with a targeted rename map: outbound requests rename `todowrite` to `TodoWrite`, and streamed responses normalize `TodoWrite` back to `todowrite`.
> 
> Removes the `TOOL_PREFIX` constant and `prefixToolNames` path, updates `rewriteRequestBody`/stream handling accordingly, and adjusts tests/snapshots to assert **non-blocked** tool names pass through unchanged while the blocked tool is rewritten.
> 
> Also adds `mise.local.toml` to `.gitignore` and introduces `.idea/biome.xml` for IDE formatting/import-on-save settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e4bd41f66d812b2e57d3c2b49a933b786f840d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->