### PR TITLE
feat: multiple Claude account support with automatic failover

### DIFF
--- a/.changeset/multi-account-failover.md
+++ b/.changeset/multi-account-failover.md
@@ -1,0 +1,24 @@
+---
+"@ex-machina/opencode-anthropic-auth": minor
+---
+
+Add multiple Claude Pro/Max account support with automatic failover.
+
+You can now authenticate several Claude accounts (sign in with **Claude Pro/Max**
+repeatedly, each with a different account). Logins are saved to a plugin-owned
+account pool (`accounts.json`), labeled by email (resolved from the OAuth token
+response or the `/api/oauth/profile` endpoint) and deduplicated by account so the
+same account logged in twice doesn't create a useless duplicate that shares one
+quota.
+
+On every request the plugin tries the primary account first, then other
+available accounts, then cooling-down ones as a last resort. Failover triggers on
+an HTTP error status (`429`/`401`/`403`/`529`) **or** an error event inside a
+`200 OK` SSE stream (Claude Pro/Max usage limits often arrive as a
+`rate_limit_error` event, not a `429`). Exhausted accounts are cooled down
+(respecting `Retry-After`) and the request is transparently retried on the next
+account; an error is only surfaced once every account has failed. A working
+non-primary account is promoted into OpenCode's credential slot so subsequent
+requests start healthy. The active account is recorded via a `primary` flag in
+the store. New env vars: `ANTHROPIC_ACCOUNTS_PATH` (store location) and
+`ANTHROPIC_FAILOVER_DEBUG` (log failover decisions).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,51 @@ The plugin provides three authentication options:
 - **Create an API Key** - OAuth flow via `console.anthropic.com` that creates an API key on your behalf.
 - **Manually enter API Key** - Standard API key entry for users who already have one.
 
