### PR TITLE
Move app token generation before checkout step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,20 +17,22 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-      - run: bun install --frozen-lockfile
-
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
           app-id: 2986376
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      - run: bun install --frozen-lockfile
 
       - name: Create Release PR or Publish
         id: changesets


### PR DESCRIPTION
This pull request moves the GitHub app token generation step to occur before the checkout action and configures the checkout to use the generated app token instead of the default GitHub token. This ensures that subsequent git operations in the workflow will have the proper authentication credentials from the start of the job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that primarily affects CI authentication for checkout; low blast radius but could break publishing if the app token/permissions are misconfigured.
> 
> **Overview**
> Updates the `Publish` GitHub Actions workflow to generate a GitHub App token *before* `actions/checkout`, and configures checkout to use that token instead of the default workflow token.
> 
> This ensures subsequent git operations in the publish job (including Changesets release PR/publish) run under the app’s credentials from the start of the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ff540e24c2719e062bb74cb95217f1ed3b5ed4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->