### PR TITLE
Remove system prompt relocation, use three-block layout instead

### DIFF
--- a/.changeset/chilly-dryers-invent.md
+++ b/.changeset/chilly-dryers-invent.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Remove system block to user message relocation, remove experimental FF, and align system blocks to match Anthropic

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ The plugin supports the following environment variables:
 |-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ANTHROPIC_BASE_URL`              | Override the API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL.                                                                                                             |
 | `ANTHROPIC_INSECURE`              | Set to `1` or `true` to skip TLS certificate verification. Only effective when `ANTHROPIC_BASE_URL` is also set.                                                                            |
-| `EXPERIMENTAL_KEEP_SYSTEM_PROMPT` | Set to `1` or `true` to keep the sanitized system prompt in the `system[]` field instead of relocating it to a user message. See [System Prompt Sanitization](#system-prompt-sanitization). |
 
 ## How It Works
 
@@ -62,10 +61,7 @@ The Anthropic API for Max subscriptions has specific requirements for the system
 2. **Paragraph removal by anchor** — Any paragraph containing a known URL anchor (e.g. `github.com/anomalyco/opencode`, `opencode.ai/docs`) is removed entirely. This is resilient to upstream rewording — as long as the anchor URL appears somewhere in the paragraph, the removal works regardless of surrounding text changes.
 3. **Inline text replacements** — Short branded strings inside paragraphs we want to keep are replaced (e.g. "OpenCode" → "the assistant" in the professional objectivity section).
 
-Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The system prompt is then **split** and only the billing header and identity line are left in the system prompt. The remainder is moved into a user message to bypass system prompt checks.
-
-> [!NOTE]
-> Set `EXPERIMENTAL_KEEP_SYSTEM_PROMPT=1` to skip the relocation step. The sanitized system prompt will remain in `system[]` in its entirety. This may cause API rejections for OAuth-authenticated requests.
+Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The sanitized system prompt is structured as three blocks in `system[]`: the billing header, the Claude Code identity line, and the remaining system content.
 
 ## Development
 

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -140,7 +140,21 @@ exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snaps
 {
   "messages": [
     {
-      "content": 
+      "content": "Hello",
+      "role": "user",
+    },
+  ],
+  "system": [
+    {
+      "text": "x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=185f8;",
+      "type": "text",
+    },
+    {
+      "text": "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+      "type": "text",
+    },
+    {
+      "text": 
 "You are an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
@@ -273,19 +287,7 @@ Instructions from: /Users/user/project/.opencode/AGENTS.md
 
 This project uses Bun as the runtime and test runner.
 Run \`bun test\` to execute tests.
-Run \`bun run build\` to compile.
-
-Hello"
-,
-      "role": "user",
-    },
-  ],
-  "system": [
-    {
-      "text": 
-"x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=185f8;
-
-You are a Claude agent, built on Anthropic's Claude Agent SDK."
+Run \`bun run build\` to compile."
 ,
       "type": "text",
     },

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -207,15 +207,15 @@ describe('auth.loader', () => {
     const parsedBody = JSON.parse(capturedBody!)
     // Tool name should be prefixed
     expect(parsedBody.tools[0].name).toBe('mcp_Bash')
-    // After relocation, system should only contain the identity block
-    expect(parsedBody.system).toHaveLength(1)
-    expect(parsedBody.system[0].text).toBe(
-      "x-anthropic-billing-header: cc_version=2.1.87.6ff; cc_entrypoint=sdk-cli; cch=4ffc3;\n\nYou are a Claude agent, built on Anthropic's Claude Agent SDK.",
+    // Three-block layout: billing header, identity, rest
+    expect(parsedBody.system).toHaveLength(3)
+    expect(parsedBody.system[0].text).toContain('x-anthropic-billing-header')
+    expect(parsedBody.system[1].text).toBe(
+      "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
     )
-    // Non-core system text relocated to first user message
-    expect(parsedBody.messages[0].content).toContain(
-      'You are a helpful assistant.',
-    )
+    expect(parsedBody.system[2].text).toBe('You are a helpful assistant.')
+    // User message is untouched
+    expect(parsedBody.messages[0].content).toBe('hello world test message')
   })
 
   test('fetch wrapper refreshes expired token', async () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -7,7 +7,6 @@ import {
 } from '../constants'
 import {
   createStrippedStream,
-  experimentalKeepSystemPrompt,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
@@ -406,43 +405,6 @@ describe('isInsecure', () => {
   })
 })
 
-describe('experimentalKeepSystemPrompt', () => {
-  const originalKeep = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
-
-  afterEach(() => {
-    if (originalKeep === undefined) {
-      delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
-    } else {
-      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = originalKeep
-    }
-  })
-
-  test('returns false when env var is not set', () => {
-    delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
-    expect(experimentalKeepSystemPrompt()).toBe(false)
-  })
-
-  test('returns true when set to "1"', () => {
-    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
-    expect(experimentalKeepSystemPrompt()).toBe(true)
-  })
-
-  test('returns true when set to "true"', () => {
-    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = 'true'
-    expect(experimentalKeepSystemPrompt()).toBe(true)
-  })
-
-  test('returns false for other values like "yes"', () => {
-    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = 'yes'
-    expect(experimentalKeepSystemPrompt()).toBe(false)
-  })
-
-  test('trims whitespace', () => {
-    process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '  true  '
-    expect(experimentalKeepSystemPrompt()).toBe(true)
-  })
-})
-
 describe('createStrippedStream', () => {
   test('strips tool prefixes from streamed response body', async () => {
     const chunks = [
@@ -666,7 +628,10 @@ describe('rewriteRequestBody', () => {
     })
     const result = JSON.parse(rewriteRequestBody(body))
     expect(result.tools[0].name).toBe('mcp_Bash')
-    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    // system[0] = billing header, system[1] = identity, system[2] = rest
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[2].text).toBe('You are a helpful assistant.')
   })
 
   test('handles missing system field', () => {
@@ -674,8 +639,10 @@ describe('rewriteRequestBody', () => {
       messages: [{ role: 'user', content: 'hi' }],
     })
     const result = JSON.parse(rewriteRequestBody(body))
-    expect(result.system).toHaveLength(1)
-    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    // system[0] = billing header, system[1] = identity (no rest block)
+    expect(result.system).toHaveLength(2)
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
   })
 
   test('returns original string on invalid JSON', () => {
@@ -698,9 +665,11 @@ describe('rewriteRequestBody', () => {
     //    [0] "You are OpenCode..." + generic content + "# Code References\n..."
     //    [1] "Additional context block"
     //
-    //  Expected output after relocation:
-    //    system = [identity block only]
-    //    Non-core system text relocated to first user message
+    //  Expected output (three-block layout):
+    //    system[0] = billing header
+    //    system[1] = identity
+    //    system[2..n] = sanitized system blocks
+    //    User messages are untouched.
 
     const systemPrompt = [
       'You are OpenCode, the best coding agent on the planet.',
@@ -735,86 +704,46 @@ describe('rewriteRequestBody', () => {
 
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // System should only contain the identity block
-    expect(result.system).toHaveLength(1)
-    expect(result.system).toMatchInlineSnapshot(`
-      [
-        {
-          "text": 
-      "x-anthropic-billing-header: cc_version=2.1.87.1c6; cc_entrypoint=sdk-cli; cch=ffa5e;
+    // Three-block layout: billing header, identity, sanitized blocks
+    expect(result.system).toHaveLength(4)
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[2].text).toContain('You have access to tools.')
+    expect(result.system[2].text).toContain('# Code References')
+    expect(result.system[2].text).not.toContain(OPENCODE_IDENTITY_PREFIX)
+    expect(result.system[3].text).toBe('Additional context block')
 
-      You are a Claude agent, built on Anthropic's Claude Agent SDK."
-      ,
-          "type": "text",
-        },
-      ]
-      `)
-
-    // Non-core system text relocated to first user message
-    const userContent = result.messages
-    expect(userContent).toMatchInlineSnapshot(`
-      [
-        {
-          "content": 
-      "You have access to tools.
-
-      # Code References
-
-      Here are some files.
-
-      Additional context block
-
-      Help me fix this bug"
-      ,
-          "role": "user",
-        },
-        {
-          "content": [
-            {
-              "id": "tool_1",
-              "name": "mcp_Bash",
-              "type": "tool_use",
-            },
-            {
-              "text": "Let me check",
-              "type": "text",
-            },
-          ],
-          "role": "assistant",
-        },
-      ]
-    `)
+    // User messages are untouched
+    expect(result.messages[0].content).toBe('Help me fix this bug')
+    expect(result.messages[1].content[0].name).toBe('mcp_Bash')
   })
 
   test('handles body with no messages array', () => {
     const body = JSON.stringify({ model: 'claude-3' })
     const result = JSON.parse(rewriteRequestBody(body))
-    expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
+    // No messages → no billing header; system[0] = identity only
+    expect(result.system).toHaveLength(1)
+    expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
   })
 
-  test('relocates non-core system entries to first user message (string content)', () => {
+  test('keeps system blocks in system[] (string content)', () => {
     const body = JSON.stringify({
       system: 'Custom instructions for the assistant.',
       messages: [{ role: 'user', content: 'hello' }],
     })
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // System should only contain the identity block
-    expect(result.system).toHaveLength(1)
-    expect(result.system[0].text).toBe(
-      'x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=2cf24;\n\n' +
-        CLAUDE_CODE_IDENTITY,
-    )
+    // system[0] = billing, system[1] = identity, system[2] = rest
+    expect(result.system).toHaveLength(3)
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[2].text).toBe('Custom instructions for the assistant.')
 
-    // Non-core text relocated to first user message (string content)
-    expect(result.messages[0].content).toContain(
-      'Custom instructions for the assistant.',
-    )
-    // Original user content preserved
-    expect(result.messages[0].content).toContain('hello')
+    // User message is untouched
+    expect(result.messages[0].content).toBe('hello')
   })
 
-  test('relocates non-core system entries to first user message (array content)', () => {
+  test('keeps system blocks in system[] (array content)', () => {
     const body = JSON.stringify({
       system: [
         { type: 'text', text: 'Block A instructions' },
@@ -829,19 +758,16 @@ describe('rewriteRequestBody', () => {
     })
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // System should only contain the identity block
-    expect(result.system).toHaveLength(1)
-    expect(result.system[0].text).toBe(
-      'x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=2cf24;\n\n' +
-        CLAUDE_CODE_IDENTITY,
-    )
+    // system[0] = billing, system[1] = identity, system[2..3] = rest
+    expect(result.system).toHaveLength(4)
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[2].text).toBe('Block A instructions')
+    expect(result.system[3].text).toBe('Block B instructions')
 
-    // Relocated content prepended as first content block
-    expect(result.messages[0].content[0].type).toBe('text')
-    expect(result.messages[0].content[0].text).toContain('Block A instructions')
-    expect(result.messages[0].content[0].text).toContain('Block B instructions')
-    // Original user content preserved
-    expect(result.messages[0].content[1].text).toBe('hello')
+    // User message is untouched
+    expect(result.messages[0].content).toHaveLength(1)
+    expect(result.messages[0].content[0].text).toBe('hello')
   })
 
   test('keeps system intact when no user messages exist', () => {
@@ -851,13 +777,13 @@ describe('rewriteRequestBody', () => {
     })
     const result = JSON.parse(rewriteRequestBody(body))
 
-    // With no user messages to relocate into, system stays as-is
+    // No user messages → no billing header; system[0] = identity, system[1] = rest
     expect(result.system).toHaveLength(2)
     expect(result.system[0].text).toBe(CLAUDE_CODE_IDENTITY)
     expect(result.system[1].text).toBe('Some instructions')
   })
 
-  test('relocates multiple non-core entries joined with double newline', () => {
+  test('keeps multiple system blocks as separate entries', () => {
     const body = JSON.stringify({
       system: [
         { type: 'text', text: 'First block' },
@@ -868,110 +794,16 @@ describe('rewriteRequestBody', () => {
     })
     const result = JSON.parse(rewriteRequestBody(body))
 
-    expect(result.system).toHaveLength(1)
-    expect(result.system[0].text).toBe(
-      'x-anthropic-billing-header: cc_version=2.1.87.201; cc_entrypoint=sdk-cli; cch=8f434;\n\n' +
-        CLAUDE_CODE_IDENTITY,
-    )
+    // system[0] = billing, system[1] = identity, system[2..4] = original blocks
+    expect(result.system).toHaveLength(5)
+    expect(result.system[0].text).toContain('x-anthropic-billing-header')
+    expect(result.system[1].text).toBe(CLAUDE_CODE_IDENTITY)
+    expect(result.system[2].text).toBe('First block')
+    expect(result.system[3].text).toBe('Second block')
+    expect(result.system[4].text).toBe('Third block')
 
-    // All three blocks joined with \n\n and prepended to user message
-    const userContent = result.messages[0].content
-    expect(userContent).toContain('First block')
-    expect(userContent).toContain('Second block')
-    expect(userContent).toContain('Third block')
-    expect(userContent).toContain('First block\n\nSecond block\n\nThird block')
-  })
-
-  describe('with EXPERIMENTAL_KEEP_SYSTEM_PROMPT=1', () => {
-    const originalKeep = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
-
-    afterEach(() => {
-      if (originalKeep === undefined) {
-        delete process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT
-      } else {
-        process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = originalKeep
-      }
-    })
-
-    test('keeps non-core system blocks in system[] instead of relocating', () => {
-      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
-      const body = JSON.stringify({
-        system: [
-          { type: 'text', text: 'Block A instructions' },
-          { type: 'text', text: 'Block B instructions' },
-        ],
-        messages: [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: 'hello' }],
-          },
-        ],
-      })
-      const result = JSON.parse(rewriteRequestBody(body))
-
-      // System should retain all blocks (identity + sanitized blocks)
-      expect(result.system.length).toBeGreaterThan(1)
-      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
-      expect(result.system[1].text).toBe('Block A instructions')
-      expect(result.system[2].text).toBe('Block B instructions')
-
-      // User message should NOT have system text prepended
-      expect(result.messages[0].content).toHaveLength(1)
-      expect(result.messages[0].content[0].text).toBe('hello')
-    })
-
-    test('still sanitizes system text', () => {
-      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
-      const body = JSON.stringify({
-        system: `${OPENCODE_IDENTITY_PREFIX}\n\nSome instructions.\n\nVisit github.com/anomalyco/opencode for help.`,
-        messages: [{ role: 'user', content: 'hello' }],
-      })
-      const result = JSON.parse(rewriteRequestBody(body))
-
-      // Identity block is Claude Code's
-      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
-      // Sanitized: OpenCode identity removed, anchor paragraph removed
-      const allText = result.system
-        .map((b: { text: string }) => b.text)
-        .join(' ')
-      expect(allText).not.toContain(OPENCODE_IDENTITY_PREFIX)
-      expect(allText).not.toContain('github.com/anomalyco/opencode')
-      expect(allText).toContain('Some instructions.')
-    })
-
-    test('still adds billing header', () => {
-      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
-      const body = JSON.stringify({
-        system: 'Custom instructions.',
-        messages: [{ role: 'user', content: 'hello' }],
-      })
-      const result = JSON.parse(rewriteRequestBody(body))
-
-      expect(result.system[0].text).toContain('x-anthropic-billing-header')
-      expect(result.system[0].text).toContain(CLAUDE_CODE_IDENTITY)
-    })
-
-    test('still prefixes tool names', () => {
-      process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT = '1'
-      const body = JSON.stringify({
-        tools: [{ name: 'bash', type: 'function' }],
-        messages: [
-          {
-            role: 'user',
-            content: [{ type: 'text', text: 'hello' }],
-          },
-          {
-            role: 'assistant',
-            content: [{ type: 'tool_use', name: 'bash', id: '1' }],
-          },
-        ],
-        system: 'Instructions.',
-      })
-      const result = JSON.parse(rewriteRequestBody(body))
-
-      expect(result.tools[0].name).toBe('mcp_Bash')
-      expect(result.messages[1].content[0].name).toBe('mcp_Bash')
-    })
+    // User message is untouched
+    expect(result.messages[0].content).toBe('hi')
   })
 })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -155,16 +155,6 @@ export function isInsecure(): boolean {
 }
 
 /**
- * Check if system prompt relocation should be skipped.
- * When enabled, sanitized system blocks stay in system[] instead of
- * being moved to the first user message.
- */
-export function experimentalKeepSystemPrompt(): boolean {
-  const raw = process.env.EXPERIMENTAL_KEEP_SYSTEM_PROMPT?.trim()
-  return raw === '1' || raw === 'true'
-}
-
-/**
  * Parse ANTHROPIC_BASE_URL from the environment.
  * Returns a valid HTTP(S) URL or null if unset/invalid.
  */
@@ -358,50 +348,10 @@ export function rewriteRequestBody(body: string): string {
     // Sanitize system prompt and prepend Claude Code identity
     parsed.system = prependClaudeCodeIdentity(parsed.system)
 
-    // --- Relocate non-core system entries to user messages ---
-    // Anthropic's API validates system[] content for OAuth requests.
-    // Third-party system prompts trigger a 400 rejection when they
-    // appear in `system[]`. Keep only the identity block in `system[]`
-    // and prepend everything else to the first user message.
-    if (
-      !experimentalKeepSystemPrompt() &&
-      Array.isArray(parsed.system) &&
-      parsed.system.length > 1
-    ) {
-      const kept = [parsed.system[0]] // identity block
-      const movedTexts: string[] = []
-
-      for (let i = 1; i < parsed.system.length; i++) {
-        const entry = parsed.system[i]
-        const txt = typeof entry === 'string' ? entry : (entry?.text ?? '')
-        if (txt.length > 0) movedTexts.push(txt)
-      }
-
-      if (movedTexts.length > 0 && Array.isArray(parsed.messages)) {
-        const firstUser = parsed.messages.find(
-          (m: { role?: string }) => m.role === 'user',
-        )
-
-        if (firstUser) {
-          parsed.system = kept
-          const prefix = movedTexts.join('\n\n')
-
-          if (typeof firstUser.content === 'string') {
-            firstUser.content = `${prefix}\n\n${firstUser.content}`
-          } else if (Array.isArray(firstUser.content)) {
-            firstUser.content.unshift({ type: 'text', text: prefix })
-          }
-        }
-      }
-    }
-
-    const identityBlock = parsed.system[0]
-    if (
-      billingHeader &&
-      identityBlock?.type === 'text' &&
-      identityBlock.text === CLAUDE_CODE_IDENTITY
-    ) {
-      identityBlock.text = `${billingHeader}\n\n${CLAUDE_CODE_IDENTITY}`
+    // Prepend the billing header as a separate system block so the
+    // final layout is: [billing header, identity, ...rest]
+    if (billingHeader && Array.isArray(parsed.system)) {
+      parsed.system.unshift({ type: 'text', text: billingHeader })
     }
 
     return prefixToolNames(parsed)


### PR DESCRIPTION
Fixes #86

This pull request changes the system prompt handling from a split approach to a three-block layout. Previously, the sanitized system prompt was split with only the billing header and identity line remaining in `system[]` while the rest was moved to a user message. Now, the sanitized system prompt is structured as three blocks in `system[]`: the billing header, the Claude Code identity line, and the remaining system content.

The change removes the `EXPERIMENTAL_KEEP_SYSTEM_PROMPT` environment variable and its associated functionality, along with all related tests. The billing header is now prepended as a separate system block rather than being concatenated with the identity block. Test snapshots and assertions have been updated to reflect the new three-block structure where `system[0]` contains the billing header, `system[1]` contains the identity, and subsequent blocks contain the sanitized system content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth request bodies are rewritten, which can affect Anthropic API validation and potentially break message requests if the new `system[]` layout is not accepted. Scope is limited to prompt/billing-header shaping and test/docs updates.
> 
> **Overview**
> Switches system-prompt handling from *relocating* non-core system text into the first user message to a **three-block `system[]` layout**: separate billing header block, Claude Code identity block, then the remaining sanitized system content.
> 
> Removes the `EXPERIMENTAL_KEEP_SYSTEM_PROMPT` flag and all relocation logic, updates `rewriteRequestBody` to `unshift` the billing header as its own block, and adjusts docs/tests/snapshots to assert that user messages remain untouched while `system[]` contains all sanitized content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b523f5ce51ae93942914d73b40091ae7e23ec7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->