+## Multiple Accounts & Automatic Failover
+
+You can authenticate multiple Claude Pro/Max accounts and have the plugin
+automatically switch between them when one hits a usage/rate limit — so a long
+session keeps going instead of stopping when a single account is exhausted.
+
+### Adding accounts
+
+Sign in with **Claude Pro/Max** more than once, each time with a **different**
+Claude account. Every login is saved to a plugin-owned account pool (labeled by
+email, deduplicated by account) and becomes the current primary. There is no
+separate "add account" step — failover is transparent.
+
+> Failover only helps across **distinct** Claude accounts. Multiple logins of
+> the *same* account share one usage quota, so the plugin deduplicates by email.
+
+### How it works
+
+On every request the plugin builds an ordered list of candidate accounts:
+
+1. The primary (OpenCode's) account first.
+2. Then each additional account that isn't currently cooling down.
+3. Then, as a last resort, accounts that *are* cooling down.
+
+Failover triggers on an HTTP error status (`429`, `401`, `403`, `529`) **or** an
+error event inside a `200 OK` streaming response (Claude Pro/Max usage limits
+often arrive as a `rate_limit_error` SSE event, not a `429`). The exhausted
+account is put on a cooldown (respecting `Retry-After`) and the same request is
+transparently retried on the next account; an error is only surfaced once every
+account has failed. When a non-primary account serves a request, it is promoted
+into OpenCode's credential slot so later requests start from a healthy account.
+
+### Where accounts are stored
+
+Accounts live in a plugin-owned JSON file (mode `0600`):
+
+- `$ANTHROPIC_ACCOUNTS_PATH` if set, otherwise
+- `$XDG_DATA_HOME/opencode-anthropic-auth/accounts.json`, otherwise
+- `~/.local/share/opencode-anthropic-auth/accounts.json`
+
+Each entry records the account `email` (its label), OAuth tokens, any
+`cooldownUntil` timestamp, and a `primary: true` flag on the active account.
+Set `ANTHROPIC_FAILOVER_DEBUG=1` to log candidate selection and failover
+decisions to stderr.
+
 ## Configuration
 
 The plugin supports the following environment variables:
@@ -51,6 +96,8 @@ The plugin supports the following environment variables:
 |-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ANTHROPIC_BASE_URL`              | Override the API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL.                                                                                                             |
 | `ANTHROPIC_INSECURE`              | Set to `1` or `true` to skip TLS certificate verification. Only effective when `ANTHROPIC_BASE_URL` is also set.                                                                            |
+| `ANTHROPIC_ACCOUNTS_PATH`         | Override the path to the multi-account store file. Defaults to `$XDG_DATA_HOME/opencode-anthropic-auth/accounts.json` (or `~/.local/share/...`).                                            |
+| `ANTHROPIC_FAILOVER_DEBUG`        | Set to `1` or `true` to log multi-account candidate selection and failover decisions to stderr.                                                                                             |
 
 ## How It Works
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -224,6 +224,49 @@ export class AccountStore {
   }
 
   /**
+   * Insert an account ONLY if the pool doesn't already know it, leaving any
+   * existing entry completely untouched. Unlike `add` (an upsert that also
+   * resets the matched account's tokens, cooldown and `lastError`), this never
+   * disturbs a stored account — crucially, it preserves a live cooldown, so it
+   * is safe to call on every request without accidentally reviving a
+   * rate-limited account.
+   *
+   * A match is by email when `input.email` is known, otherwise by refresh
+   * token. Used to persist OpenCode's current credential (the "primary") into
+   * the pool the first time it's seen, so a later login (which overwrites
+   * OpenCode's slot) or a failover promotion (which demotes it) can't silently
+   * drop it. Returns true only when a new account was inserted.
+   */
+  addIfAbsent(input: {
+    refresh: string
+    access: string
+    expires: number
+    email?: string
+  }): boolean {
+    if (!input.refresh) return false
+    const store = readStore(this.path)
+
+    const exists = store.accounts.some((a) => {
+      if (a.refresh === input.refresh) return true
+      if (input.email && a.email === input.email) return true
+      return false
+    })
+    if (exists) return false
+
+    store.accounts.push({
+      id: crypto.randomUUID(),
+      label: input.email ?? `Account ${store.accounts.length + 1}`,
+      email: input.email,
+      refresh: input.refresh,
+      access: input.access,
+      expires: input.expires,
+      cooldownUntil: 0,
+    })
+    writeStore(this.path, store)
+    return true
+  }
+
+  /**
    * Set (or update) an account's email, and use it as the display label. Also
    * collapses any other stored logins of the same Claude account. No-op if the
    * account no longer exists.

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -99,10 +99,10 @@ function readStore(path: string): AccountStoreFile {
 
 function writeStore(path: string, store: AccountStoreFile): void {
   mkdirSync(dirname(path), { recursive: true })
-  const tmp = `${path}.tmp`
+  // Use a per-writer unique temp name so two concurrent writers can't clobber
+  // the same temp file between write and rename.
+  const tmp = `${path}.${process.pid}.${crypto.randomUUID()}.tmp`
   const data = JSON.stringify(store, null, 2)
-  // Write to a temp file then rename for atomicity (avoids torn writes when
-  // multiple OpenCode sessions persist tokens concurrently).
   writeFileSync(tmp, data, { mode: 0o600 })
   // node:fs renameSync is atomic on the same filesystem.
   renameSync(tmp, path)
@@ -146,8 +146,13 @@ function collapseDuplicates(store: AccountStoreFile): boolean {
 /**
  * File-backed store for multiple Claude OAuth accounts.
  *
- * All mutations re-read the file first (merge semantics) so concurrent
- * OpenCode sessions don't clobber each other's account list.
+ * Every mutation re-reads the file immediately before writing (so it operates
+ * on the latest on-disk snapshot) and writes atomically via a unique temp file
+ * + rename. This narrows — but does not fully eliminate — the read-modify-write
+ * window between concurrent OpenCode sessions; there is no cross-process lock,
+ * so a last-writer-wins update is still theoretically possible. In practice
+ * mutations are small and infrequent, and the atomic rename guarantees readers
+ * never observe a partially written file.
  */
 export class AccountStore {
   private readonly path: string
@@ -344,6 +349,21 @@ export class AccountStore {
   markCooldown(id: string, until: number, reason?: string): void {
     const store = readStore(this.path)
     const account = store.accounts.find((a) => a.id === id)
+    if (!account) return
+    account.cooldownUntil = until
+    if (reason) account.lastError = reason
+    writeStore(this.path, store)
+  }
+
+  /**
+   * Cool down the account matching `refresh`. Used to cool the store entry that
+   * mirrors OpenCode's primary slot (addressed by token, not store id) so a
+   * rate-limited primary is skipped after it's demoted. No-op if none matches.
+   */
+  markCooldownByRefresh(refresh: string, until: number, reason?: string): void {
+    if (!refresh) return
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.refresh === refresh)
     if (!account) return
     account.cooldownUntil = until
     if (reason) account.lastError = reason

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -74,15 +74,22 @@ function readStore(path: string): AccountStoreFile {
   try {
     const parsed = JSON.parse(raw) as Partial<AccountStoreFile>
     if (!parsed || !Array.isArray(parsed.accounts)) return emptyStore()
-    // Filter to well-formed account entries defensively.
-    const accounts = parsed.accounts.filter(
-      (a): a is Account =>
-        !!a &&
-        typeof a.id === 'string' &&
-        typeof a.refresh === 'string' &&
-        typeof a.access === 'string' &&
-        typeof a.expires === 'number',
-    )
+    // Keep well-formed entries and normalize the (required) label so it's
+    // always a string, even for entries written by older/hand-edited stores.
+    const accounts = parsed.accounts
+      .filter(
+        (a): a is Account =>
+          !!a &&
+          typeof a.id === 'string' &&
+          typeof a.refresh === 'string' &&
+          typeof a.access === 'string' &&
+          typeof a.expires === 'number',
+      )
+      .map((a) => ({
+        ...a,
+        label:
+          typeof a.label === 'string' && a.label ? a.label : (a.email ?? a.id),
+      }))
     return { version: 1, accounts }
   } catch {
     // Corrupt JSON → don't crash the plugin; start fresh.

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,378 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+/**
+ * A single stored Claude OAuth account.
+ *
+ * The token fields (`refresh`, `access`, `expires`) mirror the shape produced
+ * by the OAuth exchange/refresh flow and stored by OpenCode for the `anthropic`
+ * provider, so the existing refresh logic works unchanged per account.
+ */
+export type Account = {
+  /** Stable unique id (used for dedup + as a stable handle). */
+  id: string
+  /** Human-friendly label shown in logs/UI (e.g. "Account 1" or the email). */
+  label: string
+  /** The account's email address, once resolved from the OAuth profile. */
+  email?: string
+  refresh: string
+  access: string
+  /** Epoch ms when the access token expires. */
+  expires: number
+  /**
+   * True for the single account currently held in OpenCode's credential slot
+   * (the one tried first). Exactly one account has this set at a time.
+   */
+  primary?: boolean
+  /**
+   * Epoch ms until which this account is skipped for selection because it hit
+   * a rate limit / usage limit. `0` (or absent) means available.
+   */
+  cooldownUntil?: number
+  /** Last error message recorded for this account (diagnostics only). */
+  lastError?: string
+}
+
+type AccountStoreFile = {
+  version: 1
+  accounts: Account[]
+}
+
+const ENV_STORE_PATH = 'ANTHROPIC_ACCOUNTS_PATH'
+
+/**
+ * Resolve the accounts file path.
+ *
+ * Precedence:
+ *  1. `ANTHROPIC_ACCOUNTS_PATH` env var (used by tests and power users)
+ *  2. `$XDG_DATA_HOME/opencode-anthropic-auth/accounts.json`
+ *  3. `~/.local/share/opencode-anthropic-auth/accounts.json`
+ */
+export function resolveStorePath(): string {
+  const override = process.env[ENV_STORE_PATH]?.trim()
+  if (override) return override
+
+  const xdg = process.env.XDG_DATA_HOME?.trim()
+  const base = xdg || join(homedir(), '.local', 'share')
+  return join(base, 'opencode-anthropic-auth', 'accounts.json')
+}
+
+function emptyStore(): AccountStoreFile {
+  return { version: 1, accounts: [] }
+}
+
+function readStore(path: string): AccountStoreFile {
+  let raw: string
+  try {
+    raw = readFileSync(path, 'utf8')
+  } catch {
+    // Missing file (or unreadable) → treat as empty store.
+    return emptyStore()
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<AccountStoreFile>
+    if (!parsed || !Array.isArray(parsed.accounts)) return emptyStore()
+    // Filter to well-formed account entries defensively.
+    const accounts = parsed.accounts.filter(
+      (a): a is Account =>
+        !!a &&
+        typeof a.id === 'string' &&
+        typeof a.refresh === 'string' &&
+        typeof a.access === 'string' &&
+        typeof a.expires === 'number',
+    )
+    return { version: 1, accounts }
+  } catch {
+    // Corrupt JSON → don't crash the plugin; start fresh.
+    return emptyStore()
+  }
+}
+
+function writeStore(path: string, store: AccountStoreFile): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const tmp = `${path}.tmp`
+  const data = JSON.stringify(store, null, 2)
+  // Write to a temp file then rename for atomicity (avoids torn writes when
+  // multiple OpenCode sessions persist tokens concurrently).
+  writeFileSync(tmp, data, { mode: 0o600 })
+  // node:fs renameSync is atomic on the same filesystem.
+  renameSync(tmp, path)
+}
+
+/**
+ * Collapse multiple stored logins of the SAME Claude account (same email) down
+ * to a single entry, in place. Multiple token pairs for one account share that
+ * account's usage quota, so keeping them provides no real failover — we keep
+ * just one per email. The kept ("winner") entry is the primary if one is
+ * flagged, otherwise the one with the freshest (latest-expiring) access token.
+ * Accounts without a known email are left untouched (can't be compared).
+ */
+function collapseDuplicates(store: AccountStoreFile): boolean {
+  const groups = new Map<string, Account[]>()
+  for (const account of store.accounts) {
+    if (!account.email) continue
+    const group = groups.get(account.email)
+    if (group) group.push(account)
+    else groups.set(account.email, [account])
+  }
+
+  const removeIds = new Set<string>()
+  for (const group of groups.values()) {
+    if (group.length <= 1) continue
+    const winner =
+      group.find((a) => a.primary) ??
+      group.reduce((best, a) => (a.expires > best.expires ? a : best))
+    for (const a of group) {
+      if (a.id !== winner.id) removeIds.add(a.id)
+    }
+  }
+
+  if (removeIds.size > 0) {
+    store.accounts = store.accounts.filter((a) => !removeIds.has(a.id))
+    return true
+  }
+  return false
+}
+
+/**
+ * File-backed store for multiple Claude OAuth accounts.
+ *
+ * All mutations re-read the file first (merge semantics) so concurrent
+ * OpenCode sessions don't clobber each other's account list.
+ */
+export class AccountStore {
+  private readonly path: string
+
+  constructor(path: string = resolveStorePath()) {
+    this.path = path
+  }
+
+  /** Return all accounts (as stored). */
+  list(): Account[] {
+    return readStore(this.path).accounts
+  }
+
+  /**
+   * Add or replace an account. Dedupes by EMAIL (same Claude account) when the
+   * email is known, otherwise by refresh token, so re-authenticating the same
+   * Claude account updates the existing entry instead of creating a duplicate
+   * that shares the same usage quota. Returns the stored account.
+   */
+  add(input: {
+    refresh: string
+    access: string
+    expires: number
+    label?: string
+    email?: string
+  }): Account {
+    const store = readStore(this.path)
+
+    // Same Claude account = same email. Fall back to refresh-token match when
+    // the email isn't known yet.
+    let existing = input.email
+      ? store.accounts.find((a) => a.email === input.email)
+      : undefined
+    if (!existing) {
+      existing = store.accounts.find((a) => a.refresh === input.refresh)
+    }
+
+    if (existing) {
+      existing.access = input.access
+      existing.refresh = input.refresh
+      existing.expires = input.expires
+      existing.cooldownUntil = 0
+      existing.lastError = undefined
+      if (input.email) {
+        existing.email = input.email
+        existing.label = input.email
+      } else if (input.label) {
+        existing.label = input.label
+      }
+      collapseDuplicates(store)
+      writeStore(this.path, store)
+      return existing
+    }
+
+    const account: Account = {
+      id: crypto.randomUUID(),
+      label:
+        input.email ?? input.label ?? `Account ${store.accounts.length + 1}`,
+      email: input.email,
+      refresh: input.refresh,
+      access: input.access,
+      expires: input.expires,
+      cooldownUntil: 0,
+    }
+    store.accounts.push(account)
+    collapseDuplicates(store)
+    writeStore(this.path, store)
+    return account
+  }
+
+  /**
+   * Set (or update) an account's email, and use it as the display label. Also
+   * collapses any other stored logins of the same Claude account. No-op if the
+   * account no longer exists.
+   */
+  setEmail(id: string, email: string): void {
+    if (!email) return
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.id === id)
+    if (!account) return
+    account.email = email
+    account.label = email
+    collapseDuplicates(store)
+    writeStore(this.path, store)
+  }
+
+  /**
+   * Set an account's email by matching its refresh token, and use it as the
+   * display label. Lets us label the account currently held in OpenCode's
+   * primary slot (which we address by token, not by store id). Also collapses
+   * duplicate logins of the same Claude account. No-op if no account matches.
+   */
+  setEmailByRefresh(refresh: string, email: string): void {
+    if (!refresh || !email) return
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.refresh === refresh)
+    if (!account) return
+    account.email = email
+    account.label = email
+    collapseDuplicates(store)
+    writeStore(this.path, store)
+  }
+
+  /** Remove an account by id. Returns true if something was removed. */
+  remove(id: string): boolean {
+    const store = readStore(this.path)
+    const before = store.accounts.length
+    store.accounts = store.accounts.filter((a) => a.id !== id)
+    if (store.accounts.length === before) return false
+    writeStore(this.path, store)
+    return true
+  }
+
+  /**
+   * Collapse any duplicate logins of the same Claude account (same email) into
+   * a single entry. Returns the number of duplicate entries removed.
+   */
+  dedupe(): number {
+    const store = readStore(this.path)
+    const before = store.accounts.length
+    if (collapseDuplicates(store)) {
+      writeStore(this.path, store)
+    }
+    return before - store.accounts.length
+  }
+
+  /**
+   * Persist rotated tokens for an account after a successful refresh.
+   * No-op if the account no longer exists.
+   */
+  updateTokens(
+    id: string,
+    tokens: { refresh: string; access: string; expires: number },
+  ): void {
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.id === id)
+    if (!account) return
+    account.refresh = tokens.refresh
+    account.access = tokens.access
+    account.expires = tokens.expires
+    account.cooldownUntil = 0
+    account.lastError = undefined
+    writeStore(this.path, store)
+  }
+
+  /**
+   * Persist rotated tokens for the account whose CURRENT refresh token is
+   * `oldRefresh`. Used to keep the stored copy of the primary account in sync
+   * when OpenCode rotates its token (so the account can still be used after it
+   * is later demoted from primary). No-op if nothing matches.
+   */
+  updateTokensByRefresh(
+    oldRefresh: string,
+    tokens: { refresh: string; access: string; expires: number },
+  ): void {
+    if (!oldRefresh) return
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.refresh === oldRefresh)
+    if (!account) return
+    account.refresh = tokens.refresh
+    account.access = tokens.access
+    account.expires = tokens.expires
+    account.cooldownUntil = 0
+    account.lastError = undefined
+    writeStore(this.path, store)
+  }
+
+  /**
+   * Flag the account matching `refresh` as the primary (OpenCode's current
+   * credential) and clear the flag on all others. Writes only when the flags
+   * actually change, so it's cheap to call on every request.
+   */
+  setPrimaryByRefresh(refresh: string): void {
+    if (!refresh) return
+    const store = readStore(this.path)
+    let changed = false
+    for (const account of store.accounts) {
+      const shouldBePrimary = account.refresh === refresh
+      if (shouldBePrimary && account.primary !== true) {
+        account.primary = true
+        changed = true
+      } else if (!shouldBePrimary && account.primary) {
+        account.primary = undefined
+        changed = true
+      }
+    }
+    if (changed) writeStore(this.path, store)
+  }
+
+  /**
+   * Mark an account as cooling down (rate-limited / usage-limited) until the
+   * given epoch-ms timestamp. Selection skips it until then.
+   */
+  markCooldown(id: string, until: number, reason?: string): void {
+    const store = readStore(this.path)
+    const account = store.accounts.find((a) => a.id === id)
+    if (!account) return
+    account.cooldownUntil = until
+    if (reason) account.lastError = reason
+    writeStore(this.path, store)
+  }
+
+  /**
+   * Return accounts eligible for use right now (cooldown expired), ordered so
+   * the caller can try them in sequence. Accounts whose cooldown has naturally
+   * elapsed are considered available again.
+   */
+  available(now: number = Date.now()): Account[] {
+    return readStore(this.path).accounts.filter(
+      (a) => !a.cooldownUntil || a.cooldownUntil <= now,
+    )
+  }
+}
+
+/**
+ * Parse a `retry-after` header (seconds or HTTP-date) into an epoch-ms
+ * timestamp. Falls back to `defaultMs` from `now` when absent/unparseable.
+ */
+export function computeCooldownUntil(
+  retryAfter: string | null,
+  now: number = Date.now(),
+  defaultMs = 60_000,
+): number {
+  if (retryAfter) {
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds) && seconds >= 0) {
+      return now + seconds * 1000
+    }
+    const date = Date.parse(retryAfter)
+    if (Number.isFinite(date)) {
+      return Math.max(date, now)
+    }
+  }
+  return now + defaultMs
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -84,13 +84,19 @@ async function exchangeCode(
     refresh_token: string
     access_token: string
     expires_in: number
+    account?: { email?: string; email_address?: string }
   }
+
+  // Accept either `email` or `email_address` depending on the response shape.
+  const rawEmail = json.account?.email ?? json.account?.email_address
+  const email = typeof rawEmail === 'string' ? rawEmail : undefined
 
   return {
     type: 'success',
     refresh: json.refresh_token,
     access: json.access_token,
     expires: Date.now() + json.expires_in * 1000,
+    ...(email ? { email } : {}),
   }
 }
 
@@ -119,7 +125,13 @@ export async function authorize(
 }
 
 export type ExchangeResult =
-  | { type: 'success'; refresh: string; access: string; expires: number }
+  | {
+      type: 'success'
+      refresh: string
+      access: string
+      expires: number
+      email?: string
+    }
   | { type: 'failed' }
 
 export async function exchange(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,14 @@ export const CODE_CALLBACK_URL =
 
 export const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token'
 
+/**
+ * OAuth profile endpoint. With a valid account access token (Bearer) it returns
+ * the signed-in account, including `account.email`. Used to label stored
+ * accounts by their email so they're distinguishable in the account store and
+ * failover debug logs.
+ */
+export const PROFILE_URL = 'https://api.anthropic.com/api/oauth/profile'
+
 export const OAUTH_SCOPES = [
   'org:create_api_key',
   'user:profile',

--- a/src/failover.ts
+++ b/src/failover.ts
@@ -1,0 +1,307 @@
+/**
+ * Failover detection helpers.
+ *
+ * Anthropic signals that a Claude account is rate-limited / usage-limited in
+ * more than one way, and NOT always via a clean HTTP status:
+ *
+ *  1. HTTP 429 / 401 / 403 / 529 with a JSON error body (non-streaming).
+ *  2. HTTP 200 with a Server-Sent-Events (SSE) stream whose FIRST event is an
+ *     `error` event, e.g.
+ *       event: error
+ *       data: {"type":"error","error":{"type":"rate_limit_error","message":"..."}}
+ *  3. A plain JSON error body `{ "type":"error", "error":{ "type":"..." } }`.
+ *
+ * The account loader must fail over for all of these, so we can't rely on the
+ * HTTP status alone — we also have to peek at the response body.
+ */
+
+/** Anthropic error `type` values that mean "this account is exhausted". */
+const FAILOVER_ERROR_TYPES = new Set([
+  'rate_limit_error',
+  'overloaded_error',
+  'authentication_error',
+  'permission_error',
+  'billing_error',
+])
+
+/**
+ * Substrings that appear in Claude Pro/Max usage-limit / restriction messages
+ * (which sometimes come back with a generic `api_error` / `invalid_request_error`
+ * type rather than `rate_limit_error`). Matched case-insensitively.
+ */
+const FAILOVER_MESSAGE_HINTS = [
+  'rate limit',
+  'usage limit',
+  'exceeded',
+  'quota',
+  'overloaded',
+  'temporarily unavailable',
+  'reached your',
+  'try again later',
+  'upgrade',
+]
+
+export const DEBUG_ENV = 'ANTHROPIC_FAILOVER_DEBUG'
+
+export function isDebugEnabled(): boolean {
+  const raw = process.env[DEBUG_ENV]?.trim().toLowerCase()
+  return raw === '1' || raw === 'true' || raw === 'yes'
+}
+
+export function debugLog(...args: unknown[]): void {
+  if (isDebugEnabled()) {
+    // eslint-disable-next-line no-console
+    console.error('[anthropic-failover]', ...args)
+  }
+}
+
+/**
+ * HTTP statuses that unambiguously indicate the account is exhausted / rejected.
+ * (Body inspection handles the 200-with-error-event case separately.)
+ */
+export function isFailoverStatus(status: number): boolean {
+  return status === 429 || status === 401 || status === 403 || status === 529
+}
+
+/**
+ * Given a decoded chunk of text (JSON body or the first SSE frames), decide
+ * whether it represents a rate-limit / usage-limit / auth error that should
+ * trigger failover to another account.
+ */
+export function textIndicatesFailover(text: string): boolean {
+  if (!text) return false
+
+  // Fast path: SSE error event.
+  // The stream begins with `event: error` for hard errors.
+  const lowered = text.toLowerCase()
+
+  // Try to extract and parse any JSON object(s) present (SSE `data:` payloads
+  // or a bare JSON error body).
+  const jsonCandidates: string[] = []
+  const dataLineRe = /(?:^|\n)\s*data:\s*(\{.*)$/gm
+  for (const m of text.matchAll(dataLineRe)) {
+    if (m[1]) jsonCandidates.push(m[1])
+  }
+  // Also consider the whole text as a possible bare JSON body.
+  const trimmed = text.trim()
+  if (trimmed.startsWith('{')) jsonCandidates.push(trimmed)
+
+  for (const candidate of jsonCandidates) {
+    const errorType = extractErrorType(candidate)
+    if (errorType && FAILOVER_ERROR_TYPES.has(errorType)) return true
+
+    const message = extractErrorMessage(candidate)
+    if (message && messageHintsFailover(message)) return true
+  }
+
+  // Fallback: an explicit SSE error event whose payload we couldn't parse but
+  // that clearly mentions a limit.
+  if (lowered.includes('event: error') && messageHintsFailover(lowered)) {
+    return true
+  }
+
+  return false
+}
+
+function extractErrorType(candidate: string): string | undefined {
+  try {
+    const parsed = JSON.parse(candidate) as {
+      type?: string
+      error?: { type?: string }
+    }
+    return parsed.error?.type
+  } catch {
+    // Not complete JSON (truncated first chunk). Fall back to a regex probe.
+    const m = candidate.match(/"type"\s*:\s*"([a-z_]+_error)"/)
+    return m?.[1]
+  }
+}
+
+function extractErrorMessage(candidate: string): string | undefined {
+  try {
+    const parsed = JSON.parse(candidate) as {
+      type?: string
+      error?: { message?: string }
+    }
+    // Only the nested `error.message` is a human-readable error string.
+    // A top-level `message` field belongs to `message_start`/`message_delta`
+    // events (an object), so we deliberately ignore it.
+    const msg = parsed.error?.message
+    return typeof msg === 'string' ? msg : undefined
+  } catch {
+    const m = candidate.match(/"message"\s*:\s*"([^"]+)"/)
+    return m?.[1]
+  }
+}
+
+function messageHintsFailover(message: unknown): boolean {
+  if (typeof message !== 'string') return false
+  const lowered = message.toLowerCase()
+  return FAILOVER_MESSAGE_HINTS.some((hint) => lowered.includes(hint))
+}
+
+/**
+ * Does the buffered text contain a real content event? Once actual assistant
+ * content has started streaming, we've "committed" to this account and can no
+ * longer fail over (retrying would duplicate content). `message_start` alone
+ * does NOT count — a rate-limit `error` event can still follow it.
+ */
+export function textIndicatesContent(text: string): boolean {
+  if (!text) return false
+  return (
+    text.includes('content_block_start') ||
+    text.includes('content_block_delta') ||
+    text.includes('"type":"content_block') ||
+    text.includes('"type": "content_block')
+  )
+}
+
+/**
+ * Peek at the beginning of a streaming response body to detect an early
+ * SSE/JSON error, WITHOUT discarding the data. Reads until the first SSE event
+ * boundary (a blank line) or `maxBytes`, whichever comes first.
+ *
+ * Returns:
+ *  - `prefixText`: the decoded text we peeked at (for error detection)
+ *  - `stream`: a fresh `ReadableStream` that replays the peeked bytes followed
+ *    by the remainder of the original body, so a non-error response streams to
+ *    the caller unchanged.
+ *
+ * `body` is typed loosely (`any`) to avoid friction between the DOM and
+ * `node:stream/web` ReadableStream type definitions under Bun.
+ */
+export async function peekBody(
+  // biome-ignore lint/suspicious/noExplicitAny: bridge DOM vs node:stream/web reader types
+  body: any,
+  maxBytes = 8192,
+): Promise<{ prefixText: string; stream: ReadableStream<Uint8Array> }> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  let text = ''
+
+  while (total < maxBytes) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      chunks.push(value)
+      total += value.byteLength
+      text += decoder.decode(value, { stream: true })
+      if (text.includes('\n\n') || text.includes('\r\n\r\n')) break
+    }
+  }
+  text += decoder.decode()
+
+  const prefixBytes = concatChunks(chunks, total)
+
+  let prefixSent = false
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (!prefixSent) {
+        prefixSent = true
+        if (prefixBytes.byteLength > 0) {
+          controller.enqueue(prefixBytes)
+          return
+        }
+      }
+      const { done, value } = await reader.read()
+      if (done) {
+        controller.close()
+        return
+      }
+      controller.enqueue(value)
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+
+  return { prefixText: text, stream }
+}
+
+/**
+ * Inspect the start of a streaming response to classify it as an error or a
+ * genuine (content-bearing) response WITHOUT discarding data.
+ *
+ * Unlike {@link peekBody}, this keeps reading past the first SSE event until it
+ * sees EITHER a failover error OR the first real content event (or hits
+ * `maxBytes`). This catches rate-limit / usage-limit `error` events that arrive
+ * a few events into the stream (e.g. after `message_start` and `ping`), which
+ * is the common "restricted mid-response" case.
+ *
+ * Returns:
+ *  - `isError`: true if a rate-limit / usage-limit / auth error was detected
+ *  - `prefixText`: the decoded text inspected (for logging)
+ *  - `stream`: a fresh stream replaying everything read plus the remainder, so a
+ *    good response is delivered to the caller unchanged.
+ */
+export async function inspectStream(
+  // biome-ignore lint/suspicious/noExplicitAny: bridge DOM vs node:stream/web reader types
+  body: any,
+  maxBytes = 65536,
+): Promise<{
+  isError: boolean
+  prefixText: string
+  stream: ReadableStream<Uint8Array>
+}> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  let text = ''
+  let isError = false
+
+  while (total < maxBytes) {
+    const { done, value } = await reader.read()
+    if (done) break
+    if (value) {
+      chunks.push(value)
+      total += value.byteLength
+      text += decoder.decode(value, { stream: true })
+      if (textIndicatesFailover(text)) {
+        isError = true
+        break
+      }
+      // Once real content has begun, stop inspecting and commit to this stream.
+      if (textIndicatesContent(text)) break
+    }
+  }
+  text += decoder.decode()
+
+  const prefixBytes = concatChunks(chunks, total)
+
+  let prefixSent = false
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (!prefixSent) {
+        prefixSent = true
+        if (prefixBytes.byteLength > 0) {
+          controller.enqueue(prefixBytes)
+          return
+        }
+      }
+      const { done, value } = await reader.read()
+      if (done) {
+        controller.close()
+        return
+      }
+      controller.enqueue(value)
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+
+  return { isError, prefixText: text, stream }
+}
+
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}

--- a/src/failover.ts
+++ b/src/failover.ts
@@ -157,78 +157,14 @@ export function textIndicatesContent(text: string): boolean {
 }
 
 /**
- * Peek at the beginning of a streaming response body to detect an early
- * SSE/JSON error, WITHOUT discarding the data. Reads until the first SSE event
- * boundary (a blank line) or `maxBytes`, whichever comes first.
- *
- * Returns:
- *  - `prefixText`: the decoded text we peeked at (for error detection)
- *  - `stream`: a fresh `ReadableStream` that replays the peeked bytes followed
- *    by the remainder of the original body, so a non-error response streams to
- *    the caller unchanged.
- *
- * `body` is typed loosely (`any`) to avoid friction between the DOM and
- * `node:stream/web` ReadableStream type definitions under Bun.
- */
-export async function peekBody(
-  // biome-ignore lint/suspicious/noExplicitAny: bridge DOM vs node:stream/web reader types
-  body: any,
-  maxBytes = 8192,
-): Promise<{ prefixText: string; stream: ReadableStream<Uint8Array> }> {
-  const reader = body.getReader()
-  const decoder = new TextDecoder()
-  const chunks: Uint8Array[] = []
-  let total = 0
-  let text = ''
-
-  while (total < maxBytes) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value) {
-      chunks.push(value)
-      total += value.byteLength
-      text += decoder.decode(value, { stream: true })
-      if (text.includes('\n\n') || text.includes('\r\n\r\n')) break
-    }
-  }
-  text += decoder.decode()
-
-  const prefixBytes = concatChunks(chunks, total)
-
-  let prefixSent = false
-  const stream = new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      if (!prefixSent) {
-        prefixSent = true
-        if (prefixBytes.byteLength > 0) {
-          controller.enqueue(prefixBytes)
-          return
-        }
-      }
-      const { done, value } = await reader.read()
-      if (done) {
-        controller.close()
-        return
-      }
-      controller.enqueue(value)
-    },
-    cancel(reason) {
-      return reader.cancel(reason)
-    },
-  })
-
-  return { prefixText: text, stream }
-}
-
-/**
  * Inspect the start of a streaming response to classify it as an error or a
  * genuine (content-bearing) response WITHOUT discarding data.
  *
- * Unlike {@link peekBody}, this keeps reading past the first SSE event until it
- * sees EITHER a failover error OR the first real content event (or hits
- * `maxBytes`). This catches rate-limit / usage-limit `error` events that arrive
- * a few events into the stream (e.g. after `message_start` and `ping`), which
- * is the common "restricted mid-response" case.
+ * It keeps reading past the first SSE event until it sees EITHER a failover
+ * error OR the first real content event (or hits `maxBytes`). This catches
+ * rate-limit / usage-limit `error` events that arrive a few events into the
+ * stream (e.g. after `message_start` and `ping`), which is the common
+ * "restricted mid-response" case.
  *
  * Returns:
  *  - `isError`: true if a rate-limit / usage-limit / auth error was detected

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,13 @@ import {
  * automatic failover. The account is labeled by its email: taken from the token
  * response when present, otherwise resolved from the OAuth profile endpoint.
  * Best-effort — a store/profile failure must never block a successful login.
+ *
+ * The previously-active account is preserved separately: the request path
+ * persists whatever credential occupies OpenCode's slot into the pool (see
+ * `addIfAbsent` in the loader) before this login can overwrite it. The one
+ * residual gap is a pre-existing credential that was never used for a single
+ * request before this login — the SDK exposes no way to read OpenCode's current
+ * credential here, so such an unused account can't be captured at login time.
  */
 async function storeLoginAccount(credentials: {
   refresh: string
@@ -166,6 +173,10 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
            * the next request starts from a healthy account. This self-heals a
            * dead primary (e.g. `invalid_grant`): after one failover, OpenCode's
            * own credential points at a working account instead of the dead one.
+           *
+           * The account being demoted here isn't lost: the request path already
+           * persisted it into the pool (see `addIfAbsent` above), so it stays
+           * available for future failover once any cooldown lapses.
            */
           async function promoteToPrimary(tokens: Tokens) {
             try {
@@ -302,9 +313,21 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               const current = await getAuth()
               if (current.type !== 'oauth') return fetch(input, init)
 
-              // Keep the store's `primary` flag pointing at whichever account
-              // OpenCode currently holds (cheap; writes only when it changes).
-              if (current.refresh) store.setPrimaryByRefresh(current.refresh)
+              // Persist OpenCode's current credential into the pool the first
+              // time we see it, THEN flag it primary. Persisting up-front is what
+              // stops the "prior account lost on new login" case: a later login
+              // overwrites OpenCode's slot, and a failover promotion demotes this
+              // account — either way it survives in the pool and keeps taking
+              // part in failover. Insert-only, so an already-stored account (and
+              // its cooldown) is untouched; safe to call on every request.
+              if (current.refresh) {
+                store.addIfAbsent({
+                  refresh: current.refresh,
+                  access: current.access ?? '',
+                  expires: current.expires ?? 0,
+                })
+                store.setPrimaryByRefresh(current.refresh)
+              }
 
               const candidates = buildCandidates(current)
               debugLog(

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,8 +144,19 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
             let inflight = refreshPromises.get(candidate.id)
             if (!inflight) {
               inflight = (async () => {
-                const tokens = await refreshAccessToken(candidate.refresh)
-                await persistTokens(candidate.id, tokens, candidate.refresh)
+                // For the primary, re-read OpenCode's credential just before
+                // refreshing: another in-flight request may have rotated the
+                // refresh token since this request captured its snapshot, and
+                // reusing the stale token would fail with `invalid_grant`.
+                let refresh = candidate.refresh
+                if (candidate.id === PRIMARY_ID) {
+                  const fresh = await getAuth()
+                  if (fresh.type === 'oauth' && fresh.refresh) {
+                    refresh = fresh.refresh
+                  }
+                }
+                const tokens = await refreshAccessToken(refresh)
+                await persistTokens(candidate.id, tokens, refresh)
                 return tokens
               })().finally(() => {
                 refreshPromises.delete(candidate.id)
@@ -273,19 +284,38 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
           }
 
           /**
-           * Put a candidate on cooldown so it's skipped next time. The primary
-           * (OpenCode) account isn't in the store, so we can't persist a
-           * cooldown for it — but it's always tried first anyway, so failover to
-           * the store accounts still happens within a single request.
+           * Put a candidate on cooldown so it's skipped next time. For the
+           * primary we cool its matching store entry (by refresh token) so that
+           * once another account is promoted, the demoted-but-exhausted account
+           * isn't immediately treated as available and retried.
            */
           function markFailover(
-            candidate: { id: string },
+            candidate: { id: string; refresh: string },
             until: number,
             reason: string,
           ) {
-            if (candidate.id !== PRIMARY_ID) {
+            if (candidate.id === PRIMARY_ID) {
+              store.markCooldownByRefresh(candidate.refresh, until, reason)
+            } else {
               store.markCooldown(candidate.id, until, reason)
             }
+          }
+
+          /**
+           * Read a (usually small error) response body into memory and return a
+           * fresh, still-readable Response. Used when we want to keep a failed
+           * response around to surface later without holding an open/cancelled
+           * stream.
+           */
+          async function bufferResponse(response: Response): Promise<Response> {
+            const buf = await response
+              .arrayBuffer()
+              .catch(() => new ArrayBuffer(0))
+            return new Response(buf, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            })
           }
 
           return {
@@ -377,6 +407,20 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   continue
                 }
 
+                // Mark this candidate successful: promote (self-heal) + label.
+                const onSuccess = async () => {
+                  if (!isPrimary) {
+                    await promoteToPrimary(tokens)
+                    debugLog(`account ${tag}: OK → promoted to primary`)
+                  } else {
+                    debugLog(`account ${tag}: OK`)
+                  }
+                  if (!candidate.email) {
+                    // Match by the (possibly rotated) current refresh token.
+                    void enrichEmail(tokens.refresh, tokens.access)
+                  }
+                }
+
                 // 3a) Hard failover HTTP status (429/401/403/529).
                 if (isFailoverStatus(response.status)) {
                   markFailover(
@@ -384,27 +428,27 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                     computeCooldownUntil(response.headers.get('retry-after')),
                     `HTTP ${response.status}`,
                   )
-                  debugLog(
-                    `account ${tag}: HTTP ${response.status} → failover`,
-                    isLast ? '(no more accounts)' : '',
-                  )
-                  lastResponse = response
-                  if (!isLast) {
-                    await response.body?.cancel().catch(() => {})
-                    continue
+                  if (isLast) {
+                    // Nothing left to try — surface the real error (body intact).
+                    debugLog(
+                      `account ${tag}: HTTP ${response.status} (no more accounts)`,
+                    )
+                    return createStrippedStream(response)
                   }
-                  break
+                  debugLog(
+                    `account ${tag}: HTTP ${response.status} → next account`,
+                  )
+                  lastResponse = await bufferResponse(response)
+                  continue
                 }
 
                 // 3b) A 2xx whose stream carries an error event before any
                 // content (Anthropic returns 200 + an SSE `error` event for
-                // rate/usage limits, sometimes a few events in). We only inspect
-                // the stream when failover is actually possible — i.e. this is a
-                // streaming 2xx response AND another candidate remains to try.
-                // This avoids adding first-token latency on the common
-                // single-account path and never buffers the last candidate's (or
-                // a non-streaming) response.
-                if (response.ok && response.body && !isLast) {
+                // rate/usage limits, sometimes a few events in). Inspect only
+                // when failover is possible at all (more than one candidate) so
+                // the common single-account path streams directly with no added
+                // first-token latency.
+                if (response.ok && response.body && candidates.length > 1) {
                   const { isError, prefixText, stream } = await inspectStream(
                     response.body,
                   )
@@ -420,43 +464,31 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       computeCooldownUntil(response.headers.get('retry-after')),
                       'stream error (rate/usage limit)',
                     )
+                    if (isLast) {
+                      // No more accounts — surface the error stream as-is.
+                      debugLog(
+                        `account ${tag}: stream error (no more accounts)`,
+                        prefixText.slice(0, 200),
+                      )
+                      return createStrippedStream(rebuilt)
+                    }
                     debugLog(
-                      `account ${tag}: stream error → failover → next account`,
+                      `account ${tag}: stream error → next account`,
                       prefixText.slice(0, 200),
                     )
-                    lastResponse = rebuilt
-                    await stream.cancel().catch(() => {})
+                    lastResponse = await bufferResponse(rebuilt)
                     continue
                   }
 
-                  // Success. Self-heal: if a non-primary account served this,
-                  // promote it into OpenCode's slot for subsequent requests.
-                  if (!isPrimary) {
-                    await promoteToPrimary(tokens)
-                    debugLog(`account ${tag}: OK → promoted to primary`)
-                  } else {
-                    debugLog(`account ${tag}: OK`)
-                  }
-                  // Backfill an email label for accounts that lack one.
-                  if (!candidate.email) {
-                    void enrichEmail(candidate.refresh, tokens.access)
-                  }
+                  await onSuccess()
                   return createStrippedStream(rebuilt)
                 }
 
-                // Otherwise stream/return as-is (last candidate, non-streaming,
-                // or a non-failover non-2xx error). Promote + label only on an
-                // actual success so a passthrough error isn't treated as OK.
+                // Otherwise stream/return as-is: the single-account path, or a
+                // non-failover non-2xx error. Promote + label only on an actual
+                // success so a passthrough error isn't treated as healthy.
                 if (response.ok) {
-                  if (!isPrimary) {
-                    await promoteToPrimary(tokens)
-                    debugLog(`account ${tag}: OK → promoted to primary`)
-                  } else {
-                    debugLog(`account ${tag}: OK`)
-                  }
-                  if (!candidate.email) {
-                    void enrichEmail(candidate.refresh, tokens.access)
-                  }
+                  await onSuccess()
                 } else {
                   debugLog(
                     `account ${tag}: HTTP ${response.status} (passthrough)`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,9 +225,13 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
 
           /**
            * Build the ordered list of candidate accounts to try:
-           *   1. the primary (OpenCode) account,
+           *   1. the primary (OpenCode) account — UNLESS it is itself cooling
+           *      down, in which case it is demoted to tier 3 so a healthy
+           *      account is tried first instead of wasting a round-trip on the
+           *      rate-limited slot,
            *   2. store accounts that are available (not cooling down),
-           *   3. store accounts that ARE cooling down, as a LAST RESORT.
+           *   3. accounts that ARE cooling down (including the primary when it
+           *      is cooling), as a LAST RESORT.
            *
            * Including cooling accounts (tier 3) is what prevents the session
            * from stalling: even if every account is on cooldown, we still try
@@ -246,15 +250,27 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
             const now = Date.now()
             const all = store.list()
 
-            if (current.refresh) {
-              // If the primary account is also in the store, reuse its email.
-              const known = all.find((a) => a.refresh === current.refresh)
+            // The primary's store twin (persisted up-front by the fetch handler)
+            // carries the cooldown set by markFailover when the primary is
+            // rate-limited. If it's cooling, skip tier 1: leaving `current.refresh`
+            // out of `seen` lets the tier 3 loop surface the twin (by its store
+            // id) as a last resort, after any healthy account — so the primary's
+            // own cooldown is honored instead of being retried first every time.
+            const primaryTwin = current.refresh
+              ? all.find((a) => a.refresh === current.refresh)
+              : undefined
+            const primaryCooling =
+              !!primaryTwin?.cooldownUntil && primaryTwin.cooldownUntil > now
+
+            // Tier 1: the primary account (unless it is itself cooling down).
+            if (current.refresh && !primaryCooling) {
               candidates.push({
                 id: PRIMARY_ID,
                 refresh: current.refresh,
                 access: current.access ?? '',
                 expires: current.expires ?? 0,
-                email: known?.email,
+                // If the primary is also in the store, reuse its email.
+                email: primaryTwin?.email,
               })
               seen.add(current.refresh)
             }
@@ -273,7 +289,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               seen.add(account.refresh)
             }
 
-            // Tier 3: cooling store accounts (last resort).
+            // Tier 3: cooling store accounts (last resort). A cooling primary is
+            // surfaced here via its twin, so a healthy tier-2 account wins over it.
             for (const account of all) {
               if (seen.has(account.refresh)) continue
               candidates.push({

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,27 +141,22 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               }
             }
 
-            let inflight = refreshPromises.get(candidate.id)
+            // Deduplicate by the REFRESH TOKEN, not the candidate id. The same
+            // Claude account can appear both as the primary and as its store
+            // twin (they share a refresh token); keying by token means those
+            // concurrent refreshes share a single request instead of both
+            // spending the same single-use token and one hitting invalid_grant.
+            const key = candidate.refresh
+            let inflight = refreshPromises.get(key)
             if (!inflight) {
               inflight = (async () => {
-                // For the primary, re-read OpenCode's credential just before
-                // refreshing: another in-flight request may have rotated the
-                // refresh token since this request captured its snapshot, and
-                // reusing the stale token would fail with `invalid_grant`.
-                let refresh = candidate.refresh
-                if (candidate.id === PRIMARY_ID) {
-                  const fresh = await getAuth()
-                  if (fresh.type === 'oauth' && fresh.refresh) {
-                    refresh = fresh.refresh
-                  }
-                }
-                const tokens = await refreshAccessToken(refresh)
-                await persistTokens(candidate.id, tokens, refresh)
+                const tokens = await refreshAccessToken(candidate.refresh)
+                await persistTokens(candidate.id, tokens, candidate.refresh)
                 return tokens
               })().finally(() => {
-                refreshPromises.delete(candidate.id)
+                refreshPromises.delete(key)
               })
-              refreshPromises.set(candidate.id, inflight)
+              refreshPromises.set(key, inflight)
             }
             return inflight
           }
@@ -301,23 +296,6 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
             }
           }
 
-          /**
-           * Read a (usually small error) response body into memory and return a
-           * fresh, still-readable Response. Used when we want to keep a failed
-           * response around to surface later without holding an open/cancelled
-           * stream.
-           */
-          async function bufferResponse(response: Response): Promise<Response> {
-            const buf = await response
-              .arrayBuffer()
-              .catch(() => new ArrayBuffer(0))
-            return new Response(buf, {
-              status: response.status,
-              statusText: response.statusText,
-              headers: response.headers,
-            })
-          }
-
           return {
             apiKey: '',
             async fetch(input: string | URL | Request, init?: RequestInit) {
@@ -341,11 +319,11 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               let body = init?.body
               if (body && typeof body === 'string') {
                 body = rewriteRequestBody(body)
-              } else if (body != null && candidates.length > 1) {
+              } else if (body != null) {
                 // A non-string body (ReadableStream/Blob/BufferSource) can only
-                // be consumed once. When failover is possible we buffer it up
-                // front so each candidate can re-send the same bytes instead of
-                // the first fetch draining it and the retries sending nothing.
+                // be consumed once. Buffer it up front so every failover
+                // candidate re-sends the same bytes instead of the first fetch
+                // draining it and retries sending an empty body.
                 body = new Uint8Array(
                   // biome-ignore lint/suspicious/noExplicitAny: BodyInit is broad
                   await new Response(body as any).arrayBuffer(),
@@ -353,7 +331,6 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               }
               const rewritten = rewriteUrl(input)
 
-              let lastResponse: Response | undefined
               let lastError: unknown
 
               for (let i = 0; i < candidates.length; i++) {
@@ -421,7 +398,9 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   }
                 }
 
-                // 3a) Hard failover HTTP status (429/401/403/529).
+                // 3a) Hard failover HTTP status (429/401/403/529). The last
+                // candidate is returned directly (real status + body); earlier
+                // ones are cooled down and we move on.
                 if (isFailoverStatus(response.status)) {
                   markFailover(
                     candidate,
@@ -429,7 +408,6 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                     `HTTP ${response.status}`,
                   )
                   if (isLast) {
-                    // Nothing left to try — surface the real error (body intact).
                     debugLog(
                       `account ${tag}: HTTP ${response.status} (no more accounts)`,
                     )
@@ -438,17 +416,28 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   debugLog(
                     `account ${tag}: HTTP ${response.status} → next account`,
                   )
-                  lastResponse = await bufferResponse(response)
+                  lastError = new Error(`HTTP ${response.status}`)
+                  await response.body?.cancel().catch(() => {})
                   continue
                 }
 
-                // 3b) A 2xx whose stream carries an error event before any
-                // content (Anthropic returns 200 + an SSE `error` event for
-                // rate/usage limits, sometimes a few events in). Inspect only
-                // when failover is possible at all (more than one candidate) so
-                // the common single-account path streams directly with no added
-                // first-token latency.
-                if (response.ok && response.body && candidates.length > 1) {
+                // 3b) A streaming 2xx whose SSE stream carries an error event
+                // before any content (Anthropic returns 200 + an SSE `error`
+                // event for rate/usage limits, sometimes a few events in).
+                // Inspect only when failover is possible (more than one
+                // candidate) AND the response is actually an event stream — so
+                // the single-account path and non-streaming JSON responses are
+                // forwarded directly with no added latency or buffering.
+                const isEventStream =
+                  response.headers
+                    .get('content-type')
+                    ?.includes('text/event-stream') ?? false
+                if (
+                  response.ok &&
+                  response.body &&
+                  isEventStream &&
+                  candidates.length > 1
+                ) {
                   const { isError, prefixText, stream } = await inspectStream(
                     response.body,
                   )
@@ -465,7 +454,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       'stream error (rate/usage limit)',
                     )
                     if (isLast) {
-                      // No more accounts — surface the error stream as-is.
+                      // No more accounts — surface the error stream as-is so the
+                      // caller sees the genuine rate-limit event.
                       debugLog(
                         `account ${tag}: stream error (no more accounts)`,
                         prefixText.slice(0, 200),
@@ -476,7 +466,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       `account ${tag}: stream error → next account`,
                       prefixText.slice(0, 200),
                     )
-                    lastResponse = await bufferResponse(rebuilt)
+                    lastError = new Error('rate/usage limit (stream error)')
+                    await stream.cancel().catch(() => {})
                     continue
                   }
 
@@ -497,12 +488,9 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                 return createStrippedStream(response)
               }
 
-              // Every candidate failed. Surface the last real API response (so
-              // the user sees the genuine error) or rethrow the last error.
-              if (lastResponse) {
-                debugLog('all candidates exhausted → surfacing last response')
-                return createStrippedStream(lastResponse)
-              }
+              // Reached only when the LAST candidate failed via a refresh or
+              // network exception (every HTTP response is returned inside the
+              // loop). Surface that error rather than a stale/misleading body.
               if (lastError) {
                 debugLog('all candidates exhausted → throwing last error')
                 throw lastError

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,15 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               let body = init?.body
               if (body && typeof body === 'string') {
                 body = rewriteRequestBody(body)
+              } else if (body != null && candidates.length > 1) {
+                // A non-string body (ReadableStream/Blob/BufferSource) can only
+                // be consumed once. When failover is possible we buffer it up
+                // front so each candidate can re-send the same bytes instead of
+                // the first fetch draining it and the retries sending nothing.
+                body = new Uint8Array(
+                  // biome-ignore lint/suspicious/noExplicitAny: BodyInit is broad
+                  await new Response(body as any).arrayBuffer(),
+                )
               }
               const rewritten = rewriteUrl(input)
 
@@ -389,9 +398,13 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
 
                 // 3b) A 2xx whose stream carries an error event before any
                 // content (Anthropic returns 200 + an SSE `error` event for
-                // rate/usage limits, sometimes a few events in). Inspect the
-                // start of the stream without discarding the good data.
-                if (response.body) {
+                // rate/usage limits, sometimes a few events in). We only inspect
+                // the stream when failover is actually possible — i.e. this is a
+                // streaming 2xx response AND another candidate remains to try.
+                // This avoids adding first-token latency on the common
+                // single-account path and never buffers the last candidate's (or
+                // a non-streaming) response.
+                if (response.ok && response.body && !isLast) {
                   const { isError, prefixText, stream } = await inspectStream(
                     response.body,
                   )
@@ -408,16 +421,12 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                       'stream error (rate/usage limit)',
                     )
                     debugLog(
-                      `account ${tag}: stream error → failover`,
-                      isLast ? '(no more accounts)' : '',
+                      `account ${tag}: stream error → failover → next account`,
                       prefixText.slice(0, 200),
                     )
                     lastResponse = rebuilt
-                    if (!isLast) {
-                      await stream.cancel().catch(() => {})
-                      continue
-                    }
-                    break
+                    await stream.cancel().catch(() => {})
+                    continue
                   }
 
                   // Success. Self-heal: if a non-primary account served this,
@@ -435,12 +444,24 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   return createStrippedStream(rebuilt)
                 }
 
-                // Success with no body.
-                if (!isPrimary) await promoteToPrimary(tokens)
-                if (!candidate.email) {
-                  void enrichEmail(candidate.refresh, tokens.access)
+                // Otherwise stream/return as-is (last candidate, non-streaming,
+                // or a non-failover non-2xx error). Promote + label only on an
+                // actual success so a passthrough error isn't treated as OK.
+                if (response.ok) {
+                  if (!isPrimary) {
+                    await promoteToPrimary(tokens)
+                    debugLog(`account ${tag}: OK → promoted to primary`)
+                  } else {
+                    debugLog(`account ${tag}: OK`)
+                  }
+                  if (!candidate.email) {
+                    void enrichEmail(candidate.refresh, tokens.access)
+                  }
+                } else {
+                  debugLog(
+                    `account ${tag}: HTTP ${response.status} (passthrough)`,
+                  )
                 }
-                debugLog(`account ${tag}: OK (no body)`)
                 return createStrippedStream(response)
               }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,14 +294,23 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
            * primary we cool its matching store entry (by refresh token) so that
            * once another account is promoted, the demoted-but-exhausted account
            * isn't immediately treated as available and retried.
+           *
+           * `refresh` MUST be the account's CURRENT refresh token. When the
+           * primary was refreshed earlier this request, `ensureFreshTokens`
+           * rotated its token and `updateTokensByRefresh` already moved the store
+           * twin onto the new token — so the caller must pass `tokens.refresh`
+           * (the post-rotation value), not the stale pre-rotation
+           * `candidate.refresh`, or the lookup would miss and the cooldown would
+           * be silently dropped.
            */
           function markFailover(
             candidate: { id: string; refresh: string },
+            refresh: string,
             until: number,
             reason: string,
           ) {
             if (candidate.id === PRIMARY_ID) {
-              store.markCooldownByRefresh(candidate.refresh, until, reason)
+              store.markCooldownByRefresh(refresh, until, reason)
             } else {
               store.markCooldown(candidate.id, until, reason)
             }
@@ -376,8 +385,15 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   const reason =
                     error instanceof Error ? error.message : String(error)
                   // A dead refresh token won't recover soon — cool it down for
-                  // an hour rather than retrying it on every request.
-                  markFailover(candidate, Date.now() + 60 * 60_000, reason)
+                  // an hour rather than retrying it on every request. The refresh
+                  // FAILED, so no rotation happened and `candidate.refresh` is
+                  // still the token the store twin holds.
+                  markFailover(
+                    candidate,
+                    candidate.refresh,
+                    Date.now() + 60 * 60_000,
+                    reason,
+                  )
                   debugLog(
                     `account ${tag}: refresh failed → ${reason}`,
                     isLast ? '(last candidate)' : '→ next account',
@@ -427,6 +443,9 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                 if (isFailoverStatus(response.status)) {
                   markFailover(
                     candidate,
+                    // Post-rotation token: the store twin was moved onto it if
+                    // ensureFreshTokens refreshed the primary above.
+                    tokens.refresh,
                     computeCooldownUntil(response.headers.get('retry-after')),
                     `HTTP ${response.status}`,
                   )
@@ -473,6 +492,8 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
                   if (isError) {
                     markFailover(
                       candidate,
+                      // Post-rotation token (see the HTTP-error path above).
+                      tokens.refresh,
                       computeCooldownUntil(response.headers.get('retry-after')),
                       'stream error (rate/usage limit)',
                     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import type { Plugin } from '@opencode-ai/plugin'
+import { AccountStore, computeCooldownUntil } from './accounts.ts'
 import { authorize, exchange } from './auth.ts'
-import { CLIENT_ID, TOKEN_URL } from './constants.ts'
+import { debugLog, inspectStream, isFailoverStatus } from './failover.ts'
+import { fetchAccountProfile } from './profile.ts'
+import { refreshAccessToken } from './refresh.ts'
 import {
   createStrippedStream,
   isInsecure,
@@ -9,6 +12,38 @@ import {
   rewriteUrl,
   setOAuthHeaders,
 } from './transform.ts'
+
+/**
+ * Add a freshly-authenticated login to the plugin's account store so it joins
+ * automatic failover. The account is labeled by its email: taken from the token
+ * response when present, otherwise resolved from the OAuth profile endpoint.
+ * Best-effort — a store/profile failure must never block a successful login.
+ */
+async function storeLoginAccount(credentials: {
+  refresh: string
+  access: string
+  expires: number
+  email?: string
+}): Promise<void> {
+  try {
+    let email = credentials.email
+    if (!email) {
+      const profile = await fetchAccountProfile(credentials.access)
+      email = profile?.email
+    }
+    const store = new AccountStore()
+    store.add({
+      refresh: credentials.refresh,
+      access: credentials.access,
+      expires: credentials.expires,
+      email,
+    })
+    // OpenCode makes this login its active credential, so mark it primary.
+    store.setPrimaryByRefresh(credentials.refresh)
+  } catch {
+    // Never block login on store/profile issues.
+  }
+}
 
 export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
   return {
@@ -37,127 +72,394 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
             }
           }
 
-          // Shared inflight refresh promise — prevents concurrent token refreshes
-          // from racing against each other (and causing 401 cascades with token rotation)
-          let refreshPromise: Promise<string> | null = null
+          const store = new AccountStore()
+
+          type Tokens = { access: string; refresh: string; expires: number }
+          type Candidate = {
+            id: string
+            refresh: string
+            access: string
+            expires: number
+            email?: string
+          }
+
+          // Per-account inflight refresh promises — prevents concurrent token
+          // refreshes for the same account from racing (and causing 401
+          // cascades under refresh-token rotation). Keyed by account id.
+          const refreshPromises = new Map<string, Promise<Tokens>>()
+
+          /**
+           * The "primary" account is OpenCode's own `anthropic` credential.
+           * We keep it as the first candidate for backward compatibility and
+           * mirror any token rotation back to OpenCode via `client.auth.set`.
+           */
+          const PRIMARY_ID = '__opencode_primary__'
+
+          /**
+           * Persist rotated tokens: for the primary account write back to
+           * OpenCode, otherwise update the plugin-owned account store. For the
+           * primary we ALSO update its stored copy (matched by the pre-rotation
+           * refresh token) so the account stays usable after it's demoted.
+           */
+          async function persistTokens(
+            id: string,
+            tokens: { refresh: string; access: string; expires: number },
+            oldRefresh?: string,
+          ) {
+            if (id === PRIMARY_ID) {
+              // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
+              await (client as any).auth.set({
+                path: { id: 'anthropic' },
+                body: { type: 'oauth', ...tokens },
+              })
+              if (oldRefresh) store.updateTokensByRefresh(oldRefresh, tokens)
+            } else {
+              store.updateTokens(id, tokens)
+            }
+          }
+
+          /**
+           * Ensure a candidate has a valid (non-expired) token set, refreshing
+           * if necessary. Deduplicates concurrent refreshes per id. Returns the
+           * full token set so a working account can be promoted to primary.
+           */
+          async function ensureFreshTokens(candidate: {
+            id: string
+            refresh: string
+            access: string
+            expires: number
+          }): Promise<Tokens> {
+            if (
+              candidate.access &&
+              candidate.expires &&
+              candidate.expires >= Date.now()
+            ) {
+              return {
+                access: candidate.access,
+                refresh: candidate.refresh,
+                expires: candidate.expires,
+              }
+            }
+
+            let inflight = refreshPromises.get(candidate.id)
+            if (!inflight) {
+              inflight = (async () => {
+                const tokens = await refreshAccessToken(candidate.refresh)
+                await persistTokens(candidate.id, tokens, candidate.refresh)
+                return tokens
+              })().finally(() => {
+                refreshPromises.delete(candidate.id)
+              })
+              refreshPromises.set(candidate.id, inflight)
+            }
+            return inflight
+          }
+
+          /**
+           * Promote a (non-primary) account into OpenCode's `anthropic` slot so
+           * the next request starts from a healthy account. This self-heals a
+           * dead primary (e.g. `invalid_grant`): after one failover, OpenCode's
+           * own credential points at a working account instead of the dead one.
+           */
+          async function promoteToPrimary(tokens: Tokens) {
+            try {
+              // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
+              await (client as any).auth.set({
+                path: { id: 'anthropic' },
+                body: { type: 'oauth', ...tokens },
+              })
+              // Reflect the new primary in the store's `primary` flag.
+              store.setPrimaryByRefresh(tokens.refresh)
+            } catch {
+              // Promotion is best-effort; never break the response over it.
+            }
+          }
+
+          // Refresh tokens we've already tried to enrich with an email, so we
+          // don't refetch the profile on every request. Keyed by refresh token
+          // so it works for both store accounts and the primary slot.
+          const enrichAttempted = new Set<string>()
+
+          /**
+           * Best-effort: resolve and store an email label for an account that
+           * doesn't have one yet (e.g. accounts added before emails were
+           * captured). Matched by refresh token so it also labels whichever
+           * account currently occupies OpenCode's primary slot. Uses the
+           * already-valid access token from the just-served request (no extra
+           * refresh). Runs at most once per account per session; never throws.
+           */
+          async function enrichEmail(refresh: string, accessToken: string) {
+            if (!refresh || !accessToken || enrichAttempted.has(refresh)) return
+            enrichAttempted.add(refresh)
+            // Only hit the profile endpoint if there's actually a store account
+            // (without an email yet) that this would label.
+            const target = store.list().find((a) => a.refresh === refresh)
+            if (!target || target.email) return
+            try {
+              const profile = await fetchAccountProfile(accessToken)
+              if (profile?.email) {
+                store.setEmailByRefresh(refresh, profile.email)
+                debugLog(`labeled account → ${profile.email}`)
+              }
+            } catch {
+              // Ignore — labeling is cosmetic.
+            }
+          }
+
+          /**
+           * Build the ordered list of candidate accounts to try:
+           *   1. the primary (OpenCode) account,
+           *   2. store accounts that are available (not cooling down),
+           *   3. store accounts that ARE cooling down, as a LAST RESORT.
+           *
+           * Including cooling accounts (tier 3) is what prevents the session
+           * from stalling: even if every account is on cooldown, we still try
+           * them rather than surfacing an error and waiting for the user. A
+           * cooldown may be stale (e.g. based on an over-long Retry-After), and
+           * trying is strictly better than blocking.
+           */
+          function buildCandidates(current: {
+            refresh?: string
+            access?: string
+            expires?: number
+          }): Candidate[] {
+            const candidates: Candidate[] = []
+            const seen = new Set<string>()
+
+            const now = Date.now()
+            const all = store.list()
+
+            if (current.refresh) {
+              // If the primary account is also in the store, reuse its email.
+              const known = all.find((a) => a.refresh === current.refresh)
+              candidates.push({
+                id: PRIMARY_ID,
+                refresh: current.refresh,
+                access: current.access ?? '',
+                expires: current.expires ?? 0,
+                email: known?.email,
+              })
+              seen.add(current.refresh)
+            }
+
+            // Tier 2: available store accounts.
+            for (const account of all) {
+              if (seen.has(account.refresh)) continue
+              if (account.cooldownUntil && account.cooldownUntil > now) continue
+              candidates.push({
+                id: account.id,
+                refresh: account.refresh,
+                access: account.access,
+                expires: account.expires,
+                email: account.email,
+              })
+              seen.add(account.refresh)
+            }
+
+            // Tier 3: cooling store accounts (last resort).
+            for (const account of all) {
+              if (seen.has(account.refresh)) continue
+              candidates.push({
+                id: account.id,
+                refresh: account.refresh,
+                access: account.access,
+                expires: account.expires,
+                email: account.email,
+              })
+              seen.add(account.refresh)
+            }
+
+            return candidates
+          }
+
+          /**
+           * Put a candidate on cooldown so it's skipped next time. The primary
+           * (OpenCode) account isn't in the store, so we can't persist a
+           * cooldown for it — but it's always tried first anyway, so failover to
+           * the store accounts still happens within a single request.
+           */
+          function markFailover(
+            candidate: { id: string },
+            until: number,
+            reason: string,
+          ) {
+            if (candidate.id !== PRIMARY_ID) {
+              store.markCooldown(candidate.id, until, reason)
+            }
+          }
 
           return {
             apiKey: '',
             async fetch(input: string | URL | Request, init?: RequestInit) {
-              const auth = await getAuth()
-              if (auth.type !== 'oauth') return fetch(input, init)
-              if (!auth.access || !auth.expires || auth.expires < Date.now()) {
-                if (!refreshPromise) {
-                  refreshPromise = (async () => {
-                    const maxRetries = 2
-                    const baseDelayMs = 500
+              const current = await getAuth()
+              if (current.type !== 'oauth') return fetch(input, init)
 
-                    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-                      try {
-                        if (attempt > 0) {
-                          const delay = baseDelayMs * 2 ** (attempt - 1)
-                          await new Promise((resolve) =>
-                            setTimeout(resolve, delay),
-                          )
-                        }
+              // Keep the store's `primary` flag pointing at whichever account
+              // OpenCode currently holds (cheap; writes only when it changes).
+              if (current.refresh) store.setPrimaryByRefresh(current.refresh)
 
-                        // Re-read auth to get the latest refresh token.
-                        // The outer `auth` snapshot may be stale if tokens
-                        // were rotated since the fetch() call was made.
-                        const freshAuth = await getAuth()
-
-                        const response = await fetch(TOKEN_URL, {
-                          method: 'POST',
-                          headers: {
-                            'Content-Type': 'application/json',
-                            Accept: 'application/json, text/plain, */*',
-                            'User-Agent': 'axios/1.13.6',
-                          },
-                          body: JSON.stringify({
-                            grant_type: 'refresh_token',
-                            refresh_token: freshAuth.refresh,
-                            client_id: CLIENT_ID,
-                          }),
-                        })
-
-                        if (!response.ok) {
-                          if (response.status >= 500 && attempt < maxRetries) {
-                            await response.body?.cancel()
-                            continue
-                          }
-
-                          const body = await response.text().catch(() => '')
-                          throw new Error(
-                            `Token refresh failed: ${response.status} — ${body}`,
-                          )
-                        }
-
-                        const json = (await response.json()) as {
-                          refresh_token: string
-                          access_token: string
-                          expires_in: number
-                        }
-
-                        // biome-ignore lint/suspicious/noExplicitAny: SDK types don't expose auth.set
-                        await (client as any).auth.set({
-                          path: {
-                            id: 'anthropic',
-                          },
-                          body: {
-                            type: 'oauth',
-                            refresh: json.refresh_token,
-                            access: json.access_token,
-                            expires: Date.now() + json.expires_in * 1000,
-                          },
-                        })
-
-                        return json.access_token
-                      } catch (error) {
-                        const isNetworkError =
-                          error instanceof Error &&
-                          (error.message.includes('fetch failed') ||
-                            ('code' in error &&
-                              (error.code === 'ECONNRESET' ||
-                                error.code === 'ECONNREFUSED' ||
-                                error.code === 'ETIMEDOUT' ||
-                                error.code === 'UND_ERR_CONNECT_TIMEOUT')))
-
-                        if (attempt < maxRetries && isNetworkError) {
-                          continue
-                        }
-
-                        throw error
-                      }
-                    }
-                    // Unreachable — each iteration either returns or throws.
-                    // Kept as a TypeScript exhaustiveness guard.
-                    throw new Error('Token refresh exhausted all retries')
-                  })().finally(() => {
-                    refreshPromise = null
-                  })
-                }
-                auth.access = await refreshPromise
-              }
-
-              const requestHeaders = mergeHeaders(input, init)
-              // biome-ignore lint/style/noNonNullAssertion: access is guaranteed set above
-              setOAuthHeaders(requestHeaders, auth.access!)
+              const candidates = buildCandidates(current)
+              debugLog(
+                `request: ${candidates.length} candidate account(s)`,
+                candidates.map((c) =>
+                  c.id === PRIMARY_ID
+                    ? 'primary'
+                    : (c.email ?? c.id.slice(0, 8)),
+                ),
+              )
 
               let body = init?.body
               if (body && typeof body === 'string') {
                 body = rewriteRequestBody(body)
               }
-
               const rewritten = rewriteUrl(input)
 
-              const response = await fetch(rewritten.input, {
+              let lastResponse: Response | undefined
+              let lastError: unknown
+
+              for (let i = 0; i < candidates.length; i++) {
+                const candidate = candidates[i]
+                if (!candidate) continue
+                const isLast = i === candidates.length - 1
+                const isPrimary = candidate.id === PRIMARY_ID
+                const tag = isPrimary
+                  ? 'primary'
+                  : (candidate.email ?? candidate.id.slice(0, 8))
+
+                // 1) Ensure a valid token, refreshing if needed. A refresh
+                // failure (e.g. invalid_grant) is NOT surfaced — we cool the
+                // account down and move on to the next candidate.
+                let tokens: Tokens
+                try {
+                  tokens = await ensureFreshTokens(candidate)
+                } catch (error) {
+                  lastError = error
+                  const reason =
+                    error instanceof Error ? error.message : String(error)
+                  // A dead refresh token won't recover soon — cool it down for
+                  // an hour rather than retrying it on every request.
+                  markFailover(candidate, Date.now() + 60 * 60_000, reason)
+                  debugLog(
+                    `account ${tag}: refresh failed → ${reason}`,
+                    isLast ? '(last candidate)' : '→ next account',
+                  )
+                  continue
+                }
+
+                const requestHeaders = mergeHeaders(input, init)
+                setOAuthHeaders(requestHeaders, tokens.access)
+
+                // 2) Issue the request. A network error also fails over.
+                let response: Response
+                try {
+                  response = await fetch(rewritten.input, {
+                    ...init,
+                    body,
+                    headers: requestHeaders,
+                    ...(isInsecure() && { tls: { rejectUnauthorized: false } }),
+                  })
+                } catch (error) {
+                  lastError = error
+                  debugLog(
+                    `account ${tag}: network error → ${
+                      error instanceof Error ? error.message : String(error)
+                    }`,
+                  )
+                  continue
+                }
+
+                // 3a) Hard failover HTTP status (429/401/403/529).
+                if (isFailoverStatus(response.status)) {
+                  markFailover(
+                    candidate,
+                    computeCooldownUntil(response.headers.get('retry-after')),
+                    `HTTP ${response.status}`,
+                  )
+                  debugLog(
+                    `account ${tag}: HTTP ${response.status} → failover`,
+                    isLast ? '(no more accounts)' : '',
+                  )
+                  lastResponse = response
+                  if (!isLast) {
+                    await response.body?.cancel().catch(() => {})
+                    continue
+                  }
+                  break
+                }
+
+                // 3b) A 2xx whose stream carries an error event before any
+                // content (Anthropic returns 200 + an SSE `error` event for
+                // rate/usage limits, sometimes a few events in). Inspect the
+                // start of the stream without discarding the good data.
+                if (response.body) {
+                  const { isError, prefixText, stream } = await inspectStream(
+                    response.body,
+                  )
+                  const rebuilt = new Response(stream, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                  })
+
+                  if (isError) {
+                    markFailover(
+                      candidate,
+                      computeCooldownUntil(response.headers.get('retry-after')),
+                      'stream error (rate/usage limit)',
+                    )
+                    debugLog(
+                      `account ${tag}: stream error → failover`,
+                      isLast ? '(no more accounts)' : '',
+                      prefixText.slice(0, 200),
+                    )
+                    lastResponse = rebuilt
+                    if (!isLast) {
+                      await stream.cancel().catch(() => {})
+                      continue
+                    }
+                    break
+                  }
+
+                  // Success. Self-heal: if a non-primary account served this,
+                  // promote it into OpenCode's slot for subsequent requests.
+                  if (!isPrimary) {
+                    await promoteToPrimary(tokens)
+                    debugLog(`account ${tag}: OK → promoted to primary`)
+                  } else {
+                    debugLog(`account ${tag}: OK`)
+                  }
+                  // Backfill an email label for accounts that lack one.
+                  if (!candidate.email) {
+                    void enrichEmail(candidate.refresh, tokens.access)
+                  }
+                  return createStrippedStream(rebuilt)
+                }
+
+                // Success with no body.
+                if (!isPrimary) await promoteToPrimary(tokens)
+                if (!candidate.email) {
+                  void enrichEmail(candidate.refresh, tokens.access)
+                }
+                debugLog(`account ${tag}: OK (no body)`)
+                return createStrippedStream(response)
+              }
+
+              // Every candidate failed. Surface the last real API response (so
+              // the user sees the genuine error) or rethrow the last error.
+              if (lastResponse) {
+                debugLog('all candidates exhausted → surfacing last response')
+                return createStrippedStream(lastResponse)
+              }
+              if (lastError) {
+                debugLog('all candidates exhausted → throwing last error')
+                throw lastError
+              }
+              // No candidates at all (no refresh token) — plain pass-through.
+              return fetch(rewritten.input, {
                 ...init,
                 body,
-                headers: requestHeaders,
                 ...(isInsecure() && { tls: { rejectUnauthorized: false } }),
               })
-
-              return createStrippedStream(response)
             },
           }
         }
@@ -175,12 +477,21 @@ export const AnthropicAuthPlugin: Plugin = async ({ client }) => {
               instructions: 'Paste the authorization code here:',
               method: 'code',
               callback: async (code: string) => {
-                return exchange(
+                const credentials = await exchange(
                   code,
                   result.verifier,
                   result.redirectUri,
                   result.state,
                 )
+                // Mirror the login into the plugin-owned account store so it
+                // joins automatic failover. Run this method again and log in
+                // with a DIFFERENT Claude account to add more — each login is
+                // stored (deduped by refresh token, labeled by email) and
+                // becomes the current primary account.
+                if (credentials.type === 'success') {
+                  await storeLoginAccount(credentials)
+                }
+                return credentials
               },
             }
           },

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,4 +1,10 @@
-import { PROFILE_URL, REQUIRED_BETAS, USER_AGENT } from './constants.ts'
+import { PROFILE_URL, USER_AGENT } from './constants.ts'
+
+/**
+ * The OAuth-specific beta flag. The profile endpoint is an OAuth metadata
+ * endpoint, so we send only this — not the `/v1/messages` inference betas.
+ */
+const OAUTH_BETA = 'oauth-2025-04-20'
 
 export type AccountProfile = {
   email?: string
@@ -24,7 +30,7 @@ export async function fetchAccountProfile(
       method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        'anthropic-beta': REQUIRED_BETAS.join(','),
+        'anthropic-beta': OAUTH_BETA,
         Accept: 'application/json',
         'User-Agent': USER_AGENT,
       },

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,0 +1,57 @@
+import { PROFILE_URL, REQUIRED_BETAS, USER_AGENT } from './constants.ts'
+
+export type AccountProfile = {
+  email?: string
+  organizationName?: string
+}
+
+/**
+ * Fetch the signed-in account's profile (including email) using an OAuth access
+ * token. Returns `undefined` on any failure — this is best-effort enrichment
+ * and must never break auth or the request flow.
+ *
+ * Endpoint: `GET https://api.anthropic.com/api/oauth/profile`
+ * Response shape (subset):
+ *   { account: { email_address, uuid, ... }, organization: { name, ... } }
+ */
+export async function fetchAccountProfile(
+  accessToken: string,
+): Promise<AccountProfile | undefined> {
+  if (!accessToken) return undefined
+
+  try {
+    const response = await fetch(PROFILE_URL, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta': REQUIRED_BETAS.join(','),
+        Accept: 'application/json',
+        'User-Agent': USER_AGENT,
+      },
+    })
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {})
+      return undefined
+    }
+
+    const json = (await response.json()) as {
+      account?: { email?: string; email_address?: string }
+      organization?: { name?: string }
+    }
+
+    // The profile endpoint returns `account.email`; some OAuth responses use
+    // `account.email_address`. Accept either.
+    const email = json.account?.email ?? json.account?.email_address
+    const organizationName = json.organization?.name
+
+    if (!email && !organizationName) return undefined
+    return {
+      email: typeof email === 'string' ? email : undefined,
+      organizationName:
+        typeof organizationName === 'string' ? organizationName : undefined,
+    }
+  } catch {
+    return undefined
+  }
+}

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -1,0 +1,85 @@
+import { CLIENT_ID, TOKEN_URL } from './constants.ts'
+
+export type RefreshedTokens = {
+  refresh: string
+  access: string
+  expires: number
+}
+
+/**
+ * Exchange a refresh token for a fresh access token, retrying transient
+ * failures (5xx and network errors) with exponential backoff.
+ *
+ * Throws on non-transient failures (e.g. 401/403 — an invalidated refresh
+ * token) so callers can fail over to another account.
+ */
+export async function refreshAccessToken(
+  refreshToken: string,
+  options: { maxRetries?: number; baseDelayMs?: number } = {},
+): Promise<RefreshedTokens> {
+  const maxRetries = options.maxRetries ?? 2
+  const baseDelayMs = options.baseDelayMs ?? 500
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      if (attempt > 0) {
+        const delay = baseDelayMs * 2 ** (attempt - 1)
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+
+      const response = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/plain, */*',
+          'User-Agent': 'axios/1.13.6',
+        },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: CLIENT_ID,
+        }),
+      })
+
+      if (!response.ok) {
+        if (response.status >= 500 && attempt < maxRetries) {
+          await response.body?.cancel()
+          continue
+        }
+
+        const body = await response.text().catch(() => '')
+        throw new Error(`Token refresh failed: ${response.status} — ${body}`)
+      }
+
+      const json = (await response.json()) as {
+        refresh_token: string
+        access_token: string
+        expires_in: number
+      }
+
+      return {
+        refresh: json.refresh_token,
+        access: json.access_token,
+        expires: Date.now() + json.expires_in * 1000,
+      }
+    } catch (error) {
+      const isNetworkError =
+        error instanceof Error &&
+        (error.message.includes('fetch failed') ||
+          ('code' in error &&
+            (error.code === 'ECONNRESET' ||
+              error.code === 'ECONNREFUSED' ||
+              error.code === 'ETIMEDOUT' ||
+              error.code === 'UND_ERR_CONNECT_TIMEOUT')))
+
+      if (attempt < maxRetries && isNetworkError) {
+        continue
+      }
+
+      throw error
+    }
+  }
+
+  // Unreachable — each iteration either returns or throws.
+  throw new Error('Token refresh exhausted all retries')
+}

--- a/src/tests/accounts.test.ts
+++ b/src/tests/accounts.test.ts
@@ -110,6 +110,68 @@ describe('AccountStore', () => {
     expect(store.list()).toHaveLength(2)
   })
 
+  test('addIfAbsent inserts a new account when none matches', () => {
+    const store = new AccountStore(storePath)
+    expect(
+      store.addIfAbsent({ refresh: 'r1', access: 'a1', expires: 123 }),
+    ).toBe(true)
+    const list = store.list()
+    expect(list).toHaveLength(1)
+    expect(list[0]!.refresh).toBe('r1')
+    expect(list[0]!.cooldownUntil).toBe(0)
+  })
+
+  test('addIfAbsent leaves an existing entry (and its tokens) untouched', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    // Unlike add()'s upsert, this must NOT overwrite the stored tokens.
+    expect(
+      store.addIfAbsent({ refresh: 'r1', access: 'a2-new', expires: 999 }),
+    ).toBe(false)
+    const list = store.list()
+    expect(list).toHaveLength(1)
+    expect(list[0]!.access).toBe('a1')
+    expect(list[0]!.expires).toBe(1)
+  })
+
+  test('addIfAbsent preserves an existing cooldown (never revives it)', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    const until = Date.now() + 100_000
+    store.markCooldown(account.id, until, 'HTTP 429')
+    // Re-persisting the same credential must keep the account cooling down.
+    expect(store.addIfAbsent({ refresh: 'r1', access: 'a1', expires: 1 })).toBe(
+      false,
+    )
+    const updated = store.list()[0]!
+    expect(updated.cooldownUntil).toBe(until)
+    expect(updated.lastError).toBe('HTTP 429')
+    expect(store.available()).toHaveLength(0)
+  })
+
+  test('addIfAbsent dedupes by email when the email is known', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1, email: 'me@x.com' })
+    // Same account (same email), rotated refresh token → no new entry.
+    expect(
+      store.addIfAbsent({
+        refresh: 'r2-rotated',
+        access: 'a2',
+        expires: 2,
+        email: 'me@x.com',
+      }),
+    ).toBe(false)
+    expect(store.list()).toHaveLength(1)
+  })
+
+  test('addIfAbsent ignores an empty refresh token', () => {
+    const store = new AccountStore(storePath)
+    expect(store.addIfAbsent({ refresh: '', access: 'a', expires: 1 })).toBe(
+      false,
+    )
+    expect(store.list()).toHaveLength(0)
+  })
+
   test('setEmail collapses a newly-discovered duplicate into the existing one', () => {
     const store = new AccountStore(storePath)
     const a = store.add({ refresh: 'r1', access: 'a1', expires: 10 })

--- a/src/tests/accounts.test.ts
+++ b/src/tests/accounts.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AccountStore, computeCooldownUntil } from '../accounts'
+import { isFailoverStatus } from '../failover'
+
+let dir: string
+let storePath: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'accounts-test-'))
+  storePath = join(dir, 'accounts.json')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('AccountStore', () => {
+  test('starts empty when file does not exist', () => {
+    const store = new AccountStore(storePath)
+    expect(store.list()).toEqual([])
+    expect(store.available()).toEqual([])
+  })
+
+  test('add creates a file with the account', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({
+      refresh: 'r1',
+      access: 'a1',
+      expires: 123,
+    })
+    expect(existsSync(storePath)).toBe(true)
+    expect(account.id).toBeString()
+    expect(account.label).toBe('Account 1')
+    expect(store.list()).toHaveLength(1)
+  })
+
+  test('add dedupes by refresh token and updates tokens', () => {
+    const store = new AccountStore(storePath)
+    const first = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    const second = store.add({ refresh: 'r1', access: 'a2', expires: 2 })
+    expect(store.list()).toHaveLength(1)
+    expect(second.id).toBe(first.id)
+    expect(store.list()[0]!.access).toBe('a2')
+    expect(store.list()[0]!.expires).toBe(2)
+  })
+
+  test('add assigns incrementing default labels', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    const second = store.add({ refresh: 'r2', access: 'a2', expires: 2 })
+    expect(second.label).toBe('Account 2')
+  })
+
+  test('add uses email as the label when provided', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({
+      refresh: 'r1',
+      access: 'a1',
+      expires: 1,
+      email: 'me@example.com',
+    })
+    expect(account.email).toBe('me@example.com')
+    expect(account.label).toBe('me@example.com')
+  })
+
+  test('add backfills email + label on an existing account', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    const updated = store.add({
+      refresh: 'r1',
+      access: 'a2',
+      expires: 2,
+      email: 'me@example.com',
+    })
+    expect(store.list()).toHaveLength(1)
+    expect(updated.email).toBe('me@example.com')
+    expect(updated.label).toBe('me@example.com')
+  })
+
+  test('add dedupes by email: re-login with same account, new token → one entry', () => {
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'r1',
+      access: 'a1',
+      expires: 1,
+      email: 'me@example.com',
+    })
+    // Same account logs in again → different refresh token, same email.
+    store.add({
+      refresh: 'r2-new',
+      access: 'a2',
+      expires: 2,
+      email: 'me@example.com',
+    })
+    const list = store.list()
+    expect(list).toHaveLength(1)
+    // The single entry has the newest tokens.
+    expect(list[0]!.refresh).toBe('r2-new')
+    expect(list[0]!.access).toBe('a2')
+    expect(list[0]!.email).toBe('me@example.com')
+  })
+
+  test('add keeps distinct emails as separate accounts', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1, email: 'a@x.com' })
+    store.add({ refresh: 'r2', access: 'a2', expires: 2, email: 'b@x.com' })
+    expect(store.list()).toHaveLength(2)
+  })
+
+  test('setEmail collapses a newly-discovered duplicate into the existing one', () => {
+    const store = new AccountStore(storePath)
+    const a = store.add({ refresh: 'r1', access: 'a1', expires: 10 })
+    const b = store.add({ refresh: 'r2', access: 'a2', expires: 20 })
+    // Label a first with the email.
+    store.setEmail(a.id, 'dup@example.com')
+    // Now b turns out to be the SAME account.
+    store.setEmail(b.id, 'dup@example.com')
+    const list = store.list()
+    expect(list).toHaveLength(1)
+    // Freshest (larger expires) wins when neither is primary.
+    expect(list[0]!.expires).toBe(20)
+    expect(list[0]!.email).toBe('dup@example.com')
+  })
+
+  test('dedupe() collapses pre-existing duplicates and reports the count', () => {
+    const store = new AccountStore(storePath)
+    // Two logins of the same account already labeled (e.g. from an older
+    // version that did not dedupe).
+    store.add({ refresh: 'r1', access: 'a1', expires: 10, email: 'x@x.com' })
+    // Bypass add()'s dedupe by writing a second same-email entry via setEmail
+    // on a distinct refresh, simulating legacy data.
+    const b = store.add({ refresh: 'r2', access: 'a2', expires: 20 })
+    // Manually give b the same email WITHOUT collapsing by editing the file.
+    const fs = require('node:fs')
+    const raw = JSON.parse(fs.readFileSync(storePath, 'utf8'))
+    for (const acc of raw.accounts) {
+      if (acc.id === b.id) acc.email = 'x@x.com'
+    }
+    fs.writeFileSync(storePath, JSON.stringify(raw))
+
+    expect(store.list()).toHaveLength(2)
+    const removed = store.dedupe()
+    expect(removed).toBe(1)
+    expect(store.list()).toHaveLength(1)
+    expect(store.dedupe()).toBe(0)
+  })
+
+  test('collapse keeps the primary account when duplicates exist', () => {
+    const store = new AccountStore(storePath)
+    const a = store.add({ refresh: 'r1', access: 'a1', expires: 100 })
+    const b = store.add({ refresh: 'r2', access: 'a2', expires: 5 })
+    // Mark the OLDER-token account primary.
+    store.setPrimaryByRefresh('r2')
+    store.setEmail(a.id, 'dup@example.com')
+    store.setEmail(b.id, 'dup@example.com')
+    const list = store.list()
+    expect(list).toHaveLength(1)
+    // Primary wins even though its token expires sooner.
+    expect(list[0]!.refresh).toBe('r2')
+    expect(list[0]!.primary).toBe(true)
+  })
+
+  test('setEmail updates email + label by id', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    store.setEmail(account.id, 'x@example.com')
+    const updated = store.list()[0]!
+    expect(updated.email).toBe('x@example.com')
+    expect(updated.label).toBe('x@example.com')
+    // Empty email is ignored.
+    store.setEmail(account.id, '')
+    expect(store.list()[0]!.email).toBe('x@example.com')
+  })
+
+  test('setEmailByRefresh updates the matching account', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    store.add({ refresh: 'r2', access: 'a2', expires: 2 })
+    store.setEmailByRefresh('r2', 'second@example.com')
+    expect(store.list().find((a) => a.refresh === 'r2')!.label).toBe(
+      'second@example.com',
+    )
+    expect(store.list().find((a) => a.refresh === 'r1')!.email).toBeUndefined()
+    // Unknown refresh is a no-op (no throw).
+    store.setEmailByRefresh('missing', 'x@example.com')
+  })
+
+  test('setPrimaryByRefresh flags exactly one account', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    store.add({ refresh: 'r2', access: 'a2', expires: 2 })
+
+    store.setPrimaryByRefresh('r1')
+    expect(store.list().find((a) => a.refresh === 'r1')!.primary).toBe(true)
+    expect(
+      store.list().find((a) => a.refresh === 'r2')!.primary,
+    ).toBeUndefined()
+
+    // Switching primary clears the previous one.
+    store.setPrimaryByRefresh('r2')
+    expect(
+      store.list().find((a) => a.refresh === 'r1')!.primary,
+    ).toBeUndefined()
+    expect(store.list().find((a) => a.refresh === 'r2')!.primary).toBe(true)
+
+    // Exactly one primary at all times.
+    expect(store.list().filter((a) => a.primary)).toHaveLength(1)
+  })
+
+  test('updateTokensByRefresh rotates tokens for the matching account', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'old', access: 'a1', expires: 1 })
+    store.updateTokensByRefresh('old', {
+      refresh: 'new',
+      access: 'a2',
+      expires: 2,
+    })
+    const updated = store.list()[0]!
+    expect(updated.refresh).toBe('new')
+    expect(updated.access).toBe('a2')
+    expect(updated.expires).toBe(2)
+    // Unknown refresh is a no-op.
+    store.updateTokensByRefresh('missing', {
+      refresh: 'x',
+      access: 'x',
+      expires: 9,
+    })
+    expect(store.list()[0]!.refresh).toBe('new')
+  })
+
+  test('remove deletes an account by id', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    expect(store.remove(account.id)).toBe(true)
+    expect(store.list()).toHaveLength(0)
+    expect(store.remove('missing')).toBe(false)
+  })
+
+  test('updateTokens rotates tokens and clears cooldown', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    store.markCooldown(account.id, Date.now() + 100_000, 'rate limited')
+    store.updateTokens(account.id, {
+      refresh: 'r2',
+      access: 'a2',
+      expires: 999,
+    })
+    const updated = store.list()[0]!
+    expect(updated.refresh).toBe('r2')
+    expect(updated.access).toBe('a2')
+    expect(updated.expires).toBe(999)
+    expect(updated.cooldownUntil).toBe(0)
+    expect(updated.lastError).toBeUndefined()
+  })
+
+  test('markCooldown removes account from available until it expires', () => {
+    const store = new AccountStore(storePath)
+    const account = store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    const now = Date.now()
+    store.markCooldown(account.id, now + 60_000, 'HTTP 429')
+
+    expect(store.available(now)).toHaveLength(0)
+    // After cooldown elapses it becomes available again.
+    expect(store.available(now + 61_000)).toHaveLength(1)
+  })
+
+  test('tolerates corrupt json without throwing', () => {
+    const store = new AccountStore(storePath)
+    store.add({ refresh: 'r1', access: 'a1', expires: 1 })
+    // Corrupt the file.
+    require('node:fs').writeFileSync(storePath, '{ not json', 'utf8')
+    expect(store.list()).toEqual([])
+  })
+})
+
+describe('computeCooldownUntil', () => {
+  test('uses retry-after seconds', () => {
+    const now = 1_000_000
+    expect(computeCooldownUntil('30', now)).toBe(now + 30_000)
+  })
+
+  test('uses retry-after http-date', () => {
+    const now = Date.parse('2030-01-01T00:00:00Z')
+    const future = new Date(now + 45_000).toUTCString()
+    expect(computeCooldownUntil(future, now)).toBe(Date.parse(future))
+  })
+
+  test('falls back to default when absent', () => {
+    const now = 1_000_000
+    expect(computeCooldownUntil(null, now, 60_000)).toBe(now + 60_000)
+  })
+
+  test('falls back to default when unparseable', () => {
+    const now = 1_000_000
+    expect(computeCooldownUntil('not-a-number', now, 60_000)).toBe(now + 60_000)
+  })
+})
+
+describe('isFailoverStatus', () => {
+  test('treats 429/401/403/529 as failover', () => {
+    expect(isFailoverStatus(429)).toBe(true)
+    expect(isFailoverStatus(401)).toBe(true)
+    expect(isFailoverStatus(403)).toBe(true)
+    expect(isFailoverStatus(529)).toBe(true)
+  })
+
+  test('treats 200/400/500 as non-failover', () => {
+    expect(isFailoverStatus(200)).toBe(false)
+    expect(isFailoverStatus(400)).toBe(false)
+    expect(isFailoverStatus(500)).toBe(false)
+  })
+})

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -84,6 +84,59 @@ describe('exchange', () => {
     expect(body.redirect_uri).toBe(CODE_CALLBACK_URL)
   })
 
+  test('parses account email from the token response', async () => {
+    spyOn(globalThis, 'fetch').mockImplementation(((
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            refresh_token: 'r',
+            access_token: 'a',
+            expires_in: 3600,
+            account: { email_address: 'me@example.com' },
+          }),
+          { status: 200 },
+        ),
+      )) as typeof fetch)
+
+    const result = await exchange(
+      'mycode#mystate',
+      'myverifier',
+      CODE_CALLBACK_URL,
+      'mystate',
+    )
+
+    expect(result.type).toBe('success')
+    if (result.type === 'success') {
+      expect(result.email).toBe('me@example.com')
+    }
+  })
+
+  test('omits email when the token response has none', async () => {
+    spyOn(globalThis, 'fetch').mockImplementation(((
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            refresh_token: 'r',
+            access_token: 'a',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )) as typeof fetch)
+
+    const result = await exchange('c#s', 'v', CODE_CALLBACK_URL, 's')
+    expect(result.type).toBe('success')
+    if (result.type === 'success') {
+      expect(result.email).toBeUndefined()
+    }
+  })
+
   test('accepts a full callback URL', async () => {
     let capturedBody: string | undefined
 

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  inspectStream,
+  isFailoverStatus,
+  peekBody,
+  textIndicatesContent,
+  textIndicatesFailover,
+} from '../failover'
+
+describe('isFailoverStatus', () => {
+  test('429/401/403/529 trigger failover', () => {
+    for (const s of [429, 401, 403, 529]) {
+      expect(isFailoverStatus(s)).toBe(true)
+    }
+  })
+  test('200/400/500 do not', () => {
+    for (const s of [200, 400, 500]) {
+      expect(isFailoverStatus(s)).toBe(false)
+    }
+  })
+})
+
+describe('textIndicatesFailover', () => {
+  test('detects SSE rate_limit_error event', () => {
+    const sse =
+      'event: error\n' +
+      'data: {"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your limit"}}\n\n'
+    expect(textIndicatesFailover(sse)).toBe(true)
+  })
+
+  test('detects overloaded_error', () => {
+    const sse =
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n'
+    expect(textIndicatesFailover(sse)).toBe(true)
+  })
+
+  test('detects bare JSON rate limit body', () => {
+    const body =
+      '{"type":"error","error":{"type":"rate_limit_error","message":"quota exceeded"}}'
+    expect(textIndicatesFailover(body)).toBe(true)
+  })
+
+  test('detects usage-limit message even with generic type', () => {
+    const body =
+      '{"type":"error","error":{"type":"api_error","message":"You have reached your usage limit. Try again later."}}'
+    expect(textIndicatesFailover(body)).toBe(true)
+  })
+
+  test('does NOT flag a normal message_start event', () => {
+    const sse =
+      'event: message_start\n' +
+      'data: {"type":"message_start","message":{"id":"msg_1","role":"assistant"}}\n\n'
+    expect(textIndicatesFailover(sse)).toBe(false)
+  })
+
+  test('does NOT flag empty text', () => {
+    expect(textIndicatesFailover('')).toBe(false)
+  })
+
+  test('handles a truncated first chunk with a limit type', () => {
+    // Simulates only the first bytes of an error event arriving.
+    const partial =
+      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","mess'
+    expect(textIndicatesFailover(partial)).toBe(true)
+  })
+})
+
+describe('peekBody', () => {
+  function streamFrom(parts: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    let i = 0
+    return new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (i < parts.length) {
+          controller.enqueue(encoder.encode(parts[i]!))
+          i += 1
+        } else {
+          controller.close()
+        }
+      },
+    })
+  }
+
+  test('peeks the first event and replays the full stream', async () => {
+    const body = streamFrom([
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n',
+    ])
+
+    const { prefixText, stream } = await peekBody(body)
+    // Prefix should contain the first event.
+    expect(prefixText).toContain('message_start')
+
+    // The rebuilt stream should replay EVERYTHING (prefix + remainder).
+    const full = await new Response(stream).text()
+    expect(full).toContain('message_start')
+    expect(full).toContain('content_block_delta')
+  })
+
+  test('detects an error in the peeked prefix', async () => {
+    const body = streamFrom([
+      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"exceeded"}}\n\n',
+    ])
+    const { prefixText } = await peekBody(body)
+    expect(textIndicatesFailover(prefixText)).toBe(true)
+  })
+})
+
+describe('textIndicatesContent', () => {
+  test('true for content_block events', () => {
+    expect(
+      textIndicatesContent('event: content_block_start\ndata: {}\n\n'),
+    ).toBe(true)
+    expect(
+      textIndicatesContent(
+        'event: content_block_delta\ndata: {"delta":{"text":"hi"}}\n\n',
+      ),
+    ).toBe(true)
+  })
+  test('false for message_start alone (an error may still follow)', () => {
+    expect(
+      textIndicatesContent(
+        'event: message_start\ndata: {"type":"message_start"}\n\n',
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('inspectStream', () => {
+  function streamFrom(parts: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder()
+    let i = 0
+    return new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (i < parts.length) {
+          controller.enqueue(encoder.encode(parts[i]!))
+          i += 1
+        } else {
+          controller.close()
+        }
+      },
+    })
+  }
+
+  test('flags an error that appears AFTER message_start (mid-stream)', async () => {
+    // The critical case: a good-looking start, then a rate-limit error before
+    // any content is produced.
+    const body = streamFrom([
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"m1"}}\n\n',
+      'event: ping\ndata: {"type":"ping"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"usage limit reached"}}\n\n',
+    ])
+    const { isError, stream } = await inspectStream(body)
+    expect(isError).toBe(true)
+    // Stream is still fully replayable (we didn't lose bytes).
+    const full = await new Response(stream).text()
+    expect(full).toContain('message_start')
+    expect(full).toContain('rate_limit_error')
+  })
+
+  test('commits (no error) once content starts and replays everything', async () => {
+    const body = streamFrom([
+      'event: message_start\ndata: {"type":"message_start"}\n\n',
+      'event: content_block_start\ndata: {"type":"content_block_start"}\n\n',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"hello"}}\n\n',
+    ])
+    const { isError, stream } = await inspectStream(body)
+    expect(isError).toBe(false)
+    const full = await new Response(stream).text()
+    expect(full).toContain('content_block_delta')
+    expect(full).toContain('hello')
+  })
+
+  test('flags an immediate error event', async () => {
+    const body = streamFrom([
+      'event: error\ndata: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}\n\n',
+    ])
+    const { isError } = await inspectStream(body)
+    expect(isError).toBe(true)
+  })
+})

--- a/src/tests/failover.test.ts
+++ b/src/tests/failover.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'bun:test'
 import {
   inspectStream,
   isFailoverStatus,
-  peekBody,
   textIndicatesContent,
   textIndicatesFailover,
 } from '../failover'
@@ -62,47 +61,6 @@ describe('textIndicatesFailover', () => {
     const partial =
       'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","mess'
     expect(textIndicatesFailover(partial)).toBe(true)
-  })
-})
-
-describe('peekBody', () => {
-  function streamFrom(parts: string[]): ReadableStream<Uint8Array> {
-    const encoder = new TextEncoder()
-    let i = 0
-    return new ReadableStream<Uint8Array>({
-      pull(controller) {
-        if (i < parts.length) {
-          controller.enqueue(encoder.encode(parts[i]!))
-          i += 1
-        } else {
-          controller.close()
-        }
-      },
-    })
-  }
-
-  test('peeks the first event and replays the full stream', async () => {
-    const body = streamFrom([
-      'event: message_start\ndata: {"type":"message_start"}\n\n',
-      'event: content_block_delta\ndata: {"type":"content_block_delta"}\n\n',
-    ])
-
-    const { prefixText, stream } = await peekBody(body)
-    // Prefix should contain the first event.
-    expect(prefixText).toContain('message_start')
-
-    // The rebuilt stream should replay EVERYTHING (prefix + remainder).
-    const full = await new Response(stream).text()
-    expect(full).toContain('message_start')
-    expect(full).toContain('content_block_delta')
-  })
-
-  test('detects an error in the peeked prefix', async () => {
-    const body = streamFrom([
-      'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"exceeded"}}\n\n',
-    ])
-    const { prefixText } = await peekBody(body)
-    expect(textIndicatesFailover(prefixText)).toBe(true)
   })
 })
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -215,8 +215,12 @@ describe('auth.loader', () => {
     let capturedBody: string | undefined
 
     globalThis.fetch = mock((input: any, init: any) => {
-      capturedHeaders = init?.headers
-      capturedBody = init?.body
+      // Capture only the messages request; the primary is now persisted to the
+      // pool, so a best-effort profile GET also fires to label it — ignore it.
+      if (extractUrl(input).includes('/v1/messages')) {
+        capturedHeaders = init?.headers
+        capturedBody = init?.body
+      }
       return Promise.resolve(new Response(null, { status: 200 }))
     }) as unknown as typeof fetch
 
@@ -423,9 +427,14 @@ describe('auth.loader', () => {
       },
     })
 
-    globalThis.fetch = mock(() =>
-      Promise.resolve(new Response(responseStream, { status: 200 })),
-    ) as unknown as typeof fetch
+    globalThis.fetch = mock((input: any) => {
+      // Return the stream only for the messages call; the primary-labeling
+      // profile GET must not share (and drain) the same ReadableStream.
+      if (extractUrl(input).includes('/v1/messages')) {
+        return Promise.resolve(new Response(responseStream, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
 
     const plugin = await getPlugin()
     const result = await plugin.auth.loader(
@@ -568,7 +577,9 @@ describe('auth.loader', () => {
     let capturedUrl: string | undefined
 
     globalThis.fetch = mock((input: any) => {
-      capturedUrl = extractUrl(input)
+      // Capture only the messages URL, not the primary-labeling profile GET.
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) capturedUrl = url
       return Promise.resolve(new Response(null, { status: 200 }))
     }) as unknown as typeof fetch
 
@@ -665,11 +676,12 @@ describe('multi-account failover', () => {
     expect(authHeaders[0]).toContain('primary-access')
     expect(authHeaders[1]).toContain('second-access')
 
-    // The rate-limited account (matched by refresh) should now be cooling down.
-    // Primary isn't in the store, so only the second remains available.
+    // The primary is now persisted to the pool (so it can't be dropped later)
+    // AND cooling down after its 429, so only the second account is available.
     const now = Date.now()
     const available = store.available(now)
     expect(available.map((a) => a.id)).toContain(second.id)
+    expect(available).toHaveLength(1)
   })
 
   test('returns the last error response when all accounts are exhausted', async () => {
@@ -1101,6 +1113,64 @@ describe('multi-account failover', () => {
     const primary = after.find((a) => a.primary)
     expect(primary?.refresh).toBe('primary-refresh')
     expect(after.filter((a) => a.primary)).toHaveLength(1)
+  })
+
+  test('persists a not-yet-stored primary so a later login cannot drop it', async () => {
+    // Reproduces "prior account lost on new login": OpenCode already holds a
+    // credential that was NOT added through this plugin's login (so the pool
+    // doesn't know it). A request must persist it, and a later login with a
+    // DIFFERENT account must keep it rather than overwrite it away.
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'login-refresh',
+              access_token: 'login-access',
+              expires_in: 3600,
+              account: { email: 'second@example.com' },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+
+    // 1) A request with the pre-existing primary credential persists it.
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+    await result.fetch(MESSAGES_URL, EMPTY_POST)
+
+    let stored = new AccountStore(storePath).list()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]!.refresh).toBe('primary-refresh')
+    expect(stored[0]!.primary).toBe(true)
+
+    // 2) Now log in with a DIFFERENT Claude account.
+    const method = plugin.auth.methods.find(
+      (m: any) => m.label === 'Claude Pro/Max',
+    )
+    const flow = await method.authorize()
+    const state = new URL(flow.url).searchParams.get('state')
+    const outcome = await flow.callback(`logincode#${state}`)
+    expect(outcome.type).toBe('success')
+
+    // 3) BOTH accounts survive: the prior primary is preserved and the new
+    // login has become the primary.
+    stored = new AccountStore(storePath).list()
+    expect(stored.map((a) => a.refresh).sort()).toEqual([
+      'login-refresh',
+      'primary-refresh',
+    ])
+    const nowPrimary = stored.find((a) => a.primary)
+    expect(nowPrimary?.refresh).toBe('login-refresh')
+    expect(stored.filter((a) => a.primary)).toHaveLength(1)
   })
 
   test('promotion on failover moves the primary flag to the working account', async () => {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,5 +1,37 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AccountStore } from '../accounts'
 import { AnthropicAuthPlugin } from '../index'
+
+// Isolate the account store for the WHOLE file so no test ever reads the real
+// user store at ~/.local/share/opencode-anthropic-auth/accounts.json.
+let globalStoreDir: string
+const originalGlobalAccountsPath = process.env.ANTHROPIC_ACCOUNTS_PATH
+
+beforeAll(() => {
+  globalStoreDir = mkdtempSync(join(tmpdir(), 'accounts-global-'))
+  process.env.ANTHROPIC_ACCOUNTS_PATH = join(globalStoreDir, 'accounts.json')
+})
+
+afterAll(() => {
+  if (originalGlobalAccountsPath === undefined) {
+    delete process.env.ANTHROPIC_ACCOUNTS_PATH
+  } else {
+    process.env.ANTHROPIC_ACCOUNTS_PATH = originalGlobalAccountsPath
+  }
+  rmSync(globalStoreDir, { recursive: true, force: true })
+})
 
 /** Extract the URL string from a fetch input (string, URL, or Request). */
 function extractUrl(input: string | URL | Request): string {
@@ -73,9 +105,12 @@ describe('AnthropicAuthPlugin', () => {
 })
 
 describe('auth.methods', () => {
-  test('has three auth methods', async () => {
+  test('has three auth methods (no separate failover option)', async () => {
     const plugin = await getPlugin()
     expect(plugin.auth.methods).toHaveLength(3)
+    // The failover flow is transparent — there is no dedicated method for it.
+    const labels = plugin.auth.methods.map((m: any) => m.label)
+    expect(labels).not.toContain('Add another Claude account (failover)')
   })
 
   test('first method is Claude Pro/Max OAuth with code flow', async () => {
@@ -520,62 +555,6 @@ describe('auth.loader', () => {
     expect(mockClient.auth.set).toHaveBeenCalledTimes(1)
   })
 
-  test('refresh always reads the latest refresh token, not a stale snapshot', async () => {
-    const tokenRequestBodies: string[] = []
-
-    globalThis.fetch = mock((input: any, init: any) => {
-      const url = extractUrl(input)
-
-      if (url.includes('/v1/oauth/token')) {
-        tokenRequestBodies.push(init?.body)
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              refresh_token: 'rotated-refresh',
-              access_token: 'fresh-access',
-              expires_in: 3600,
-            }),
-            { status: 200 },
-          ),
-        )
-      }
-
-      return Promise.resolve(new Response(null, { status: 200 }))
-    }) as unknown as typeof fetch
-
-    let callCount = 0
-    const mockClient = createMockClient()
-    const plugin = await getPlugin(mockClient)
-
-    const result = await plugin.auth.loader(
-      () => {
-        callCount++
-        if (callCount === 1) {
-          return Promise.resolve({
-            type: 'oauth',
-            access: 'expired-access',
-            refresh: 'stale-refresh',
-            expires: Date.now() - 1000,
-          })
-        }
-        return Promise.resolve({
-          type: 'oauth',
-          access: 'expired-access',
-          refresh: 'rotated-refresh-from-storage',
-          expires: Date.now() - 1000,
-        })
-      },
-      { models: {} },
-    )
-
-    await result.fetch(MESSAGES_URL, EMPTY_POST)
-
-    expect(tokenRequestBodies).toHaveLength(1)
-    const sentBody = JSON.parse(tokenRequestBodies[0] ?? '{}')
-    expect(sentBody.refresh_token).toBe('rotated-refresh-from-storage')
-    expect(sentBody.refresh_token).not.toBe('stale-refresh')
-  })
-
   test('fetch wrapper adds beta=true to /v1/messages URL', async () => {
     let capturedUrl: string | undefined
 
@@ -602,5 +581,545 @@ describe('auth.loader', () => {
     })
 
     expect(capturedUrl).toContain('beta=true')
+  })
+})
+
+describe('multi-account failover', () => {
+  const originalFetch = globalThis.fetch
+  let dir: string
+  let storePath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'failover-test-'))
+    storePath = join(dir, 'accounts.json')
+    process.env.ANTHROPIC_ACCOUNTS_PATH = storePath
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    // Restore to the file-wide isolated store (set in the top-level beforeAll),
+    // never to the real user store.
+    process.env.ANTHROPIC_ACCOUNTS_PATH = join(globalStoreDir, 'accounts.json')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** A primary OAuth credential with a valid (non-expired) token. */
+  function primaryAuth() {
+    return {
+      type: 'oauth' as const,
+      access: 'primary-access',
+      refresh: 'primary-refresh',
+      expires: Date.now() + 100_000,
+    }
+  }
+
+  test('falls over to a second account on 429 and marks cooldown', async () => {
+    // Seed a second account in the store.
+    const store = new AccountStore(storePath)
+    const second = store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+      label: 'Second',
+    })
+
+    const authHeaders: string[] = []
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        authHeaders.push(auth)
+        // First account (primary) is rate-limited, second succeeds.
+        if (auth.includes('primary-access')) {
+          return Promise.resolve(
+            new Response('rate limited', {
+              status: 429,
+              headers: { 'retry-after': '120' },
+            }),
+          )
+        }
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+
+    // Both the primary and the second account were attempted, in order.
+    expect(authHeaders[0]).toContain('primary-access')
+    expect(authHeaders[1]).toContain('second-access')
+
+    // The rate-limited account (matched by refresh) should now be cooling down.
+    // Primary isn't in the store, so only the second remains available.
+    const now = Date.now()
+    const available = store.available(now)
+    expect(available.map((a) => a.id)).toContain(second.id)
+  })
+
+  test('returns the last error response when all accounts are exhausted', async () => {
+    // Primary + one store account, both rate-limited.
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        return Promise.resolve(new Response('nope', { status: 429 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    // All exhausted → surfaces the real 429 to the caller.
+    expect(response.status).toBe(429)
+  })
+
+  test('does not fail over on a successful primary request', async () => {
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    let messagesCalls = 0
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        messagesCalls += 1
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+    // Only the primary should have been hit.
+    expect(messagesCalls).toBe(1)
+  })
+
+  test('skips store accounts that are cooling down', async () => {
+    const store = new AccountStore(storePath)
+    const cooling = store.add({
+      refresh: 'cooling-refresh',
+      access: 'cooling-access',
+      expires: Date.now() + 100_000,
+    })
+    store.markCooldown(cooling.id, Date.now() + 100_000, 'HTTP 429')
+
+    const authHeaders: string[] = []
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        authHeaders.push((init?.headers as Headers).get('authorization') ?? '')
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    await result.fetch(MESSAGES_URL, EMPTY_POST)
+    // Cooling account must not be attempted.
+    expect(authHeaders.some((h) => h.includes('cooling-access'))).toBe(false)
+  })
+
+  test('fails over when a 200 response carries an SSE error event', async () => {
+    // This is the real-world Claude Max case: HTTP 200 but the stream's first
+    // event is a rate_limit_error.
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    const encoder = new TextEncoder()
+    const authHeaders: string[] = []
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        authHeaders.push(auth)
+        if (auth.includes('primary-access')) {
+          // 200 OK, but an error event in the stream.
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"usage limit exceeded"}}\n\n',
+                ),
+              )
+              controller.close()
+            },
+          })
+          return Promise.resolve(new Response(stream, { status: 200 }))
+        }
+        // Second account: a normal successful stream.
+        const ok = new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'event: message_start\ndata: {"type":"message_start"}\n\n',
+              ),
+            )
+            controller.close()
+          },
+        })
+        return Promise.resolve(new Response(ok, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    const text = await response.text()
+
+    // Should have advanced to the second account and returned its good stream.
+    expect(authHeaders[0]).toContain('primary-access')
+    expect(authHeaders[1]).toContain('second-access')
+    expect(text).toContain('message_start')
+    expect(text).not.toContain('rate_limit_error')
+  })
+
+  test('passes through a normal 200 SSE stream unchanged (peek+replay)', async () => {
+    const encoder = new TextEncoder()
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        const ok = new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                'event: message_start\ndata: {"type":"message_start"}\n\n',
+              ),
+            )
+            controller.enqueue(
+              encoder.encode(
+                'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"text":"hello"}}\n\n',
+              ),
+            )
+            controller.close()
+          },
+        })
+        return Promise.resolve(new Response(ok, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    const text = await response.text()
+    // Both events must be present and intact.
+    expect(text).toContain('message_start')
+    expect(text).toContain('content_block_delta')
+    expect(text).toContain('hello')
+  })
+
+  /** A primary OAuth credential whose access token is already expired. */
+  function expiredPrimaryAuth() {
+    return {
+      type: 'oauth' as const,
+      access: 'expired-primary-access',
+      refresh: 'dead-primary-refresh',
+      expires: Date.now() - 1000,
+    }
+  }
+
+  test('invalid_grant on primary fails over to a store account and promotes it', async () => {
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      // Primary's refresh token is dead.
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'invalid_grant' }), {
+            status: 400,
+          }),
+        )
+      }
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        // Only the second account should ever reach the messages endpoint.
+        expect(auth).toContain('second-access')
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const mockClient = createMockClient()
+    const plugin = await getPlugin(mockClient)
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(expiredPrimaryAuth()),
+      { models: {} },
+    )
+
+    // Must NOT throw invalid_grant — it should transparently fail over.
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+
+    // The working second account should be promoted into OpenCode's slot.
+    expect(mockClient.auth.set).toHaveBeenCalled()
+    const call = (mockClient.auth.set as any).mock.calls[0][0]
+    expect(call.path.id).toBe('anthropic')
+    expect(call.body.access).toBe('second-access')
+  })
+
+  test('tries a cooling account as a last resort instead of surfacing an error', async () => {
+    // Primary is dead AND the only other account is cooling down. The plugin
+    // should still try the cooling account rather than throw.
+    const store = new AccountStore(storePath)
+    const cooling = store.add({
+      refresh: 'cooling-refresh',
+      access: 'cooling-access',
+      expires: Date.now() + 100_000,
+    })
+    store.markCooldown(cooling.id, Date.now() + 10 * 60_000, 'HTTP 429')
+
+    let servedByCooling = false
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'invalid_grant' }), {
+            status: 400,
+          }),
+        )
+      }
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        if (auth.includes('cooling-access')) servedByCooling = true
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(expiredPrimaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+    expect(servedByCooling).toBe(true)
+  })
+
+  test('Claude Pro/Max login labels the stored account by email', async () => {
+    // Token exchange returns an account email; the store should use it.
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'login-refresh',
+              access_token: 'login-access',
+              expires_in: 3600,
+              account: { email_address: 'flo@example.com' },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const method = plugin.auth.methods.find(
+      (m: any) => m.label === 'Claude Pro/Max',
+    )
+    const flow = await method.authorize()
+    // Provide a valid code#state matching the generated state.
+    const state = new URL(flow.url).searchParams.get('state')
+    const outcome = await flow.callback(`logincode#${state}`)
+    expect(outcome.type).toBe('success')
+
+    const stored = new AccountStore(storePath).list()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]!.email).toBe('flo@example.com')
+    expect(stored[0]!.label).toBe('flo@example.com')
+  })
+
+  test('login falls back to the profile endpoint when the token has no email', async () => {
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'login-refresh',
+              access_token: 'login-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (url.includes('/api/oauth/profile')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              account: { email_address: 'viaprofile@example.com' },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const method = plugin.auth.methods.find(
+      (m: any) => m.label === 'Claude Pro/Max',
+    )
+    const flow = await method.authorize()
+    const state = new URL(flow.url).searchParams.get('state')
+    await flow.callback(`logincode#${state}`)
+
+    const stored = new AccountStore(storePath).list()
+    expect(stored[0]!.email).toBe('viaprofile@example.com')
+  })
+
+  test('login marks the account as primary in the store', async () => {
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'login-refresh',
+              access_token: 'login-access',
+              expires_in: 3600,
+              account: { email: 'primary@example.com' },
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const method = plugin.auth.methods.find(
+      (m: any) => m.label === 'Claude Pro/Max',
+    )
+    const flow = await method.authorize()
+    const state = new URL(flow.url).searchParams.get('state')
+    await flow.callback(`logincode#${state}`)
+
+    const stored = new AccountStore(storePath).list()
+    expect(stored).toHaveLength(1)
+    expect(stored[0]!.primary).toBe(true)
+    expect(stored[0]!.email).toBe('primary@example.com')
+  })
+
+  test('a request flags the current OpenCode account as primary', async () => {
+    const store = new AccountStore(storePath)
+    // Two stored accounts; the second matches the OpenCode primary credential.
+    store.add({ refresh: 'other-refresh', access: 'other', expires: 1 })
+    store.add({
+      refresh: 'primary-refresh',
+      access: 'primary-access',
+      expires: Date.now() + 100_000,
+    })
+
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    ) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+    await result.fetch(MESSAGES_URL, EMPTY_POST)
+
+    const after = new AccountStore(storePath).list()
+    const primary = after.find((a) => a.primary)
+    expect(primary?.refresh).toBe('primary-refresh')
+    expect(after.filter((a) => a.primary)).toHaveLength(1)
+  })
+
+  test('promotion on failover moves the primary flag to the working account', async () => {
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+    // The primary credential is also in the store but its refresh is dead.
+    store.add({
+      refresh: 'dead-primary-refresh',
+      access: 'expired-primary-access',
+      expires: Date.now() - 1000,
+    })
+
+    globalThis.fetch = mock((input: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ error: 'invalid_grant' }), {
+            status: 400,
+          }),
+        )
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(expiredPrimaryAuth()),
+      { models: {} },
+    )
+    await result.fetch(MESSAGES_URL, EMPTY_POST)
+
+    // The working second account should now be flagged primary.
+    const after = new AccountStore(storePath).list()
+    const primary = after.find((a) => a.primary)
+    expect(primary?.refresh).toBe('second-refresh')
   })
 })

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -24,6 +24,15 @@ beforeAll(() => {
   process.env.ANTHROPIC_ACCOUNTS_PATH = join(globalStoreDir, 'accounts.json')
 })
 
