### PR TITLE
Add claude opus 4.7 + tests

### DIFF
--- a/.changeset/add-claude-opus-4-7.md
+++ b/.changeset/add-claude-opus-4-7.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+Add Claude Opus 4.7 to the model selection list via a new `provider` hook. The plugin now injects `claude-opus-4-7` into the Anthropic provider's model map if it's not already present in OpenCode's bundled models.dev snapshot, so users can select the newly released model without waiting for an OpenCode update.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,64 @@ import {
   setOAuthHeaders,
 } from './transform.ts'
 
+/**
+ * Models not yet present in OpenCode's bundled models.dev snapshot that
+ * this plugin injects so they appear in the model selection UI.
+ *
+ * Pricing: USD per million tokens (same scale as models.dev).
+ * Capabilities mirror claude-opus-4-6 (same family/generation).
+ */
+const INJECTED_MODELS = [
+  {
+    id: 'claude-opus-4-7',
+    providerID: 'anthropic',
+    api: {
+      id: 'anthropic',
+      url: 'https://api.anthropic.com/v1',
+      npm: '@ai-sdk/anthropic',
+    },
+    name: 'Claude Opus 4.7',
+    family: 'claude-opus',
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: true },
+      output: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      interleaved: { field: 'reasoning_content' as const },
+    },
+    cost: { input: 5, output: 25, cache: { read: 0.5, write: 6.25 } },
+    limit: { context: 1_000_000, output: 128_000 },
+    status: 'active' as const,
+    options: {},
+    headers: {},
+    release_date: '2026-04-16',
+  },
+]
+
 export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
   return {
+    provider: {
+      id: 'anthropic',
+      async models(provider: { models: Record<string, unknown> }) {
+        const models: Record<string, unknown> = { ...provider.models }
+        for (const model of INJECTED_MODELS) {
+          // Don't overwrite if OpenCode already knows the model natively
+          if (!(model.id in models)) {
+            models[model.id] = model
+          }
+        }
+        return models
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: ProviderHook not yet in typed Hooks interface
+    } as any,
     auth: {
       provider: 'anthropic',
       async loader(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -70,6 +70,13 @@ describe('AnthropicAuthPlugin', () => {
     expect(plugin.auth.loader).toBeFunction()
     expect(plugin.auth.methods).toBeArray()
   })
+
+  test('returns a provider hook targeting anthropic', async () => {
+    const plugin = await getPlugin()
+    expect(plugin.provider).toBeDefined()
+    expect(plugin.provider.id).toBe('anthropic')
+    expect(plugin.provider.models).toBeFunction()
+  })
 })
 
 describe('auth.methods', () => {
@@ -546,5 +553,75 @@ describe('auth.loader', () => {
     })
 
     expect(capturedUrl).toContain('beta=true')
+  })
+})
+
+describe('provider hook', () => {
+  test('injects claude-opus-4-7 when not already present', async () => {
+    const plugin = await getPlugin()
+    const result = await plugin.provider.models({ models: {} })
+    expect(result['claude-opus-4-7']).toBeDefined()
+    expect(result['claude-opus-4-7'].id).toBe('claude-opus-4-7')
+    expect(result['claude-opus-4-7'].name).toBe('Claude Opus 4.7')
+    expect(result['claude-opus-4-7'].providerID).toBe('anthropic')
+  })
+
+  test('injected claude-opus-4-7 has correct capabilities', async () => {
+    const plugin = await getPlugin()
+    const result = await plugin.provider.models({ models: {} })
+    const model = result['claude-opus-4-7']
+    expect(model.capabilities.toolcall).toBe(true)
+    expect(model.capabilities.attachment).toBe(true)
+    expect(model.capabilities.reasoning).toBe(true)
+    expect(model.capabilities.input.image).toBe(true)
+    expect(model.capabilities.input.pdf).toBe(true)
+  })
+
+  test('injected claude-opus-4-7 has correct pricing', async () => {
+    const plugin = await getPlugin()
+    const result = await plugin.provider.models({ models: {} })
+    const model = result['claude-opus-4-7']
+    expect(model.cost.input).toBe(5)
+    expect(model.cost.output).toBe(25)
+    expect(model.cost.cache.read).toBe(0.5)
+    expect(model.cost.cache.write).toBe(6.25)
+  })
+
+  test('injected claude-opus-4-7 has correct context limits', async () => {
+    const plugin = await getPlugin()
+    const result = await plugin.provider.models({ models: {} })
+    const model = result['claude-opus-4-7']
+    expect(model.limit.context).toBe(1_000_000)
+    expect(model.limit.output).toBe(128_000)
+  })
+
+  test('preserves existing provider models', async () => {
+    const plugin = await getPlugin()
+    const existingModels = {
+      'claude-opus-4-6': { id: 'claude-opus-4-6', name: 'Claude Opus 4.6' },
+      'claude-sonnet-4-6': {
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+      },
+    }
+    const result = await plugin.provider.models({ models: existingModels })
+    expect(result['claude-opus-4-6']).toBeDefined()
+    expect(result['claude-sonnet-4-6']).toBeDefined()
+    expect(result['claude-opus-4-7']).toBeDefined()
+  })
+
+  test('does not overwrite claude-opus-4-7 if already present in provider', async () => {
+    const plugin = await getPlugin()
+    const existing47 = {
+      id: 'claude-opus-4-7',
+      name: 'Existing Opus 4.7',
+      custom: true,
+    }
+    const result = await plugin.provider.models({
+      models: { 'claude-opus-4-7': existing47 },
+    })
+    // Should keep the existing entry, not overwrite it
+    expect((result['claude-opus-4-7'] as any).custom).toBe(true)
+    expect(result['claude-opus-4-7'].name).toBe('Existing Opus 4.7')
   })
 })


