### PR TITLE
Improve OpenCode identity removal accuracy

### DIFF
--- a/.changeset/huge-maps-doubt.md
+++ b/.changeset/huge-maps-doubt.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Remove OpenCode identity more accurately

--- a/.idea/biome.xml
+++ b/.idea/biome.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="BiomeSettings">
+    <option name="applySafeFixesOnSave" value="true" />
+    <option name="enableLspFormat" value="true" />
+    <option name="formatOnSave" value="true" />
+    <option name="sortImportOnSave" value="true" />
+  </component>
+</project>

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="project">
+    <words>
+      <w>unprefix</w>
+    </words>
+  </dictionary>
+</component>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,8 +26,7 @@ export const REQUIRED_BETAS = [
   'interleaved-thinking-2025-05-14',
 ]
 
-export const OPENCODE_IDENTITY =
-  'You are OpenCode, the best coding agent on the planet.'
+export const OPENCODE_IDENTITY_PREFIX = 'You are OpenCode'
 export const CLAUDE_CODE_IDENTITY =
   "You are a Claude agent, built on Anthropic's Claude Agent SDK."
 

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 import dedent from 'dedent'
 import {
   CLAUDE_CODE_IDENTITY,
-  OPENCODE_IDENTITY,
+  OPENCODE_IDENTITY_PREFIX,
   REQUIRED_BETAS,
 } from '../constants'
 import {
@@ -140,19 +140,19 @@ describe('setOAuthHeaders', () => {
 
 describe('prefixToolNames', () => {
   test('prefixes tool definition names', () => {
-    const body = JSON.stringify({
+    const body = {
       tools: [
         { name: 'read_file', type: 'function' },
         { name: 'write_file', type: 'function' },
       ],
-    })
+    }
     const result = JSON.parse(prefixToolNames(body))
     expect(result.tools[0].name).toBe('mcp_Read_file')
     expect(result.tools[1].name).toBe('mcp_Write_file')
   })
 
   test('prefixes tool_use block names in messages', () => {
-    const body = JSON.stringify({
+    const body = {
       messages: [
         {
           role: 'assistant',
@@ -162,21 +162,21 @@ describe('prefixToolNames', () => {
           ],
         },
       ],
-    })
+    }
     const result = JSON.parse(prefixToolNames(body))
     expect(result.messages[0].content[0].name).toBe('mcp_Bash')
     expect(result.messages[0].content[1].type).toBe('text')
   })
 
   test('does not prefix non-tool_use blocks', () => {
-    const body = JSON.stringify({
+    const body = {
       messages: [
         {
           role: 'user',
           content: [{ type: 'text', text: 'hello' }],
         },
       ],
-    })
+    }
     const result = JSON.parse(prefixToolNames(body))
     expect(result.messages[0].content[0]).toEqual({
       type: 'text',
@@ -185,20 +185,15 @@ describe('prefixToolNames', () => {
   })
 
   test('handles missing tools and messages gracefully', () => {
-    const body = JSON.stringify({ model: 'claude-3' })
+    const body = { model: 'claude-3' }
     const result = JSON.parse(prefixToolNames(body))
     expect(result.model).toBe('claude-3')
   })
 
-  test('returns original string on invalid JSON', () => {
-    const body = 'not valid json'
-    expect(prefixToolNames(body)).toBe(body)
-  })
-
   test('handles tools without names', () => {
-    const body = JSON.stringify({
+    const body = {
       tools: [{ type: 'function' }],
-    })
+    }
     const result = JSON.parse(prefixToolNames(body))
     expect(result.tools[0].name).toBeUndefined()
   })
@@ -634,13 +629,13 @@ describe('prependClaudeCodeIdentity', () => {
     const system = [
       {
         type: 'text',
-        text: `${OPENCODE_IDENTITY}\nstuff\n# Code References\nrest`,
+        text: `${OPENCODE_IDENTITY_PREFIX}\nstuff\n\n# Code References\nrest`,
       },
       { type: 'text', text: 'other block' },
     ]
     const result = prependClaudeCodeIdentity(system)
     expect(result[0]?.text).toBe(CLAUDE_CODE_IDENTITY)
-    expect(result[1]?.text).not.toContain(OPENCODE_IDENTITY)
+    expect(result[1]?.text).not.toContain(OPENCODE_IDENTITY_PREFIX)
     expect(result[1]?.text).toContain('# Code References')
   })
 
@@ -692,7 +687,7 @@ describe('rewriteRequestBody', () => {
     const onError = mock(() => {})
     const body = JSON.stringify({
       messages: [],
-      system: `${OPENCODE_IDENTITY}\nsome other content`,
+      system: `${OPENCODE_IDENTITY_PREFIX}\nsome other content`,
     })
     rewriteRequestBody(body)
     expect(onError).not.toHaveBeenCalled()
@@ -928,7 +923,7 @@ describe('rewriteRequestBody', () => {
     test('still sanitizes system text', () => {
       process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
       const body = JSON.stringify({
-        system: `${OPENCODE_IDENTITY}\n\nSome instructions.\n\nVisit github.com/anomalyco/opencode for help.`,
+        system: `${OPENCODE_IDENTITY_PREFIX}\n\nSome instructions.\n\nVisit github.com/anomalyco/opencode for help.`,
         messages: [{ role: 'user', content: 'hello' }],
       })
       const result = JSON.parse(rewriteRequestBody(body))
@@ -939,7 +934,7 @@ describe('rewriteRequestBody', () => {
       const allText = result.system
         .map((b: { text: string }) => b.text)
         .join(' ')
-      expect(allText).not.toContain(OPENCODE_IDENTITY)
+      expect(allText).not.toContain(OPENCODE_IDENTITY_PREFIX)
       expect(allText).not.toContain('github.com/anomalyco/opencode')
       expect(allText).toContain('Some instructions.')
     })

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,7 +2,7 @@ import { buildBillingHeaderValue } from './cch'
 import {
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
-  OPENCODE_IDENTITY,
+  OPENCODE_IDENTITY_PREFIX,
   PARAGRAPH_REMOVAL_ANCHORS,
   REQUIRED_BETAS,
   TEXT_REPLACEMENTS,
@@ -98,46 +98,40 @@ export function setOAuthHeaders(
  * Add TOOL_PREFIX to tool names in the request body.
  * Prefixes both tool definitions and tool_use blocks in messages.
  */
-export function prefixToolNames(body: string): string {
-  try {
-    const parsed = JSON.parse(body)
-
-    if (parsed.tools && Array.isArray(parsed.tools)) {
-      parsed.tools = parsed.tools.map(
-        (tool: { name?: string; [k: string]: unknown }) => ({
-          ...tool,
-          name: tool.name ? prefixName(tool.name) : tool.name,
-        }),
-      )
-    }
-
-    if (parsed.messages && Array.isArray(parsed.messages)) {
-      parsed.messages = parsed.messages.map(
-        (msg: {
-          content?: Array<{
-            type: string
-            name?: string
-            [k: string]: unknown
-          }>
-          [k: string]: unknown
-        }) => {
-          if (msg.content && Array.isArray(msg.content)) {
-            msg.content = msg.content.map((block) => {
-              if (block.type === 'tool_use' && block.name) {
-                return { ...block, name: prefixName(block.name) }
-              }
-              return block
-            })
-          }
-          return msg
-        },
-      )
-    }
-
-    return JSON.stringify(parsed)
-  } catch {
-    return body
+export function prefixToolNames(parsed: Record<string, unknown>): string {
+  if (parsed.tools && Array.isArray(parsed.tools)) {
+    parsed.tools = parsed.tools.map(
+      (tool: { name?: string; [k: string]: unknown }) => ({
+        ...tool,
+        name: tool.name ? prefixName(tool.name) : tool.name,
+      }),
+    )
   }
+
+  if (parsed.messages && Array.isArray(parsed.messages)) {
+    parsed.messages = parsed.messages.map(
+      (msg: {
+        content?: Array<{
+          type: string
+          name?: string
+          [k: string]: unknown
+        }>
+        [k: string]: unknown
+      }) => {
+        if (msg.content && Array.isArray(msg.content)) {
+          msg.content = msg.content.map((block) => {
+            if (block.type === 'tool_use' && block.name) {
+              return { ...block, name: prefixName(block.name) }
+            }
+            return block
+          })
+        }
+        return msg
+      },
+    )
+  }
+
+  return JSON.stringify(parsed)
 }
 
 /**
@@ -244,7 +238,7 @@ export function rewriteUrl(input: FetchInput): {
 /**
  * Sanitize OpenCode-branded strings from the system prompt text.
  *
- * 1. Removes the OPENCODE_IDENTITY line.
+ * 1. Removes the OPENCODE_IDENTITY paragraph.
  * 2. Removes any paragraph (text between blank lines) that contains
  *    one of the PARAGRAPH_REMOVAL_ANCHORS — typically URLs that
  *    identify OpenCode-specific content.
@@ -256,17 +250,13 @@ export function rewriteUrl(input: FetchInput): {
  * somewhere in the paragraph, the removal works.
  */
 export function sanitizeSystemText(text: string): string {
-  if (!text.includes(OPENCODE_IDENTITY)) return text
-
   // Split into paragraphs (separated by one or more blank lines)
   const paragraphs = text.split(/\n\n+/)
 
   const filtered = paragraphs.filter((paragraph) => {
-    // Remove the identity line (may be its own paragraph or part of one)
-    if (paragraph.includes(OPENCODE_IDENTITY)) {
-      // If the paragraph is JUST the identity, drop it entirely
-      if (paragraph.trim() === OPENCODE_IDENTITY) return false
-      // Otherwise it's mixed — we'll handle inline below
+    if (paragraph.includes(OPENCODE_IDENTITY_PREFIX)) {
+      // If the paragraph contains the identity, drop it entirely
+      return false
     }
 
     // Remove paragraphs containing any removal anchor
@@ -278,9 +268,6 @@ export function sanitizeSystemText(text: string): string {
   })
 
   let result = filtered.join('\n\n')
-
-  // Remove the identity line if it was part of a larger paragraph
-  result = result.replace(OPENCODE_IDENTITY, '').replace(/\n{3,}/g, '\n\n')
 
   // Apply inline text replacements
   for (const rule of TEXT_REPLACEMENTS) {
@@ -417,40 +404,7 @@ export function rewriteRequestBody(body: string): string {
       identityBlock.text = `${billingHeader}\n\n${CLAUDE_CODE_IDENTITY}`
     }
 
-    // Prefix tool names
-    if (parsed.tools && Array.isArray(parsed.tools)) {
-      parsed.tools = parsed.tools.map(
-        (tool: { name?: string; [k: string]: unknown }) => ({
-          ...tool,
-          name: tool.name ? prefixName(tool.name) : tool.name,
-        }),
-      )
-    }
-
-    if (parsed.messages && Array.isArray(parsed.messages)) {
-      parsed.messages = parsed.messages.map(
-        (msg: {
-          content?: Array<{
-            type: string
-            name?: string
-            [k: string]: unknown
-          }>
-          [k: string]: unknown
-        }) => {
-          if (msg.content && Array.isArray(msg.content)) {
-            msg.content = msg.content.map((block) => {
-              if (block.type === 'tool_use' && block.name) {
-                return { ...block, name: prefixName(block.name) }
-              }
-              return block
-            })
-          }
-          return msg
-        },
-      )
-    }
-
-    return JSON.stringify(parsed)
+    return prefixToolNames(parsed)
   } catch {
     return body
   }


### PR DESCRIPTION
This pull request improves the accuracy of OpenCode identity removal from system prompts. The key changes include:

- Changed `OPENCODE_IDENTITY` constant from a full sentence to `OPENCODE_IDENTITY_PREFIX` containing just "You are OpenCode" for more precise matching
- Updated `sanitizeSystemText()` to remove entire paragraphs containing the OpenCode identity prefix rather than attempting inline removal
- Refactored `prefixToolNames()` to accept a parsed object instead of a JSON string, eliminating redundant parsing logic in `rewriteRequestBody()`
- Added IDE configuration files for Biome formatting and a project dictionary
- Updated all related tests to use the new prefix-based approach

The changeset indicates this is a patch-level change focused on more accurate OpenCode identity removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-body rewriting and system-prompt sanitization logic, which could affect how prompts/tools are sent to Anthropic and potentially alter downstream behavior if the new matching is too broad or too narrow.
> 
> **Overview**
> Improves system-prompt debranding by replacing the exact `OPENCODE_IDENTITY` match with an `OPENCODE_IDENTITY_PREFIX` check and updating `sanitizeSystemText()` to drop *any paragraph* containing that prefix (instead of trying inline removal).
> 
> Refactors `prefixToolNames()` to operate on an already-parsed request object (removing its internal JSON parse/invalid-JSON fallback) and updates `rewriteRequestBody()` to reuse it; tests are adjusted accordingly. Adds a patch changeset and some IDE config files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc03d9e8d07dc17b1346356cf537735482e0166. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->