### PR TITLE
docs: fix opencode's cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 An [OpenCode](https://github.com/anomalyco/opencode) plugin that provides Anthropic OAuth authentication, enabling Claude Pro/Max users to use their subscription directly with OpenCode.
 
 > [!IMPORTANT]
-> If you are seeing issues, please try to `rm -rf ~/.config/opencode` and check your `opencode.json` config to make sure you're on the latest version.
+> If you are seeing issues, please try to `rm -rf ~/.cache/opencode` and check your `opencode.json` config to make sure you're on the latest version.
 >
 > Try this FIRST before making an Issue. Thanks!
 


### PR DESCRIPTION
Or maybe even
`cd ~/.cache/opencode && bun add @ex-machina/opencode-anthropic-auth@latest`

this should also help to wipe cached version. but not .config folder for sure