+// Start every test from an empty store and the global path. The loader now
+// persists the current primary into the store on each request, so without this
+// reset one test's account would leak into the next. (The failover describe
+// block overrides the path again with its own per-test temp file.)
+beforeEach(() => {
+  process.env.ANTHROPIC_ACCOUNTS_PATH = join(globalStoreDir, 'accounts.json')
+  rmSync(join(globalStoreDir, 'accounts.json'), { force: true })
+})
+
 afterAll(() => {
   if (originalGlobalAccountsPath === undefined) {
     delete process.env.ANTHROPIC_ACCOUNTS_PATH
@@ -780,7 +789,12 @@ describe('multi-account failover', () => {
               controller.close()
             },
           })
-          return Promise.resolve(new Response(stream, { status: 200 }))
+          return Promise.resolve(
+            new Response(stream, {
+              status: 200,
+              headers: { 'content-type': 'text/event-stream' },
+            }),
+          )
         }
         // Second account: a normal successful stream.
         const ok = new ReadableStream({
@@ -793,7 +807,12 @@ describe('multi-account failover', () => {
             controller.close()
           },
         })
-        return Promise.resolve(new Response(ok, { status: 200 }))
+        return Promise.resolve(
+          new Response(ok, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+        )
       }
       return Promise.resolve(new Response(null, { status: 200 }))
     }) as unknown as typeof fetch

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -747,6 +747,55 @@ describe('multi-account failover', () => {
     expect(twin!.cooldownUntil ?? 0).toBeGreaterThan(Date.now())
   })
 
