### PR TITLE
Add mise.local.toml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist/
 .opencode/
 .claude/
 
+mise.local.toml
+
 # mitmproxy capture files (binary, large)
 *.flow
 *.flow.log


### PR DESCRIPTION
This pull request adds `mise.local.toml` to the `.gitignore` file to prevent local mise configuration files from being tracked in version control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to `.gitignore`, preventing accidental commits of local mise configuration without affecting runtime behavior.
> 
> **Overview**
> Adds `mise.local.toml` to `.gitignore` so local mise configuration files are not tracked or committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee155ce722a2a456d770b7d18e3cfacda028941. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->