### PR TITLE
feat(transform): apply hybrid 1h prompt caching in rewriteRequestBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,45 @@
-# OpenCode Anthropic Auth Plugin
+# opencode-anthropic-auth
 
 > [!WARNING]
 > This plugin comes with no guarantees. You might be banned for breaking the TOS, you might not be. I don't work at Anthropic, nor am I an attorney.
 >
-> Use your best judgment and don't try to abuse the subscriptions. Plugins like oh-my-openagent are _known_ to trigger bans. Please be careful when using Ralph loops or insanely heavy usage patterns.
+> Use your best judgment and don't abuse your subscription.
 
-> [!IMPORTANT]
-> If you are seeing issues, please try to `rm -rf ~/.cache/opencode` and check your `opencode.json` config to make sure you're on the latest version.
->
-> Try this FIRST before making an Issue. Thanks!
+Fork of [ex-machina-co/opencode-anthropic-auth](https://github.com/ex-machina-co/opencode-anthropic-auth).
 
 An [OpenCode](https://github.com/anomalyco/opencode) plugin that provides Anthropic OAuth authentication, enabling Claude Pro/Max users to use their subscription directly with OpenCode.
 
-## Usage
+## Install
 
-Add the plugin to your OpenCode configuration:
-
-```json
-{
-  "plugin": ["@ex-machina/opencode-anthropic-auth"]
-}
-```
-
-> [!TIP]
-> It is STRONGLY advised that you pin the plugin to a version. This will keep you from getting automatic updates; however, this will protect you from nefarious updates.
->
-> This holds true for ANY OpenCode plugin. If you do not pin them, OpenCode will automatically update them on startup. It's a massive vulnerability waiting to happen.
-
-#### Example of pinned version
+Add to your OpenCode config (`~/.config/opencode/opencode.json`):
 
 ```json
 {
-  "plugin": ["@ex-machina/opencode-anthropic-auth@1.8.0"]
+  "plugin": ["@sahiljassal/opencode-anthropic-auth"]
 }
 ```
 
 ## Authentication Methods
 
-The plugin provides three authentication options:
+- **Claude Pro/Max** — OAuth flow via `claude.ai`. Uses your existing subscription at no additional API cost.
+- **Create an API Key** — OAuth flow via `console.anthropic.com` that creates an API key on your behalf.
+- **Manually enter API Key** — Standard API key entry.
 
-- **Claude Pro/Max** - OAuth flow via `claude.ai` for Pro/Max subscribers. Uses your existing subscription at no additional API cost.
-- **Create an API Key** - OAuth flow via `console.anthropic.com` that creates an API key on your behalf.
-- **Manually enter API Key** - Standard API key entry for users who already have one.
+## Prompt Caching
+
+This fork applies **hybrid 1-hour ephemeral prompt caching** on every request:
+
+- Strips any existing `cache_control` blocks from the request
+- Anchors a `1h` ephemeral cache on the last system block (after identity) and the first two user messages
+
+This reduces token usage and latency on repeated requests by reusing cached prompt prefixes.
 
 ## Configuration
 
-The plugin supports the following environment variables:
-
-| Variable                          | Description                                                                                                                                                                                 |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ANTHROPIC_BASE_URL`              | Override the API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL.                                                                                                             |
-| `ANTHROPIC_INSECURE`              | Set to `1` or `true` to skip TLS certificate verification. Only effective when `ANTHROPIC_BASE_URL` is also set.                                                                            |
-
-## How It Works
-
-For Claude Pro/Max authentication, the plugin:
-
-1. Initiates a PKCE OAuth flow against Anthropic's authorization endpoint
-2. Exchanges the authorization code for access and refresh tokens
-3. Automatically refreshes expired tokens
-4. Injects the required OAuth headers and beta flags into API requests
-5. Sanitizes the system prompt for compatibility (see below)
-6. Zeros out model costs (since usage is covered by the subscription)
-
-### System Prompt Sanitization
-
-The Anthropic API for Max subscriptions has specific requirements for the system prompt to identify as Claude Code. The plugin rewrites the system prompt on each request using an **anchor-based** approach that minimizes what gets changed:
-
-1. **Identity swap** — The OpenCode identity line is removed and replaced with the Claude Code identity.
-2. **Paragraph removal by anchor** — Any paragraph containing a known URL anchor (e.g. `github.com/anomalyco/opencode`, `opencode.ai/docs`) is removed entirely. This is resilient to upstream rewording — as long as the anchor URL appears somewhere in the paragraph, the removal works regardless of surrounding text changes.
-3. **Inline text replacements** — Short branded strings inside paragraphs we want to keep are replaced (e.g. "OpenCode" → "the assistant" in the professional objectivity section).
-
-Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The sanitized system prompt is structured as three blocks in `system[]`: the billing header, the Claude Code identity line, and the remaining system content.
-
-## Development
-
-### Local Testing
-
-Use `bun run dev` to test plugin changes locally without publishing to npm:
-
-```bash
-bun run dev
-```
-
-This does three things:
-
-1. Builds the plugin
-2. Symlinks the build output into `.opencode/plugins/` so OpenCode loads it as a local plugin
-3. Starts `tsc --watch` for automatic rebuilds on source changes
-
-After starting the dev script, restart OpenCode in this project directory to pick up the local build. Any edits to `src/` will trigger a rebuild — restart OpenCode again to load the new version.
-
-Ctrl+C stops the watcher and cleans up the symlink. If the process was killed without cleanup (e.g. `kill -9`), you can manually remove the symlink:
-
-```bash
-bun run dev:clean
-```
-
-> [!NOTE]
-> If you have the npm version of this plugin in your global OpenCode config, both will load. The local version takes precedence for auth handling.
-
-### Publishing
-
-This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing. See the [changeset README](.changeset/README.md) for more details.
-
-```bash
-bun change          # create a changeset describing your changes
-```
-
-When changesets are merged to `main`, CI will automatically open a release PR. Merging that PR publishes to npm.
+| Variable | Description |
+|---|---|
+| `ANTHROPIC_BASE_URL` | Override API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL. |
+| `ANTHROPIC_INSECURE` | Set to `1` or `true` to skip TLS verification. Only effective with `ANTHROPIC_BASE_URL`. |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@ex-machina/opencode-anthropic-auth",
-  "version": "1.8.1",
+  "name": "@sahiljassal/opencode-anthropic-auth",
+  "version": "2.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ex-machina-co/opencode-anthropic-auth"
+    "url": "git+https://github.com/shljsl75891/opencode-anthropic-auth.git"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,4 @@
-import { buildBillingHeaderValue } from './cch.ts'
 import {
-  CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
   OPENCODE_IDENTITY_PREFIX,
   PARAGRAPH_REMOVAL_ANCHORS,
@@ -277,6 +275,68 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value)
 }
 
+const CACHE_1H = { type: 'ephemeral', ttl: '1h' } as const
+
+function removeCacheControl(value: unknown): void {
+  if (!isRecord(value)) return
+  delete value.cache_control
+  delete value.cacheControl
+}
+
+function removeAllCacheControls(parsed: Record<string, unknown>): void {
+  if (Array.isArray(parsed.system)) {
+    for (const block of parsed.system) removeCacheControl(block)
+  }
+  if (!Array.isArray(parsed.messages)) return
+  for (const msg of parsed.messages) {
+    removeCacheControl(msg)
+    if (isRecord(msg) && Array.isArray(msg.content)) {
+      for (const block of msg.content) removeCacheControl(block)
+    }
+  }
+}
+
+function setWireCacheControl(value: unknown): boolean {
+  if (!isRecord(value)) return false
+  delete value.cacheControl
+  value.cache_control = { ...CACHE_1H }
+  return true
+}
+
+function setMessageCacheAnchor(message: unknown): boolean {
+  if (!isRecord(message)) return false
+  const content = Array.isArray(message.content)
+    ? message.content
+    : typeof message.content === 'string'
+      ? [{ type: 'text', text: message.content }]
+      : null
+  if (!content?.length) return setWireCacheControl(message)
+  message.content = content
+  const target = [...content]
+    .reverse()
+    .find((b) => isRecord(b) && b.type !== 'thinking')
+  return setWireCacheControl(target ?? message)
+}
+
+function applyHybridCache1h(parsed: Record<string, unknown>): void {
+  removeAllCacheControls(parsed)
+
+  // Cache last system block after the identity block
+  if (Array.isArray(parsed.system)) {
+    const identityIdx = parsed.system.findIndex(
+      (b) => isRecord(b) && b.text === CLAUDE_CODE_IDENTITY,
+    )
+    const cacheableSystem = parsed.system
+      .slice(identityIdx >= 0 ? identityIdx + 1 : 0)
+      .filter(isRecord)
+    setWireCacheControl(cacheableSystem[cacheableSystem.length - 1])
+  }
+
+  if (!Array.isArray(parsed.messages)) return
+  setMessageCacheAnchor(parsed.messages[0])
+  setMessageCacheAnchor(parsed.messages[1])
+}
+
 /**
  * Sanitize system prompt and prepend Claude Code identity.
  * Handles all Anthropic API system formats: undefined, string, or array of text blocks.
@@ -332,32 +392,14 @@ export function prependClaudeCodeIdentity(system: unknown): SystemBlock[] {
 }
 
 /**
- * Rewrite the full request body: sanitize system prompt and prefix tool names.
+ * Rewrite the full request body: sanitize system prompt, prefix tool names,
+ * and apply hybrid 1h prompt caching.
  */
 export function rewriteRequestBody(body: string): string {
   try {
     const parsed = JSON.parse(body)
-    const billingHeader =
-      Array.isArray(parsed.messages) &&
-      parsed.messages.some(
-        (message: { role?: string }) => message.role === 'user',
-      )
-        ? buildBillingHeaderValue(
-            parsed.messages,
-            undefined,
-            CLAUDE_CODE_ENTRYPOINT,
-          )
-        : null
-
-    // Sanitize system prompt and prepend Claude Code identity
     parsed.system = prependClaudeCodeIdentity(parsed.system)
-
-    // Prepend the billing header as a separate system block so the
-    // final layout is: [billing header, identity, ...rest]
-    if (billingHeader && Array.isArray(parsed.system)) {
-      parsed.system.unshift({ type: 'text', text: billingHeader })
-    }
-
+    applyHybridCache1h(parsed)
     return prefixToolNames(parsed)
   } catch {
     return body


### PR DESCRIPTION
## Add server-side prompt caching (1h TTL)
Anthropic's prompt caching went GA in 2025 — no beta header needed anymore. This PR adds a hybrid caching strategy that places cache_control: { type: "ephemeral", ttl: "1h" } breakpoints on three stable positions in the request body:
1. Last system block (after the CC identity block) — caches the entire system prompt prefix
2. `messages[0]` — anchors the first user message
3. `messages[1]` — anchors the first assistant reply
These three breakpoints stay stable across turns, so the cached prefix grows without invalidation.

## What changed
- Added caching helpers: `removeCacheControl`, `removeAllCacheControls`, `setWireCacheControl`, `setMessageCacheAnchor`, `applyHybridCache1h`
- Removed billing header injection (`buildBillingHeaderValue` / `CLAUDE_CODE_ENTRYPOINT` import) and cch= signing from `rewriteRequestBody`
- Simplified rewriteRequestBody to a synchronous pipeline: parse → sanitize → cache → prefix

## Why drop the billing header
The cch= billing token in `system[0]` changes on every request (xxhash64 of the full body). Anthropic's cache is strictly prefix-based — when `system[0]` mutates, all downstream breakpoints miss. The billing header was making caching impossible. Dropping it means the entire system prefix stays byte-identical across turns, giving real cache hits.

## What we lose
The billing header was part of Anthropic's client classification. Without it, the cch fingerprint is gone. Other CC disguise elements (User-Agent, OAuth headers, system identity, tool prefixing) remain intact. Low risk for normal interactive usage.

## Verified
Tested against claude-sonnet-4-6 via Claude Max OAuth. Session showed cache_write=408, cache_read=39,808 — ~97x token efficiency on the second request.

## References
- Prompt caching docs (https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) — official caching docs, confirms cache_control format and that no beta header is needed
- Beta headers (https://docs.anthropic.com/en/api/beta-headers) — confirms extended-cache-ttl-2025-04-11 is no longer listed (retired)