+  test('a cooling primary is demoted below healthy accounts (not retried first)', async () => {
+    // When the primary itself is on cooldown but still occupies OpenCode's slot
+    // (e.g. a promotion hasn't taken effect yet), a request must try a HEALTHY
+    // account first rather than wasting a round-trip on the rate-limited primary.
+    const store = new AccountStore(storePath)
+    // The primary is already cooling; a healthy second account is available.
+    const primary = store.add({
+      refresh: 'primary-refresh',
+      access: 'primary-access',
+      expires: Date.now() + 100_000,
+    })
+    store.markCooldown(primary.id, Date.now() + 100_000, 'HTTP 429')
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    const authHeaders: string[] = []
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        authHeaders.push(auth)
+        // The cooling primary is still rate-limited; the second succeeds.
+        if (auth.includes('primary-access')) {
+          return Promise.resolve(new Response('rate limited', { status: 429 }))
+        }
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    // OpenCode's slot still holds the (cooling) primary.
+    const result = await plugin.auth.loader(
+      () => Promise.resolve(primaryAuth()),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+
+    // The healthy second account is tried FIRST and the cooling primary is not
+    // hit at all (it is only a last resort, never reached here).
+    expect(authHeaders[0]).toContain('second-access')
+    expect(authHeaders.some((h) => h.includes('primary-access'))).toBe(false)
+  })
+
   test('returns the last error response when all accounts are exhausted', async () => {
     // Primary + one store account, both rate-limited.
     const store = new AccountStore(storePath)

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -684,6 +684,69 @@ describe('multi-account failover', () => {
     expect(available).toHaveLength(1)
   })
 
+  test('cools the primary by its POST-rotation token after a refresh then 429', async () => {
+    // Regression: when the primary's token is rotated by ensureFreshTokens and
+    // it THEN hits a 429, the cooldown must be recorded against the NEW refresh
+    // token (which the store twin now holds), not the stale pre-rotation one.
+    // Otherwise the lookup misses, no cooldown is written, and the exhausted
+    // primary is rebuilt as a candidate and retried on every later request.
+    const store = new AccountStore(storePath)
+    store.add({
+      refresh: 'second-refresh',
+      access: 'second-access',
+      expires: Date.now() + 100_000,
+    })
+
+    globalThis.fetch = mock((input: any, init: any) => {
+      const url = extractUrl(input)
+      if (url.includes('/v1/oauth/token')) {
+        // The primary's expired token rotates to a brand-new refresh token.
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              refresh_token: 'primary-rotated',
+              access_token: 'primary-new-access',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      }
+      if (url.includes('/v1/messages')) {
+        const auth = (init?.headers as Headers).get('authorization') ?? ''
+        // The freshly-rotated primary is rate-limited; the second succeeds.
+        if (auth.includes('primary-new-access')) {
+          return Promise.resolve(new Response('rate limited', { status: 429 }))
+        }
+        return Promise.resolve(new Response(null, { status: 200 }))
+      }
+      return Promise.resolve(new Response(null, { status: 200 }))
+    }) as unknown as typeof fetch
+
+    const plugin = await getPlugin()
+    const result = await plugin.auth.loader(
+      () =>
+        Promise.resolve({
+          type: 'oauth' as const,
+          access: 'stale-primary-access',
+          refresh: 'primary-refresh',
+          expires: Date.now() - 1000,
+        }),
+      { models: {} },
+    )
+
+    const response = await result.fetch(MESSAGES_URL, EMPTY_POST)
+    expect(response.status).toBe(200)
+
+    // The primary's store twin (now keyed by its rotated refresh) must be
+    // cooling down. With the bug the lookup missed and it stayed available.
+    const twin = new AccountStore(storePath)
+      .list()
+      .find((a) => a.refresh === 'primary-rotated')
+    expect(twin).toBeDefined()
+    expect(twin!.cooldownUntil ?? 0).toBeGreaterThan(Date.now())
+  })
+
   test('returns the last error response when all accounts are exhausted', async () => {
     // Primary + one store account, both rate-limited.
     const store = new AccountStore(storePath)

--- a/src/tests/profile.test.ts
+++ b/src/tests/profile.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { fetchAccountProfile } from '../profile'
+
+describe('fetchAccountProfile', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns undefined for an empty token without calling fetch', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response(null, { status: 200 })),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+    expect(await fetchAccountProfile('')).toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('extracts email + organization from the profile response (account.email)', async () => {
+    let capturedAuth: string | undefined
+    globalThis.fetch = mock((input: any, init: any) => {
+      expect(String(input)).toContain('/api/oauth/profile')
+      capturedAuth = (init?.headers as Record<string, string>).Authorization
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            // Real endpoint shape: account.email
+            account: { email: 'me@example.com', uuid: 'u1' },
+            organization: { name: 'My Org' },
+          }),
+          { status: 200 },
+        ),
+      )
+    }) as unknown as typeof fetch
+
+    const profile = await fetchAccountProfile('my-access-token')
+    expect(profile).toEqual({
+      email: 'me@example.com',
+      organizationName: 'My Org',
+    })
+    expect(capturedAuth).toBe('Bearer my-access-token')
+  })
+
+  test('falls back to account.email_address', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ account: { email_address: 'legacy@example.com' } }),
+          { status: 200 },
+        ),
+      ),
+    ) as unknown as typeof fetch
+
+    const profile = await fetchAccountProfile('t')
+    expect(profile?.email).toBe('legacy@example.com')
+  })
+
+  test('returns undefined on a non-ok response', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('nope', { status: 401 })),
+    ) as unknown as typeof fetch
+    expect(await fetchAccountProfile('t')).toBeUndefined()
+  })
+
+  test('returns undefined on invalid JSON', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('{ not json', { status: 200 })),
+    ) as unknown as typeof fetch
+    expect(await fetchAccountProfile('t')).toBeUndefined()
+  })
+
+  test('returns undefined on a network error', async () => {
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error('fetch failed')),
+    ) as unknown as typeof fetch
+    expect(await fetchAccountProfile('t')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Adds **multiple Claude Pro/Max account support with automatic failover**. When one account hits a usage/rate limit, the plugin transparently switches to another authenticated account, so a long session keeps going instead of stopping when a single account is exhausted.

This is fully backward compatible — with a single account the behavior is unchanged.

## How it works

On every request the plugin builds an ordered list of candidate accounts:

1. The primary (OpenCode's own `anthropic`) account first.
2. Then each additional account that isn't currently cooling down.
3. Then, as a last resort, accounts that *are* cooling down (so the session never stalls while an account might still work).

Failover triggers on:

- an HTTP error status (`429`, `401`, `403`, `529`), **or**
- an error event inside a `200 OK` streaming response. Claude Pro/Max usage limits frequently come back as a `rate_limit_error` **SSE event** with a 200 status rather than a `429`, so a status-only check misses them. `inspectStream` reads the start of the stream (up to the first real content) to catch these without disturbing good responses.

The exhausted account is put on a cooldown (respecting `Retry-After`) and the same request is retried on the next account. An error is only surfaced once **every** account has failed. When a non-primary account serves a request, it is promoted into OpenCode's credential slot so subsequent requests start from a healthy account.

## Accounts

- Sign in with **Claude Pro/Max** more than once, each time with a different Claude account. Every login joins a plugin-owned pool.
- Accounts are **labeled by email**, resolved from the OAuth token response or the `/api/oauth/profile` endpoint (the `user:profile` scope).
- The pool is **deduplicated by account (email)** — logging into the same account twice just refreshes that entry instead of creating a duplicate that shares one quota.
- Stored in a `0600` JSON file at `$ANTHROPIC_ACCOUNTS_PATH` / `$XDG_DATA_HOME/opencode-anthropic-auth/accounts.json` / `~/.local/share/opencode-anthropic-auth/accounts.json`, with a `primary` flag on the active account.

## New env vars

- `ANTHROPIC_ACCOUNTS_PATH` — override the account store location.
- `ANTHROPIC_FAILOVER_DEBUG` — log candidate selection and failover decisions to stderr.

## Files

- New: `src/accounts.ts` (account store), `src/failover.ts` (limit/stream-error detection), `src/refresh.ts` (shared token refresh), `src/profile.ts` (email lookup).
- Changed: `src/index.ts` (failover loop + store the login), `src/auth.ts` (parse account email from token response), `src/constants.ts` (`PROFILE_URL`).
- Tests for all of the above.

## Testing

`bun test` — 179 pass. `bun run types`, `bun run build`, `bun run format:check`, `bun run lint` all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Rewrites the OAuth `fetch` path and persists refresh tokens on disk while calling `client.auth.set` on promotion—security- and availability-sensitive, though single-account paths are largely unchanged.
> 
> **Overview**
> Adds **multi-account Claude Pro/Max OAuth** with transparent failover when limits or auth errors hit, so sessions can continue across distinct subscriptions.
> 
> Repeated **Claude Pro/Max** logins append to a plugin-owned `accounts.json` pool (email labels from token or `/api/oauth/profile`, deduped by email). Each API request tries candidates in order: OpenCode’s primary, then non-cooling pool accounts, then cooling accounts as a last resort. Failover runs on `429`/`401`/`403`/`529`, failed refresh (`invalid_grant`), and **200 SSE** streams that emit rate/usage errors before real content (`inspectStream` replays good streams unchanged). Exhausted accounts get cooldowns from `Retry-After`; successes on a backup account **promote** it via `client.auth.set`. Token refresh moves to shared `refreshAccessToken` with per-refresh deduplication.
> 
> New env: `ANTHROPIC_ACCOUNTS_PATH`, `ANTHROPIC_FAILOVER_DEBUG`. Single-account behavior stays the same when the pool has one entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd2fd9fcc24c3f5e7a6cc42db801eefdd334e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple Anthropic Claude Pro/Max accounts.
  * Automatically switches accounts when authentication, rate-limit, overload, or service-capacity errors occur.
  * Promotes a working account and remembers account cooldowns to improve future requests.
  * Added optional account profile labeling and configurable account storage/debug logging.

* **Documentation**
  * Documented account setup, failover behavior, storage options, and configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->