### PR TITLE
Fix Cannot find module '.../dist/auth' error when opencode loads the plugin as strict ESM.

### DIFF
--- a/.changeset/fix-esm-module-resolution.md
+++ b/.changeset/fix-esm-module-resolution.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Fix `Cannot find module '.../dist/auth'` error when opencode loads the plugin as strict ESM.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,8 +4,8 @@ import {
   CODE_CALLBACK_URL,
   OAUTH_SCOPES,
   TOKEN_URL,
-} from './constants'
-import { generatePKCE } from './pkce'
+} from './constants.ts'
+import { generatePKCE } from './pkce.ts'
 
 type CallbackParams = {
   code: string

--- a/src/cch.ts
+++ b/src/cch.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { CCH_POSITIONS, CCH_SALT, CLAUDE_CODE_VERSION } from './constants'
+import { CCH_POSITIONS, CCH_SALT, CLAUDE_CODE_VERSION } from './constants.ts'
 
 type Message = {
   role?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@opencode-ai/plugin'
-import { authorize, exchange } from './auth'
-import { CLIENT_ID, TOKEN_URL } from './constants'
+import { authorize, exchange } from './auth.ts'
+import { CLIENT_ID, TOKEN_URL } from './constants.ts'
 import {
   createStrippedStream,
   isInsecure,
@@ -8,7 +8,7 @@ import {
   rewriteRequestBody,
   rewriteUrl,
   setOAuthHeaders,
-} from './transform'
+} from './transform.ts'
 
 export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
   return {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,4 @@
-import { buildBillingHeaderValue } from './cch'
+import { buildBillingHeaderValue } from './cch.ts'
 import {
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
@@ -8,7 +8,7 @@ import {
   TEXT_REPLACEMENTS,
   TOOL_PREFIX,
   USER_AGENT,
-} from './constants'
+} from './constants.ts'
 
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,8 @@
     "types": ["bun-types"],
     "declaration": true,
     "noEmit": false,
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/tests/**"]


### PR DESCRIPTION
## Summary

Fix `Cannot find module '.../dist/auth'` error when opencode loads the plugin as strict ESM.

## Error

Having this error after updating opencode to 1.4.4:

```
ERROR 2026-04-15T07:45:19 +58ms service=plugin path=@ex-machina/opencode-anthropic-auth@1.7.0 target=file:///Users/[NAME]/.cache/opencode/packages/@ex-machina/opencode-anthropic-auth@1.7.0/node_modules/@ex-machina/opencode-anthropic-auth/dist/index.js error=Cannot find module '/Users/[NAME]/.cache/opencode/packages/@ex-machina/opencode-anthropic-auth@1.7.0/node_modules/@ex-machina/opencode-anthropic-auth/dist/auth' imported from /Users/[NAME]/.cache/opencode/packages/@ex-machina/opencode-anthropic-auth@1.7.0/node_modules/@ex-machina/opencode-anthropic-auth/dist/index.js failed to load plugin
```

## Problem

`tsc` preserves extensionless relative imports (`from './auth'`) in emitted `.js` files. Node/Bun ESM does not auto-append `.js` like CommonJS, so `await import("file:///...dist/index.js")` fails at runtime.

## Fix

Enable `rewriteRelativeImportExtensions` (TS 5.7+) so `.ts` imports in source are rewritten to `.js` in output.

```
src:  from './auth.ts'  →  dist:  from './auth.js'
```