### PR TITLE
Clarify tool renaming rationale

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,8 +12,9 @@ import {
 
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
- * Claude Code uses PascalCase tool names (e.g. mcp_Bash, mcp_Read);
- * lowercase names (mcp_bash, mcp_read) are flagged as non-Claude-Code clients.
+ * This intentionally differs from OpenCode's lowercase tool names, which were
+ * identified as a classifier signal. It is not a byte-for-byte copy of Claude
+ * Code's built-in or MCP tool naming scheme.
  */
 function prefixName(name: string): string {
   return `${TOOL_PREFIX}${name.charAt(0).toUpperCase()}${name.slice(1)}`


### PR DESCRIPTION
## Summary
- Corrects the tool-renaming comment called out in #176.
- Clarifies that the current `mcp_` + uppercase transform is a workaround for OpenCode lowercase tool names, not a byte-for-byte match for Claude Code built-in or MCP tool naming.

## Test plan
- `bun test`
- `bun run types`
- `bun run build`
- `bun run format:check`
- `bun run lint`

Closes #176.