### PR TITLE
Match Claude Code OAuth refresh scopes

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,9 @@
 import {
+  API_KEY_OAUTH_SCOPES,
   AUTHORIZE_URLS,
+  CLAUDE_CODE_OAUTH_SCOPES,
   CLIENT_ID,
   CODE_CALLBACK_URL,
-  OAUTH_SCOPES,
   TOKEN_URL,
 } from './constants.ts'
 import { generatePKCE } from './pkce.ts'
@@ -105,7 +106,9 @@ export async function authorize(
   url.searchParams.set('client_id', CLIENT_ID)
   url.searchParams.set('response_type', 'code')
   url.searchParams.set('redirect_uri', CODE_CALLBACK_URL)
-  url.searchParams.set('scope', OAUTH_SCOPES.join(' '))
+  const scopes =
+    mode === 'console' ? API_KEY_OAUTH_SCOPES : CLAUDE_CODE_OAUTH_SCOPES
+  url.searchParams.set('scope', scopes.join(' '))
   url.searchParams.set('code_challenge', pkce.challenge)
   url.searchParams.set('code_challenge_method', 'S256')
   url.searchParams.set('state', state)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,14 +10,20 @@ export const CODE_CALLBACK_URL =
 
 export const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
 
-export const OAUTH_SCOPES = [
-  'org:create_api_key',
+export const CLAUDE_CODE_OAUTH_SCOPES = [
   'user:profile',
   'user:inference',
   'user:sessions:claude_code',
   'user:mcp_servers',
   'user:file_upload',
 ]
+
+export const API_KEY_OAUTH_SCOPES = [
+  'org:create_api_key',
+  ...CLAUDE_CODE_OAUTH_SCOPES,
+]
+
+export const OAUTH_SCOPES = API_KEY_OAUTH_SCOPES
 
 export const TOOL_PREFIX = 'mcp_'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@opencode-ai/plugin'
 import { authorize, exchange } from './auth.ts'
-import { CLIENT_ID, TOKEN_URL } from './constants.ts'
+import { CLAUDE_CODE_OAUTH_SCOPES, CLIENT_ID, TOKEN_URL } from './constants.ts'
 import {
   createStrippedStream,
   isInsecure,
@@ -77,6 +77,7 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                             grant_type: 'refresh_token',
                             refresh_token: freshAuth.refresh,
                             client_id: CLIENT_ID,
+                            scope: CLAUDE_CODE_OAUTH_SCOPES.join(' '),
                           }),
                         })
 

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { authorize, exchange } from '../auth'
-import { CLIENT_ID, CODE_CALLBACK_URL, OAUTH_SCOPES } from '../constants'
+import {
+  API_KEY_OAUTH_SCOPES,
+  CLAUDE_CODE_OAUTH_SCOPES,
+  CLIENT_ID,
+  CODE_CALLBACK_URL,
+} from '../constants'
 
 afterEach(() => {
   mock.restore()
@@ -37,9 +42,23 @@ describe('authorize', () => {
     expect(url.searchParams.get('client_id')).toBe(CLIENT_ID)
     expect(url.searchParams.get('response_type')).toBe('code')
     expect(url.searchParams.get('redirect_uri')).toBe(CODE_CALLBACK_URL)
-    expect(url.searchParams.get('scope')).toBe(OAUTH_SCOPES.join(' '))
+    expect(url.searchParams.get('scope')).toBe(
+      CLAUDE_CODE_OAUTH_SCOPES.join(' '),
+    )
     expect(url.searchParams.get('code_challenge_method')).toBe('S256')
     expect(url.searchParams.get('state')).toBe(result.state)
+  })
+
+  test('sets API key creation scope only for console mode', async () => {
+    const max = await authorize('max')
+    const console = await authorize('console')
+
+    expect(new URL(max.url).searchParams.get('scope')).toBe(
+      CLAUDE_CODE_OAUTH_SCOPES.join(' '),
+    )
+    expect(new URL(console.url).searchParams.get('scope')).toBe(
+      API_KEY_OAUTH_SCOPES.join(' '),
+    )
   })
 
   test('does not use localhost', async () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { CLAUDE_CODE_OAUTH_SCOPES } from '../constants'
 import { AnthropicAuthPlugin } from '../index'
 
 /** Extract the URL string from a fetch input (string, URL, or Request). */
@@ -266,6 +267,7 @@ describe('auth.loader', () => {
     const tokenBody = JSON.parse(tokenCall!.body!)
     expect(tokenBody.grant_type).toBe('refresh_token')
     expect(tokenBody.refresh_token).toBe('old-refresh')
+    expect(tokenBody.scope).toBe(CLAUDE_CODE_OAUTH_SCOPES.join(' '))
 
     // Should have called client.auth.set with new tokens
     expect(mockClient.auth.set).toHaveBeenCalled()


### PR DESCRIPTION
WIP: Research. We may just need to rotate tokens. If that's the case, I'm going to close this.

Refresh requests had drifted from Claude Code's current OAuth request shape. Claude Code now sends the Claude Code scope set when refreshing tokens; the plugin refreshed with only grant type, refresh token, and client ID. That mismatch produced 400 invalid_grant responses once OpenCode tried to refresh an existing token.

This keeps API-key creation permission scoped to the console API-key flow, while Claude Pro/Max auth and token refresh use only the Claude Code scopes. `OAUTH_SCOPES` remains as the API-key scope alias for external compatibility.

Verification:
- `bun test src/tests/auth.test.ts src/tests/index.test.ts`
- `bun run build`
- Captured OpenCode through mitmproxy after reauth: `/v1/messages?beta=true` returned 200 and `opencode run "say hello"` returned `Hello`.