### PR DESCRIPTION
## Summary

Adds **Claude Opus 4.7** to the model selection list by introducing a new `provider` hook alongside the existing `auth` hook. The plugin now injects `claude-opus-4-7` into the Anthropic provider's model map if it's not already present in OpenCode's bundled `models.dev` snapshot — so users can select the newly released model without waiting for an OpenCode update.

## Why

Claude Opus 4.7 was released on 2026-04-16. OpenCode loads its model list from a bundled `models.dev` snapshot at startup, which predates Opus 4.7 in the currently shipped versions. Since OpenCode no longer supports Claude authentication natively (only via plugins), this plugin is the right place to surface the new model until upstream OpenCode catches up.

## What changed

### `src/index.ts`
- New `INJECTED_MODELS` constant containing the full `ModelV2` definition for `claude-opus-4-7`, matching the shape expected by `@opencode-ai/sdk` v2.
- New `provider` hook targeting `id: 'anthropic'`:
  - Spreads the existing `provider.models` map
  - Adds injected models only if not already present (defensive guard — won't overwrite if OpenCode adds it natively)

### `src/tests/index.test.ts`
- 7 new tests covering:
  - Plugin returns a `provider` hook
  - `claude-opus-4-7` is injected when absent
  - Correct capabilities (tool calls, attachments, reasoning, image/PDF input)
  - Correct pricing ($5/$25 per M tokens, $0.50/$6.25 cache read/write)
  - Correct context limits (1M context, 128K output)
  - Existing provider models are preserved
  - Native `claude-opus-4-7` entries are not overwritten

### `.changeset/add-claude-opus-4-7.md`
- `minor` version bump changeset.

## Model metadata

Matches `models.dev` for Opus 4.7:

| Field | Value |
|---|---|
| ID | `claude-opus-4-7` |
| Name | Claude Opus 4.7 |
| Family | `claude-opus` |
| Input / Output cost | $5.00 / $25.00 per M tokens |
| Cache read / write | $0.50 / $6.25 per M tokens |
| Context window | 1,000,000 tokens |
| Output limit | 128,000 tokens |
| Capabilities | temperature, reasoning (interleaved `reasoning_content`), tool calls, attachments, text/image/PDF input |

Note: The existing `auth.loader` already zeros out all costs for OAuth (Max plan) users, so the cost values above only apply to API-key users.

## Implementation notes
- Related issue: https://github.com/ex-machina-co/opencode-anthropic-auth/issues/112
- The `ProviderHook` type is not yet exposed in the `Plugin` package's typed `Hooks` interface, so a scoped `as any` cast is used with a `biome-ignore` suppression directly on that line. The hook is read dynamically by OpenCode at runtime, so the runtime contract is still correct.
- Used a `for...of` loop over `INJECTED_MODELS` so adding future models (e.g., Haiku 5, Sonnet 4.7) becomes a one-line change.

## Testing

All CI checks pass locally:

- `bun run types` — pass
- `bun run build` — pass
- `bun test` — **123 pass, 0 fail** (7 new tests added)
- `bun run format:check` — clean
- `bun run lint` — 0 warnings, 0 errors

<img width="1281" height="616" alt="image" src="https://github.com/user-attachments/assets/94638626-ffb8-464f-b47b-70e770a6fa52" />


## Backward compatibility

- Fully backward compatible. If OpenCode's bundled `models.dev` already contains `claude-opus-4-7`, the plugin keeps the existing entry untouched.
- The existing `auth` hook behavior (OAuth token refresh, cost zeroing, tool prefixing, system prompt sanitization) is unchanged.

## Checklist

- [x] Tests added and passing
- [x] Types check
- [x] Build succeeds
- [x] Biome format & lint clean
- [x] Changeset added (`minor`)
- [ ] Reviewed by maintainer