### PR TITLE
fix: re-read auth before token refresh to avoid stale snapshot

### DIFF
--- a/.changeset/fix-stale-refresh-token.md
+++ b/.changeset/fix-stale-refresh-token.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Re-read auth before token refresh to avoid using a stale refresh token snapshot when token rotation occurs between requests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,11 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                           )
                         }
 
+                        // Re-read auth to get the latest refresh token.
+                        // The outer `auth` snapshot may be stale if tokens
+                        // were rotated since the fetch() call was made.
+                        const freshAuth = await getAuth()
+
                         const response = await fetch(TOKEN_URL, {
                           method: 'POST',
                           headers: {
@@ -70,7 +75,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                           },
                           body: JSON.stringify({
                             grant_type: 'refresh_token',
-                            refresh_token: auth.refresh,
+                            refresh_token: freshAuth.refresh,
                             client_id: CLIENT_ID,
                           }),
                         })
@@ -105,6 +110,21 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                             expires: Date.now() + json.expires_in * 1000,
                           },
                         })
+
+                        // DEBUG: verify auth.set round-trip — remove once root cause confirmed
+                        const verifyAuth = await getAuth()
+                        console.error(
+                          '[auth-debug] auth.set wrote refresh:',
+                          json.refresh_token?.slice(-8),
+                        )
+                        console.error(
+                          '[auth-debug] getAuth() now returns refresh:',
+                          verifyAuth.refresh?.slice(-8),
+                        )
+                        console.error(
+                          '[auth-debug] round-trip OK:',
+                          verifyAuth.refresh === json.refresh_token,
+                        )
 
                         return json.access_token
                       } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,21 +111,6 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                           },
                         })
 
-                        // DEBUG: verify auth.set round-trip — remove once root cause confirmed
-                        const verifyAuth = await getAuth()
-                        console.error(
-                          '[auth-debug] auth.set wrote refresh:',
-                          json.refresh_token?.slice(-8),
-                        )
-                        console.error(
-                          '[auth-debug] getAuth() now returns refresh:',
-                          verifyAuth.refresh?.slice(-8),
-                        )
-                        console.error(
-                          '[auth-debug] round-trip OK:',
-                          verifyAuth.refresh === json.refresh_token,
-                        )
-
                         return json.access_token
                       } catch (error) {
                         const isNetworkError =

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -520,6 +520,62 @@ describe('auth.loader', () => {
     expect(mockClient.auth.set).toHaveBeenCalledTimes(1)
   })
 
+  test('refresh always reads the latest refresh token, not a stale snapshot', async () => {
+    const tokenRequestBodies: string[] = []
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+
+      if (url.includes('/v1/oauth/token')) {
+        tokenRequestBodies.push(init?.body)
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'rotated-refresh',
+              access_token: 'fresh-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    let callCount = 0
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+
+    const result = await plugin.auth.loader(
+      () => {
+        callCount++
+        if (callCount === 1) {
+          return Promise.resolve({
+            type: 'oauth',
+            access: 'expired-access',
+            refresh: 'stale-refresh',
+            expires: Date.now() - 1000,
+          })
+        }
+        return Promise.resolve({
+          type: 'oauth',
+          access: 'expired-access',
+          refresh: 'rotated-refresh-from-storage',
+          expires: Date.now() - 1000,
+        })
+      },
+      { models: {} },
+    )
+
+    await result.fetch(MESSAGES_URL, EMPTY_POST)
+
+    expect(tokenRequestBodies).toHaveLength(1)
+    const sentBody = JSON.parse(tokenRequestBodies[0])
+    expect(sentBody.refresh_token).toBe('rotated-refresh-from-storage')
+    expect(sentBody.refresh_token).not.toBe('stale-refresh')
+  })
+
   test('fetch wrapper adds beta=true to /v1/messages URL', async () => {
     let capturedUrl: string | undefined
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -571,7 +571,7 @@ describe('auth.loader', () => {
     await result.fetch(MESSAGES_URL, EMPTY_POST)
 
     expect(tokenRequestBodies).toHaveLength(1)
-    const sentBody = JSON.parse(tokenRequestBodies[0])
+    const sentBody = JSON.parse(tokenRequestBodies[0] ?? '{}')
     expect(sentBody.refresh_token).toBe('rotated-refresh-from-storage')
     expect(sentBody.refresh_token).not.toBe('stale-refresh')
   })


### PR DESCRIPTION
## Problem

When a refresh-token rotation occurs, the `auth` object captured at the start of a fetch handler may be stale. The old (already-invalidated) refresh token was used in the POST to `/v1/oauth/token`, causing the refresh flow to fail.

## Fix

Re-fetch the latest stored auth (`getAuth()`) immediately before the refresh-token POST, ensuring the most recently rotated token is always used.

## Changes

- **`src/index.ts`**: Call `getAuth()` again just before the token refresh request; use `freshAuth.refresh` instead of the snapshot `auth.refresh`. Also adds a temporary debug round-trip assertion to confirm `auth.set` round-trips correctly — can be removed once root cause is confirmed in production.
- **`src/tests/index.test.ts`**: New test `refresh always reads the latest refresh token, not a stale snapshot` that simulates token rotation between calls and asserts the refreshed token (not the stale one) is sent.

