### PR TITLE
feat: support Claude Fable 5 / Mythos 5 (adaptive-thinking-only models)

### DIFF
--- a/.changeset/fable-5-adaptive-thinking.md
+++ b/.changeset/fable-5-adaptive-thinking.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+Add support for Claude Fable 5 / Mythos 5 (adaptive-thinking-only models). These models reject `thinking: { type: "disabled" }` with a `400 invalid_request_error`, which OpenCode (or a user's "no-thinking" model variant) can send — breaking every request. The plugin now drops the unsupported disabled `thinking` block for models matching the `claude-fable-` / `claude-mythos-` ID prefixes so the request succeeds with the model's default adaptive thinking. Enabled thinking and unset thinking are passed through unchanged, and non-adaptive models (Opus/Sonnet/Haiku) are never touched.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ The Anthropic API for Max subscriptions has specific requirements for the system
 
 Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The sanitized system prompt is structured as three blocks in `system[]`: the billing header, the Claude Code identity line, and the remaining system content.
 
+### Adaptive-thinking models (Claude Fable 5 / Mythos 5)
+
+Claude Fable 5 (`claude-fable-5`) and Claude Mythos 5 (`claude-mythos-5`) use **adaptive thinking** exclusively — thinking is always on and `thinking: { type: "disabled" }` is rejected by the Messages API with a `400 invalid_request_error`. OpenCode (or a user-defined "no-thinking" model variant) can send exactly that disabled block, which would break every request to these models.
+
+To keep these models usable, the plugin drops an unsupported `thinking: { type: "disabled" }` block when the target model is adaptive-thinking-only (matched by the `claude-fable-` / `claude-mythos-` model-ID prefixes). The request then succeeds with the model's default adaptive thinking. Requests that send `thinking: { type: "enabled", budget_tokens }`, or that don't set `thinking` at all, are passed through unchanged. Non-adaptive models (Opus, Sonnet, Haiku) are never touched, since they support disabled thinking.
+
 ## Development
 
 ### Local Testing

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,32 @@ export const REQUIRED_BETAS = [
   'interleaved-thinking-2025-05-14',
 ]
 
+/**
+ * Model-ID prefixes for Claude models that ONLY support adaptive thinking.
+ *
+ * Claude Fable 5 (`claude-fable-5`) and Claude Mythos 5 (`claude-mythos-5`,
+ * `claude-mythos-preview`) use adaptive thinking exclusively: thinking is
+ * always on, and `thinking: { type: "disabled" }` is rejected by the Messages
+ * API with a 400 `invalid_request_error`:
+ *
+ *   "thinking.type.disabled" is not supported for this model. Thinking
+ *   defaults to adaptive mode when not specified; use "thinking.type.enabled"
+ *   with "budget_tokens" for extended thinking.
+ *
+ * OpenCode (or a user's "no-thinking" model variant) can send exactly that
+ * disabled block, which would otherwise break every request to these models.
+ * See `normalizeAdaptiveThinking` in transform.ts.
+ *
+ * Matched by prefix so future point releases (e.g. `claude-fable-5-1`) and the
+ * whole Mythos line are covered automatically.
+ *
+ * Ref: https://docs.anthropic.com/en/docs/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5
+ */
+export const ADAPTIVE_THINKING_ONLY_MODEL_PREFIXES = [
+  'claude-fable-',
+  'claude-mythos-',
+] as const
+
 export const OPENCODE_IDENTITY_PREFIX = 'You are OpenCode'
 export const CLAUDE_CODE_IDENTITY =
   "You are a Claude agent, built on Anthropic's Claude Agent SDK."

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -7,9 +7,11 @@ import {
 } from '../constants'
 import {
   createStrippedStream,
+  isAdaptiveThinkingOnlyModel,
   isInsecure,
   mergeBetaHeaders,
   mergeHeaders,
+  normalizeAdaptiveThinking,
   prefixToolNames,
   prependClaudeCodeIdentity,
   rewriteRequestBody,
@@ -823,6 +825,109 @@ describe('rewriteRequestBody', () => {
 
     // User message is untouched
     expect(result.messages[0].content).toBe('hi')
+  })
+
+  test('strips disabled thinking for claude-fable-5 (adaptive-only)', () => {
+    const body = JSON.stringify({
+      model: 'claude-fable-5',
+      thinking: { type: 'disabled' },
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    // The unsupported disabled thinking block is removed so the request
+    // succeeds with the model's default adaptive thinking.
+    expect(result.thinking).toBeUndefined()
+  })
+
+  test('strips disabled thinking for claude-mythos-5 (adaptive-only)', () => {
+    const body = JSON.stringify({
+      model: 'claude-mythos-5',
+      thinking: { type: 'disabled' },
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.thinking).toBeUndefined()
+  })
+
+  test('preserves enabled thinking for claude-fable-5', () => {
+    const body = JSON.stringify({
+      model: 'claude-fable-5',
+      thinking: { type: 'enabled', budget_tokens: 1024 },
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    expect(result.thinking).toEqual({ type: 'enabled', budget_tokens: 1024 })
+  })
+
+  test('preserves disabled thinking for non-adaptive models (e.g. opus)', () => {
+    const body = JSON.stringify({
+      model: 'claude-opus-4-8',
+      thinking: { type: 'disabled' },
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    const result = JSON.parse(rewriteRequestBody(body))
+    // Opus DOES support disabled thinking — must not be touched.
+    expect(result.thinking).toEqual({ type: 'disabled' })
+  })
+})
+
+describe('isAdaptiveThinkingOnlyModel', () => {
+  test('matches Fable 5 and Mythos models by prefix', () => {
+    expect(isAdaptiveThinkingOnlyModel('claude-fable-5')).toBe(true)
+    expect(isAdaptiveThinkingOnlyModel('claude-fable-5-1')).toBe(true)
+    expect(isAdaptiveThinkingOnlyModel('claude-mythos-5')).toBe(true)
+    expect(isAdaptiveThinkingOnlyModel('claude-mythos-preview')).toBe(true)
+  })
+
+  test('tolerates an optional provider/ prefix on the id', () => {
+    expect(isAdaptiveThinkingOnlyModel('anthropic/claude-fable-5')).toBe(true)
+  })
+
+  test('does not match non-adaptive models', () => {
+    expect(isAdaptiveThinkingOnlyModel('claude-opus-4-8')).toBe(false)
+    expect(isAdaptiveThinkingOnlyModel('claude-sonnet-4-6')).toBe(false)
+    expect(isAdaptiveThinkingOnlyModel('claude-haiku-4-5')).toBe(false)
+  })
+
+  test('handles non-string input safely', () => {
+    expect(isAdaptiveThinkingOnlyModel(undefined)).toBe(false)
+    expect(isAdaptiveThinkingOnlyModel(null)).toBe(false)
+    expect(isAdaptiveThinkingOnlyModel(42)).toBe(false)
+  })
+})
+
+describe('normalizeAdaptiveThinking', () => {
+  test('deletes disabled thinking for an adaptive-only model', () => {
+    const parsed: Record<string, unknown> = {
+      model: 'claude-fable-5',
+      thinking: { type: 'disabled' },
+    }
+    normalizeAdaptiveThinking(parsed)
+    expect('thinking' in parsed).toBe(false)
+  })
+
+  test('leaves enabled thinking untouched for an adaptive-only model', () => {
+    const parsed: Record<string, unknown> = {
+      model: 'claude-fable-5',
+      thinking: { type: 'enabled', budget_tokens: 2048 },
+    }
+    normalizeAdaptiveThinking(parsed)
+    expect(parsed.thinking).toEqual({ type: 'enabled', budget_tokens: 2048 })
+  })
+
+  test('leaves disabled thinking untouched for a non-adaptive model', () => {
+    const parsed: Record<string, unknown> = {
+      model: 'claude-opus-4-8',
+      thinking: { type: 'disabled' },
+    }
+    normalizeAdaptiveThinking(parsed)
+    expect(parsed.thinking).toEqual({ type: 'disabled' })
+  })
+
+  test('is a no-op when thinking is unset', () => {
+    const parsed: Record<string, unknown> = { model: 'claude-fable-5' }
+    normalizeAdaptiveThinking(parsed)
+    expect('thinking' in parsed).toBe(false)
   })
 })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,5 +1,6 @@
 import { buildBillingHeaderValue } from './cch.ts'
 import {
+  ADAPTIVE_THINKING_ONLY_MODEL_PREFIXES,
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
   OPENCODE_IDENTITY_PREFIX,
@@ -332,6 +333,41 @@ export function prependClaudeCodeIdentity(system: unknown): SystemBlock[] {
 }
 
 /**
+ * Whether a model only supports adaptive thinking (and therefore rejects
+ * `thinking: { type: "disabled" }`). Matches Claude Fable 5 / Mythos 5 by
+ * model-ID prefix. Tolerates an optional `provider/` prefix on the id.
+ */
+export function isAdaptiveThinkingOnlyModel(model: unknown): boolean {
+  if (typeof model !== 'string') return false
+  const id = model.includes('/')
+    ? model.slice(model.lastIndexOf('/') + 1)
+    : model
+  return ADAPTIVE_THINKING_ONLY_MODEL_PREFIXES.some((prefix) =>
+    id.startsWith(prefix),
+  )
+}
+
+/**
+ * Claude Fable 5 / Mythos 5 reject `thinking: { type: "disabled" }` with a
+ * 400 invalid_request_error. OpenCode (or a user's "no-thinking" variant) can
+ * send exactly that. When the target model is adaptive-thinking-only, drop the
+ * unsupported disabled `thinking` block so the request succeeds with the
+ * model's default adaptive thinking instead of failing outright.
+ *
+ * Mutates `parsed` in place. No-op for any other model, for enabled thinking,
+ * or when thinking is unset.
+ */
+export function normalizeAdaptiveThinking(
+  parsed: Record<string, unknown>,
+): void {
+  if (!isAdaptiveThinkingOnlyModel(parsed.model)) return
+  const thinking = parsed.thinking
+  if (isRecord(thinking) && thinking.type === 'disabled') {
+    delete parsed.thinking
+  }
+}
+
+/**
  * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
 export function rewriteRequestBody(body: string): string {
@@ -357,6 +393,10 @@ export function rewriteRequestBody(body: string): string {
     if (billingHeader && Array.isArray(parsed.system)) {
       parsed.system.unshift({ type: 'text', text: billingHeader })
     }
+
+    // Drop unsupported `thinking: { type: "disabled" }` for adaptive-thinking-
+    // only models (Claude Fable 5 / Mythos 5) so they don't 400.
+    normalizeAdaptiveThinking(parsed)
 
     return prefixToolNames(parsed)
   } catch {


### PR DESCRIPTION
## Summary

Add support for **Claude Fable 5** (`claude-fable-5`) and **Claude Mythos 5** (`claude-mythos-5`), which are *adaptive‑thinking‑only* models. These models reject `thinking: { type: "disabled" }` with a `400 invalid_request_error`, which OpenCode (or a user's "no‑thinking" model variant) can send — breaking every request to them through the OAuth path.

Closes #159.

## Problem

Fable 5 is already in the models.dev catalog and works through this plugin's OAuth path for normal requests (thinking unset → adaptive). But when the outgoing body carries `thinking: { type: "disabled" }`, the Messages API responds:

```
HTTP 400 invalid_request_error
"thinking.type.disabled" is not supported for this model. Thinking defaults
to adaptive mode when not specified; use "thinking.type.enabled" with
"budget_tokens" for extended thinking.
```

Opus/Sonnet/Haiku are unaffected — they support disabled thinking — so this is specific to the Fable/Mythos line.

## Fix

`rewriteRequestBody` now drops an unsupported `thinking: { type: "disabled" }` block **only** when the target model is adaptive‑thinking‑only, so the request succeeds with the model's default adaptive thinking instead of hard‑failing.

- `constants.ts`: `ADAPTIVE_THINKING_ONLY_MODEL_PREFIXES = ['claude-fable-', 'claude-mythos-']` (prefix match → future point releases & the whole Mythos line are covered).
- `transform.ts`: `isAdaptiveThinkingOnlyModel(model)` (tolerates an optional `provider/` prefix) and `normalizeAdaptiveThinking(parsed)`, called inside `rewriteRequestBody` after the system/billing rewrites and before tool prefixing.

### Behavior

| Model | `thinking` sent | Before | After |
|---|---|---|---|
| `claude-fable-5` | `{ type: "disabled" }` | **400** | **200** (block stripped → adaptive) |
| `claude-fable-5` | `{ type: "enabled", budget_tokens }` | 200 | 200 (unchanged) |
| `claude-fable-5` | unset | 200 | 200 (unchanged) |
| `claude-opus-4-8` | `{ type: "disabled" }` | 200 | 200 (**untouched** — non‑adaptive) |

## Testing

- **Unit:** 12 new tests for `isAdaptiveThinkingOnlyModel`, `normalizeAdaptiveThinking`, and the `rewriteRequestBody` integration (adaptive/non‑adaptive × disabled/enabled/unset, provider‑prefix, non‑string input). Full suite **130/130** pass.
- **Static:** `tsc` clean, Biome lint + format clean.
- **Live (Claude Pro/Max OAuth, through the plugin's own transform):** reproduced the `400` on `claude-fable-5 + thinking:disabled`, confirmed **`200`** after the patch (block stripped), and confirmed `enabled` thinking is preserved (`200`). Control `claude-opus-4-8 + thinking:disabled` stays `200` and untouched.

## Changeset

Included (`minor`): "Add support for Claude Fable 5 / Mythos 5 (adaptive‑thinking‑only models)."

## Notes

- No catalog/cost/header changes are needed — Fable 5 is already in models.dev and bills like a standard model. This PR only removes the one incompatibility that blocks the Fable/Mythos line under disabled‑thinking configurations.
- References: [Introducing Claude Fable 5 and Claude Mythos 5](https://docs.anthropic.com/en/docs/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5), [Adaptive thinking](https://docs.anthropic.com/en/docs/build-with-claude/adaptive-thinking).
