### PR TITLE
Refresh Claude Code request fingerprint

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,8 +22,16 @@ export const OAUTH_SCOPES = [
 export const TOOL_PREFIX = 'mcp_'
 
 export const REQUIRED_BETAS = [
+  'claude-code-20250219',
   'oauth-2025-04-20',
   'interleaved-thinking-2025-05-14',
+  'thinking-token-count-2026-05-13',
+  'context-management-2025-06-27',
+  'prompt-caching-scope-2026-01-05',
+  'mid-conversation-system-2026-04-07',
+  'advisor-tool-2026-03-01',
+  'effort-2025-11-24',
+  'extended-cache-ttl-2025-04-11',
 ]
 
 export const OPENCODE_IDENTITY_PREFIX = 'You are OpenCode'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,10 +40,11 @@ export const CLAUDE_CODE_IDENTITY =
 
 export const CCH_SALT = '59cf53e54c78'
 export const CCH_POSITIONS = [4, 7, 20]
-export const CLAUDE_CODE_VERSION = '2.1.87'
-export const CLAUDE_CODE_ENTRYPOINT = 'sdk-cli'
+export const CLAUDE_CODE_VERSION = '2.1.185'
+export const CLAUDE_CODE_ENTRYPOINT = 'claude-desktop'
 
-export const USER_AGENT = 'claude-cli/2.1.87 (external, cli)'
+export const USER_AGENT =
+  'claude-cli/2.1.185 (external, claude-desktop, agent-sdk/0.3.197)'
 
 /**
  * Anchors that identify paragraphs to remove from the system prompt.

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -146,7 +146,7 @@ exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snaps
   ],
   "system": [
     {
-      "text": "x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=185f8;",
+      "text": "x-anthropic-billing-header: cc_version=2.1.185.1fc; cc_entrypoint=claude-desktop; cch=185f8;",
       "type": "text",
     },
     {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
 import dedent from 'dedent'
 import {
+  CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
+  CLAUDE_CODE_VERSION,
   OPENCODE_IDENTITY_PREFIX,
   REQUIRED_BETAS,
+  USER_AGENT,
 } from '../constants'
 import {
   createStrippedStream,
@@ -124,6 +127,14 @@ describe('mergeBetaHeaders', () => {
 })
 
 describe('setOAuthHeaders', () => {
+  test('uses the Claude Code identity constants captured from v2.1.185', () => {
+    expect(CLAUDE_CODE_VERSION).toBe('2.1.185')
+    expect(CLAUDE_CODE_ENTRYPOINT).toBe('claude-desktop')
+    expect(USER_AGENT).toBe(
+      'claude-cli/2.1.185 (external, claude-desktop, agent-sdk/0.3.197)',
+    )
+  })
+
   test('sets authorization bearer token', () => {
     const headers = new Headers()
     setOAuthHeaders(headers, 'my-token')
@@ -133,7 +144,7 @@ describe('setOAuthHeaders', () => {
   test('sets user-agent', () => {
     const headers = new Headers()
     setOAuthHeaders(headers, 'token')
-    expect(headers.get('user-agent')).toContain('claude-cli')
+    expect(headers.get('user-agent')).toBe(USER_AGENT)
   })
 
   test('removes x-api-key', () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -71,6 +71,21 @@ describe('mergeHeaders', () => {
 })
 
 describe('mergeBetaHeaders', () => {
+  test('matches the Claude Code beta fingerprint captured from v2.1.185', () => {
+    expect(REQUIRED_BETAS).toEqual([
+      'claude-code-20250219',
+      'oauth-2025-04-20',
+      'interleaved-thinking-2025-05-14',
+      'thinking-token-count-2026-05-13',
+      'context-management-2025-06-27',
+      'prompt-caching-scope-2026-01-05',
+      'mid-conversation-system-2026-04-07',
+      'advisor-tool-2026-03-01',
+      'effort-2025-11-24',
+      'extended-cache-ttl-2025-04-11',
+    ])
+  })
+
   test('includes required betas when no incoming betas', () => {
     const headers = new Headers()
     const result = mergeBetaHeaders(headers)


### PR DESCRIPTION
## Summary
- Expands the required Anthropic beta header list to match the Claude Code 2.1.185 capture, including `claude-code-20250219`, `effort-2025-11-24`, and `extended-cache-ttl-2025-04-11`.
- Updates the Claude Code version, entrypoint, and User-Agent constants to match the same 2.1.185 capture.
- Adds coverage for the beta fingerprint, exact identity constants, exact User-Agent, and the updated billing-header snapshot.

## Test plan
- `bun test`
- `bun run types`
- `bun run build`
- `bun run format:check`
- `bun run lint`

Closes #174.
Closes #175.