### PR TITLE
feat: add Claude Opus 4.8 support

### DIFF
--- a/.changeset/quiet-clouds-dance.md
+++ b/.changeset/quiet-clouds-dance.md
@@ -1,0 +1,5 @@
+---
+'@ex-machina/opencode-anthropic-auth': patch
+---
+
+Add Claude Opus 4.8 to the Anthropic provider model list for OpenCode versions that do not expose it yet.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,70 @@ import {
   setOAuthHeaders,
 } from './transform.ts'
 
+type AnthropicModel = {
+  id: string
+  name: string
+  family?: string
+  release_date: string
+  api: { id: string; [key: string]: unknown }
+  cost: {
+    input: number
+    output: number
+    cache: { read: number; write: number }
+    [key: string]: unknown
+  }
+  limit: { context: number; input?: number; output: number }
+  [key: string]: unknown
+}
+
+type AnthropicProvider = {
+  models: Record<string, AnthropicModel>
+}
+
+const CLAUDE_OPUS_4_8_ID = 'claude-opus-4-8'
+const CLAUDE_OPUS_4_8_BASE_MODELS = [
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+] as const
+
+function addClaudeOpus48Model(provider: AnthropicProvider) {
+  if (provider.models[CLAUDE_OPUS_4_8_ID]) return provider.models
+
+  const base = CLAUDE_OPUS_4_8_BASE_MODELS.map(
+    (id) => provider.models[id],
+  ).find(Boolean)
+  if (!base) return provider.models
+
+  return {
+    [CLAUDE_OPUS_4_8_ID]: {
+      ...base,
+      id: CLAUDE_OPUS_4_8_ID,
+      name: 'Claude Opus 4.8',
+      release_date: '2026-05-29',
+      api: { ...base.api, id: CLAUDE_OPUS_4_8_ID },
+      cost: {
+        input: 5,
+        output: 25,
+        cache: { read: 0.5, write: 6.25 },
+      },
+      limit: {
+        context: 1_000_000,
+        output: 128_000,
+      },
+      status: 'active',
+    },
+    ...provider.models,
+  }
+}
+
 export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
   return {
+    provider: {
+      id: 'anthropic',
+      models: async (provider: AnthropicProvider) => {
+        return addClaudeOpus48Model(provider)
+      },
+    },
     auth: {
       provider: 'anthropic',
       async loader(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -103,6 +103,76 @@ describe('auth.methods', () => {
   })
 })
 
+describe('provider.models', () => {
+  test('adds Claude Opus 4.8 from latest Opus metadata', async () => {
+    const plugin = await getPlugin()
+    const models = {
+      'claude-opus-4-7': {
+        id: 'claude-opus-4-7',
+        providerID: 'anthropic',
+        name: 'Claude Opus 4.7',
+        family: 'claude-opus',
+        release_date: '2026-05-01',
+        api: {
+          id: 'claude-opus-4-7',
+          url: 'https://api.anthropic.com/v1/messages',
+          npm: '@ai-sdk/anthropic',
+        },
+        capabilities: {
+          reasoning: true,
+          attachment: true,
+          toolcall: true,
+        },
+        cost: {
+          input: 5,
+          output: 25,
+          cache: { read: 0.5, write: 6.25 },
+        },
+        limit: {
+          context: 1_000_000,
+          output: 128_000,
+        },
+        status: 'active',
+        options: {},
+        headers: {},
+      },
+    }
+
+    const result = await plugin.provider.models({ models }, {})
+
+    expect(result['claude-opus-4-8']).toMatchObject({
+      id: 'claude-opus-4-8',
+      name: 'Claude Opus 4.8',
+      release_date: '2026-05-29',
+      api: { id: 'claude-opus-4-8' },
+      cost: {
+        input: 5,
+        output: 25,
+        cache: { read: 0.5, write: 6.25 },
+      },
+      limit: {
+        context: 1_000_000,
+        output: 128_000,
+      },
+      status: 'active',
+    })
+  })
+
+  test('does not overwrite native Claude Opus 4.8 metadata', async () => {
+    const plugin = await getPlugin()
+    const models = {
+      'claude-opus-4-8': {
+        id: 'claude-opus-4-8',
+        name: 'Claude Opus 4.8 Native',
+      },
+    }
+
+    const result = await plugin.provider.models({ models }, {})
+
+    expect(result['claude-opus-4-8']).toBe(models['claude-opus-4-8'])
+  })
+})
+
 describe('auth.loader', () => {
   const originalFetch = globalThis.fetch
   const originalSetTimeout = globalThis.setTimeout


### PR DESCRIPTION
## Summary
- add Claude Opus 4.8 to the Anthropic provider model list when OpenCode does not expose it yet
- copy the latest available Opus metadata, then override the model id, name, pricing, limits, and release date
- keep native Claude Opus 4.8 metadata untouched once OpenCode provides it itself

## Testing
- bun run types
- bun run build
- bun test
- bun run format:check
- bun run lint