### PR TITLE
fix: handle SSE tool names split across chunk boundaries

### DIFF
--- a/.changeset/calm-streams-flow.md
+++ b/.changeset/calm-streams-flow.md
@@ -1,0 +1,5 @@
+---
+"@ex-machina/opencode-anthropic-auth": patch
+---
+
+Handle CR-delimited SSE events and reject oversized newline-free stream lines.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ mise.local.toml
 # mitmproxy capture files (binary, large)
 *.flow
 *.flow.log
+coverage/
+coverage/

--- a/src/tests/auth.branches.test.ts
+++ b/src/tests/auth.branches.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { exchange } from '../auth'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+type FetchArgs = Parameters<typeof fetch>
+
+function stubFetch(response: Response): FetchArgs[] {
+  const calls: FetchArgs[] = []
+  globalThis.fetch = (async (...args: FetchArgs) => {
+    calls.push(args)
+    return response
+  }) as unknown as typeof fetch
+  return calls
+}
+
+describe('exchange - callback parsing', () => {
+  test('accepts a query-string callback with code and state', async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          access_token: 'access',
+          refresh_token: 'refresh',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    )
+
+    const result = await exchange(
+      'code=abc&state=xyz',
+      'verifier',
+      'https://example.com/callback',
+      'xyz',
+    )
+
+    expect(result.type).toBe('success')
+  })
+})
+
+describe('exchange - token endpoint failures', () => {
+  test('returns failed when the token endpoint rejects the code', async () => {
+    const calls = stubFetch(new Response('invalid_grant', { status: 400 }))
+
+    const result = await exchange(
+      'abc#xyz',
+      'verifier',
+      'https://example.com/callback',
+      'xyz',
+    )
+
+    expect(result.type).toBe('failed')
+    expect(calls).toHaveLength(1)
+  })
+
+  test('returns failed on a 500 from the token endpoint', async () => {
+    const calls = stubFetch(new Response('boom', { status: 500 }))
+
+    const result = await exchange(
+      'abc#xyz',
+      'verifier',
+      'https://example.com/callback',
+      'xyz',
+    )
+
+    expect(result.type).toBe('failed')
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/src/tests/index.methods.test.ts
+++ b/src/tests/index.methods.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { AnthropicAuthPlugin } from '../index'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+type FetchCall = {
+  url: string
+  init?: RequestInit
+}
+
+function installFetchStub(handler: (call: FetchCall) => Response): FetchCall[] {
+  const calls: FetchCall[] = []
+  globalThis.fetch = mock(
+    (input: string | URL | Request, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url
+      const call = { url, init }
+      calls.push(call)
+      return Promise.resolve(handler(call))
+    },
+  ) as unknown as typeof fetch
+  return calls
+}
+
+function tokenResponse(): Response {
+  return Response.json({
+    access_token: 'access-token',
+    refresh_token: 'refresh-token',
+    expires_in: 3600,
+  })
+}
+
+async function getOAuthMethod(index: number) {
+  const plugin = (await AnthropicAuthPlugin({
+    // @ts-expect-error: minimal client mock; authorize handlers do not use it
+    client: {},
+  })) as any
+  const method = plugin.auth.methods[index]
+  if (method?.type !== 'oauth') {
+    throw new Error(`Expected OAuth method at index ${index}`)
+  }
+  return method
+}
+
+function callbackCode(authorizationUrl: string): string {
+  const state = new URL(authorizationUrl).searchParams.get('state')
+  if (!state) throw new Error('Authorization URL is missing state')
+  return `authorization-code#${state}`
+}
+
+describe('Claude Pro/Max OAuth method', () => {
+  test('creates a claude.ai authorization code flow', async () => {
+    const method = await getOAuthMethod(0)
+    const authorization = await method.authorize()
+    const url = new URL(authorization.url)
+
+    expect(url.origin).toBe('https://claude.ai')
+    expect(url.pathname).toBe('/oauth/authorize')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(url.searchParams.get('state')).toBeTruthy()
+    expect(authorization.method).toBe('code')
+    expect(authorization.callback).toBeFunction()
+  })
+
+  test('callback exchanges the authorization code for OAuth credentials', async () => {
+    const method = await getOAuthMethod(0)
+    const authorization = await method.authorize()
+    const calls = installFetchStub(() => tokenResponse())
+
+    const credentials = await authorization.callback(
+      callbackCode(authorization.url),
+    )
+
+    expect(credentials.type).toBe('success')
+    expect(credentials.access).toBe('access-token')
+    expect(credentials.refresh).toBe('refresh-token')
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('https://platform.claude.com/v1/oauth/token')
+
+    const body = JSON.parse(String(calls[0]?.init?.body))
+    expect(body.code).toBe('authorization-code')
+    expect(body.grant_type).toBe('authorization_code')
+  })
+
+  test('callback reports a failed token exchange', async () => {
+    const method = await getOAuthMethod(0)
+    const authorization = await method.authorize()
+    const calls = installFetchStub(
+      () => new Response('invalid grant', { status: 400 }),
+    )
+
+    const credentials = await authorization.callback(
+      callbackCode(authorization.url),
+    )
+
+    expect(credentials).toEqual({ type: 'failed' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe('https://platform.claude.com/v1/oauth/token')
+  })
+})
+
+describe('Create an API Key OAuth method', () => {
+  test('creates a platform.claude.com authorization code flow', async () => {
+    const method = await getOAuthMethod(1)
+    const authorization = await method.authorize()
+    const url = new URL(authorization.url)
+
+    expect(url.origin).toBe('https://platform.claude.com')
+    expect(url.pathname).toBe('/oauth/authorize')
+    expect(url.searchParams.get('scope')).toContain('org:create_api_key')
+    expect(authorization.method).toBe('code')
+  })
+
+  test('callback creates an API key using the exchanged access token', async () => {
+    const method = await getOAuthMethod(1)
+    const authorization = await method.authorize()
+    const calls = installFetchStub(({ url }) => {
+      if (url.endsWith('/v1/oauth/token')) return tokenResponse()
+      if (url.endsWith('/api/oauth/claude_cli/create_api_key')) {
+        return Response.json({ raw_key: 'sk-ant-created' })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    const credentials = await authorization.callback(
+      callbackCode(authorization.url),
+    )
+
+    expect(credentials).toEqual({ type: 'success', key: 'sk-ant-created' })
+    expect(calls).toHaveLength(2)
+    expect(calls[1]?.init?.method).toBe('POST')
+
+    const headers = new Headers(calls[1]?.init?.headers)
+    expect(headers.get('authorization')).toBe('Bearer access-token')
+    expect(headers.get('content-type')).toBe('application/json')
+  })
+
+  test('does not request an API key when token exchange fails', async () => {
+    const method = await getOAuthMethod(1)
+    const authorization = await method.authorize()
+    const calls = installFetchStub(
+      () => new Response('invalid grant', { status: 400 }),
+    )
+
+    const credentials = await authorization.callback(
+      callbackCode(authorization.url),
+    )
+
+    expect(credentials).toEqual({ type: 'failed' })
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -380,7 +380,12 @@ describe('auth.loader', () => {
     })
 
     globalThis.fetch = mock(() =>
-      Promise.resolve(new Response(responseStream, { status: 200 })),
+      Promise.resolve(
+        new Response(responseStream, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      ),
     ) as unknown as typeof fetch
 
     const plugin = await getPlugin()

--- a/src/tests/transform.branches.test.ts
+++ b/src/tests/transform.branches.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+import { prependClaudeCodeIdentity, rewriteUrl } from '../transform'
+
+describe('rewriteUrl - unparseable input', () => {
+  test('returns the input untouched when the URL cannot be parsed', () => {
+    const result = rewriteUrl('not a valid url')
+    expect(result.url).toBeNull()
+    expect(result.input).toBe('not a valid url')
+  })
+})
+
+describe('prependClaudeCodeIdentity - non-array system values', () => {
+  test('accepts a single system block object', () => {
+    const blocks = prependClaudeCodeIdentity({
+      type: 'text',
+      text: 'plain instructions',
+    })
+    expect(blocks).toHaveLength(2)
+    expect(blocks[1]).toMatchObject({
+      type: 'text',
+      text: 'plain instructions',
+    })
+  })
+
+  test('preserves extra keys on a single system block object', () => {
+    const blocks = prependClaudeCodeIdentity({
+      type: 'text',
+      text: 'cached',
+      cache_control: { type: 'ephemeral' },
+    })
+    expect(blocks[1]).toMatchObject({ cache_control: { type: 'ephemeral' } })
+  })
+
+  test('defaults the type when a block object omits it', () => {
+    const blocks = prependClaudeCodeIdentity({ text: 'no type here' } as never)
+    expect(blocks[1]).toMatchObject({ type: 'text', text: 'no type here' })
+  })
+
+  test('stringifies array items that are neither strings nor text blocks', () => {
+    const blocks = prependClaudeCodeIdentity([
+      42,
+      { type: 'image', source: {} },
+    ])
+    expect(blocks[1]).toEqual({ type: 'text', text: '42' })
+    expect(blocks[2]).toMatchObject({ type: 'text' })
+  })
+
+  test('falls back to the identity block for unsupported system values', () => {
+    expect(prependClaudeCodeIdentity(true as never)).toHaveLength(1)
+  })
+})

--- a/src/tests/transform.stream.test.ts
+++ b/src/tests/transform.stream.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   createStrippedStream,
-  MAX_RESPONSE_JSON_BYTES,
+  MAX_JSON_TOOL_NAME_BYTES,
   MAX_SSE_LINE_BYTES,
   prefixToolNames,
   stripToolPrefix,
@@ -220,19 +220,171 @@ describe('createStrippedStream - transport semantics', () => {
       }),
     )
 
-    expect(await readText(response)).toContain('"name": "read"')
+    expect(await readText(response)).toContain('"name":"read"')
     expect(response.headers.has('content-length')).toBe(false)
   })
 
-  test('passes oversized chunked JSON through without the SSE line limit', async () => {
-    const body = new Uint8Array(MAX_RESPONSE_JSON_BYTES + 1).fill(0x78)
+  test('rewrites tool names in JSON larger than the former limit', async () => {
+    const padding = 'x'.repeat(MAX_SSE_LINE_BYTES + 1)
+    const payload =
+      '{"type":"message","content":[' +
+      '{"type":"tool_use","name":"mcp_Read","input":{}},' +
+      `{"type":"text","text":"${padding}"},` +
+      '{"type":"tool_use","name":"mcp_Write","input":{}}]}'
+    const bytes = encoder.encode(payload)
+    const chunks: Uint8Array[] = []
+    for (let offset = 0; offset < bytes.byteLength; offset += 64 * 1024) {
+      chunks.push(bytes.subarray(offset, offset + 64 * 1024))
+    }
+    for (const declaredLength of [false, true]) {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+      }
+      if (declaredLength) headers['content-length'] = String(bytes.byteLength)
+      const response = createStrippedStream(
+        new Response(streamOf(chunks), { headers }),
+      )
+
+      const output = await readText(response)
+      expect(output).toContain('"name":"read"')
+      expect(output).toContain('"name":"write"')
+      expect(output).not.toContain('mcp_')
+      expect(output.length).toBe(payload.length - 8)
+    }
+  })
+
+  test('rewrites JSON names across every relevant byte split', async () => {
+    const payload =
+      '{"type":"message","content":[{"type":"tool_use","name"  :  "mcp_Read","input":{}}]}'
+    const expected = payload.replace('mcp_Read', 'read')
+    const bytes = encoder.encode(payload)
+
+    for (let index = 1; index < bytes.byteLength; index++) {
+      const response = createStrippedStream(
+        new Response(
+          streamOf([bytes.subarray(0, index), bytes.subarray(index)]),
+          {
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+      )
+      expect(await readText(response)).toBe(expected)
+    }
+  })
+
+  test('preserves UTF-8 while rewriting JSON delivered one byte at a time', async () => {
+    const payload = '{"text":"Привет 🚀","name":"mcp_Read","tail":"готово"}'
+    const chunks = Array.from(
+      encoder.encode(payload),
+      (byte) => new Uint8Array([byte]),
+    )
     const response = createStrippedStream(
-      new Response(streamOf([body]), {
+      new Response(streamOf(chunks), {
         headers: { 'content-type': 'application/json' },
       }),
     )
 
-    expect((await response.arrayBuffer()).byteLength).toBe(body.byteLength)
+    expect(await readText(response)).toBe(payload.replace('mcp_Read', 'read'))
+  })
+
+  test('lowercases a raw non-ASCII first code point across byte splits', async () => {
+    for (const name of ['Äbc', 'Ωmega', 'Бeta']) {
+      const payload = `{"name":"mcp_${name}"}`
+      const expected = stripToolPrefix(payload)
+      const chunks = Array.from(
+        encoder.encode(payload),
+        (byte) => new Uint8Array([byte]),
+      )
+      const response = createStrippedStream(
+        new Response(streamOf(chunks), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      expect(await readText(response)).toBe(
+        expected.replace('"name": "', '"name":"'),
+      )
+    }
+  })
+
+  test('preserves a truncated non-ASCII tool name byte-for-byte', async () => {
+    for (const name of ['Ä', 'Ω', 'Б']) {
+      const payload = `{"name":"mcp_${name}`
+      const chunks = Array.from(
+        encoder.encode(payload),
+        (byte) => new Uint8Array([byte]),
+      )
+      const response = createStrippedStream(
+        new Response(streamOf(chunks), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      expect(await readText(response)).toBe(payload)
+    }
+  })
+
+  test('bounds a single JSON tool name without bounding the document', async () => {
+    const accepted = `{"name":"mcp_${'A'.repeat(MAX_JSON_TOOL_NAME_BYTES)}"}`
+    const rejected = `{"name":"mcp_${'A'.repeat(MAX_JSON_TOOL_NAME_BYTES + 1)}"}`
+
+    expect(
+      await readText(
+        createStrippedStream(
+          new Response(streamOf([accepted]), {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+      ),
+    ).toBe(`{"name":"a${'A'.repeat(MAX_JSON_TOOL_NAME_BYTES - 1)}"}`)
+
+    await expect(
+      readText(
+        createStrippedStream(
+          new Response(streamOf([rejected]), {
+            headers: { 'content-type': 'application/json' },
+          }),
+        ),
+      ),
+    ).rejects.toThrow(
+      `JSON tool name exceeds ${MAX_JSON_TOOL_NAME_BYTES} byte limit`,
+    )
+  })
+
+  test('does not rewrite an escaped name field inside JSON text', async () => {
+    const payload = '{"text":"\\"name\\":\\"mcp_Read\\"","name":"plain"}'
+    const response = createStrippedStream(
+      new Response(streamOf([payload]), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    expect(await readText(response)).toBe(payload)
+  })
+
+  test('keeps StructuredOutput casing in non-streaming JSON', async () => {
+    const payload = '{"name":"mcp_StructuredOutput"}'
+    const response = createStrippedStream(
+      new Response(streamOf([payload]), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    expect(await readText(response)).toBe('{"name":"StructuredOutput"}')
+  })
+
+  test('preserves an empty tool name prefix across chunk and EOF boundaries', async () => {
+    for (const payload of ['{"name":"mcp_"}', '{"name":"mcp_']) {
+      const bytes = encoder.encode(payload)
+      const chunks = Array.from(bytes, (byte) => new Uint8Array([byte]))
+      const response = createStrippedStream(
+        new Response(streamOf(chunks), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      expect(await readText(response)).toBe(payload)
+    }
   })
 
   test('passes invalid UTF-8 JSON through byte-for-byte', async () => {
@@ -264,7 +416,7 @@ describe('createStrippedStream - transport semantics', () => {
       ),
     )
 
-    expect(await readText(response)).toContain('"name": "read"')
+    expect(await readText(response)).toContain('"name":"read"')
     for (const name of [
       'content-digest',
       'content-encoding',
@@ -339,6 +491,22 @@ describe('createStrippedStream - transport semantics', () => {
     )
     await expect(readText(response)).rejects.toThrow('upstream boom')
   })
+
+  test('propagates an upstream JSON stream error', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"name":"mcp_Re'))
+        controller.error(new Error('JSON upstream boom'))
+      },
+    })
+    const response = createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await expect(readText(response)).rejects.toThrow('JSON upstream boom')
+  })
 })
 
 describe('prefix round-trip', () => {
@@ -392,5 +560,28 @@ describe('createStrippedStream - cancellation', () => {
       createStrippedStream(sseResponse(['data: {"name":"mcp_Read"}'])),
     )
     expect(output).toBe('data: {"name": "read"}')
+  })
+
+  test('forwards JSON consumer cancellation to the upstream stream', async () => {
+    let cancelled = false
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"padding":"ready",'))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const response = createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    const reader = response.body!.getReader()
+    await reader.read()
+    await reader.cancel()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(cancelled).toBe(true)
   })
 })

--- a/src/tests/transform.stream.test.ts
+++ b/src/tests/transform.stream.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  createStrippedStream,
+  MAX_SSE_LINE_BYTES,
+  prefixToolNames,
+  stripToolPrefix,
+} from '../transform'
+
+const encoder = new TextEncoder()
+
+function streamOf(
+  chunks: Array<string | Uint8Array>,
+): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          typeof chunk === 'string' ? encoder.encode(chunk) : chunk,
+        )
+      }
+      controller.close()
+    },
+  })
+}
+
+function sseResponse(
+  chunks: Array<string | Uint8Array>,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(streamOf(chunks), {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream', ...headers },
+  })
+}
+
+async function readText(response: Response): Promise<string> {
+  return await new Response(response.body).text()
+}
+
+const TOOL_EVENT =
+  'event: content_block_start\n' +
+  'data: {"type":"content_block_start","index":0,' +
+  '"content_block":{"type":"tool_use","id":"toolu_1","name":"mcp_Read","input":{}}}\n\n'
+
+// stripToolPrefix normalises to `"name": "x"` and lower-cases the first letter.
+const EXPECTED = TOOL_EVENT.replace('"name":"mcp_Read"', '"name": "read"')
+
+describe('createStrippedStream - chunk boundaries', () => {
+  test('strips the prefix at every possible two-chunk split point', async () => {
+    for (let index = 1; index < TOOL_EVENT.length; index++) {
+      const chunks = [TOOL_EVENT.slice(0, index), TOOL_EVENT.slice(index)]
+      expect(await readText(createStrippedStream(sseResponse(chunks)))).toBe(
+        EXPECTED,
+      )
+    }
+  })
+
+  test('strips a prefix delivered one byte per chunk', async () => {
+    const bytes = Array.from(
+      encoder.encode(TOOL_EVENT),
+      (byte) => new Uint8Array([byte]),
+    )
+    expect(await readText(createStrippedStream(sseResponse(bytes)))).toBe(
+      EXPECTED,
+    )
+  })
+
+  test('tolerates interleaved empty chunks', async () => {
+    const chunks = ['', TOOL_EVENT.slice(0, 20), '', TOOL_EVENT.slice(20), '']
+    expect(await readText(createStrippedStream(sseResponse(chunks)))).toBe(
+      EXPECTED,
+    )
+  })
+
+  test('preserves a 4-byte emoji split across chunks', async () => {
+    const payload =
+      'data: {"type":"content_block_delta","delta":{"text":"\u{1F680} ok"}}\n\n'
+    const bytes = encoder.encode(payload)
+    const cut = bytes.indexOf(0xf0) + 2
+    const output = await readText(
+      createStrippedStream(
+        sseResponse([bytes.slice(0, cut), bytes.slice(cut)]),
+      ),
+    )
+    expect(output).toBe(payload)
+  })
+
+  test('flushes a dangling partial prefix at end of stream', async () => {
+    const partial = 'data: {"name":"mcp'
+    expect(await readText(createStrippedStream(sseResponse([partial])))).toBe(
+      partial,
+    )
+  })
+})
+
+describe('createStrippedStream - correctness guards', () => {
+  test('handles CR-only SSE line endings', async () => {
+    const payload = 'data: {"name":"mcp_Read"}\r\r'
+    const expected = 'data: {"name": "read"}\r\r'
+    const chunks = payload.split('')
+
+    expect(await readText(createStrippedStream(sseResponse(chunks)))).toBe(
+      expected,
+    )
+  })
+
+  test('preserves CRLF endings split across chunks', async () => {
+    const expected = 'data: {"name": "read"}\r\n\r\n'
+    const chunks = ['data: {"name":"mcp_', 'Read"}\r', '\n\r', '\n']
+
+    expect(await readText(createStrippedStream(sseResponse(chunks)))).toBe(
+      expected,
+    )
+  })
+
+  test('rejects a newline-free SSE line above the buffer limit', async () => {
+    const oversized = `data: ${'x'.repeat(MAX_SSE_LINE_BYTES)}`
+    const response = createStrippedStream(sseResponse([oversized]))
+
+    await expect(readText(response)).rejects.toThrow(
+      `SSE line exceeds ${MAX_SSE_LINE_BYTES} byte limit`,
+    )
+  })
+
+  test('rejects an oversized line ending in the same chunk', async () => {
+    const oversized = `${'x'.repeat(MAX_SSE_LINE_BYTES + 1)}\n`
+    const response = createStrippedStream(sseResponse([oversized]))
+
+    await expect(readText(response)).rejects.toThrow(
+      `SSE line exceeds ${MAX_SSE_LINE_BYTES} byte limit`,
+    )
+  })
+
+  test('accepts a large chunk containing many bounded lines', async () => {
+    const line = 'data: x\n'
+    const payload = line.repeat(Math.ceil(MAX_SSE_LINE_BYTES / line.length))
+
+    expect(await readText(createStrippedStream(sseResponse([payload])))).toBe(
+      payload,
+    )
+  })
+
+  test('accepts a line exactly at the buffer limit', async () => {
+    const payload = 'x'.repeat(MAX_SSE_LINE_BYTES)
+
+    expect(await readText(createStrippedStream(sseResponse([payload])))).toBe(
+      payload,
+    )
+  })
+
+  test('enforces the byte limit for multi-byte UTF-8 input', async () => {
+    const payload = '🚀'.repeat(Math.floor(MAX_SSE_LINE_BYTES / 4) + 1)
+    const response = createStrippedStream(sseResponse([payload]))
+
+    await expect(readText(response)).rejects.toThrow(
+      `SSE line exceeds ${MAX_SSE_LINE_BYTES} byte limit`,
+    )
+  })
+
+  test('is a no-op for a stream with no prefixed names', async () => {
+    const payload = 'data: {"type":"message_stop"}\n\ndata: [DONE]\n\n'
+    expect(await readText(createStrippedStream(sseResponse([payload])))).toBe(
+      payload,
+    )
+  })
+
+  test('strips several tool names in a single chunk', async () => {
+    const payload = ['mcp_Read', 'mcp_Write', 'mcp_Shell']
+      .map((name) => `data: {"name":"${name}"}\n\n`)
+      .join('')
+    const expected = ['read', 'write', 'shell']
+      .map((name) => `data: {"name": "${name}"}\n\n`)
+      .join('')
+    expect(await readText(createStrippedStream(sseResponse([payload])))).toBe(
+      expected,
+    )
+  })
+
+  test('strips a very long name spanning many chunks', async () => {
+    const payload = `data: {"name":"mcp_${'A'.repeat(300)}"}\n\n`
+    const expected = `data: {"name": "a${'A'.repeat(299)}"}\n\n`
+    const chunks = payload.match(/.{1,7}/gs) ?? []
+    expect(await readText(createStrippedStream(sseResponse(chunks)))).toBe(
+      expected,
+    )
+  })
+
+  test('normalises whitespace variants of the name field', () => {
+    expect(stripToolPrefix('{"name"  :  "mcp_Read"}')).toBe('{"name": "read"}')
+  })
+
+  test('keeps StructuredOutput unchanged apart from the prefix', () => {
+    expect(stripToolPrefix('{"name":"mcp_StructuredOutput"}')).toBe(
+      '{"name": "StructuredOutput"}',
+    )
+  })
+})
+
+describe('createStrippedStream - transport semantics', () => {
+  test('preserves status, statusText and passthrough headers', () => {
+    const response = createStrippedStream(
+      new Response(streamOf([TOOL_EVENT]), {
+        status: 207,
+        statusText: 'Multi-Status',
+        headers: {
+          'content-type': 'text/event-stream',
+          'x-request-id': 'req_1',
+        },
+      }),
+    )
+    expect(response.status).toBe(207)
+    expect(response.headers.get('content-type')).toBe('text/event-stream')
+    expect(response.headers.get('x-request-id')).toBe('req_1')
+  })
+
+  test('drops content-length because the body length changes', () => {
+    const response = createStrippedStream(
+      sseResponse([TOOL_EVENT], {
+        'content-length': String(TOOL_EVENT.length),
+      }),
+    )
+    expect(response.headers.get('content-length')).toBeNull()
+  })
+
+  test('propagates an upstream stream error instead of truncating silently', async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"name":"mcp_Re'))
+        controller.error(new Error('upstream boom'))
+      },
+    })
+    const response = createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    )
+    await expect(readText(response)).rejects.toThrow('upstream boom')
+  })
+})
+
+describe('prefix round-trip', () => {
+  test('stripToolPrefix reverses prefixToolNames for lowercase tool names', () => {
+    const body = {
+      tools: [{ name: 'read' }, { name: 'write' }],
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', name: 'shell', input: {} }],
+        },
+      ],
+    }
+    const prefixed = prefixToolNames(structuredClone(body))
+    expect(prefixed).toContain('"name":"mcp_Read"')
+    expect(JSON.parse(stripToolPrefix(prefixed))).toEqual(body)
+  })
+
+  test('does not restore the original case for PascalCase tool names', () => {
+    const prefixed = prefixToolNames({ tools: [{ name: 'Read' }] })
+    // documented asymmetry: Read -> mcp_Read -> read
+    expect(JSON.parse(stripToolPrefix(prefixed)).tools[0].name).toBe('read')
+  })
+})
+
+describe('createStrippedStream - cancellation', () => {
+  test('forwards consumer cancellation to the upstream stream', async () => {
+    let cancelled = false
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(TOOL_EVENT))
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+    const response = createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    )
+    const reader = response.body!.getReader()
+    await reader.read()
+    await reader.cancel()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(cancelled).toBe(true)
+  })
+
+  test('buffers a chunk without a newline until flush', async () => {
+    const output = await readText(
+      createStrippedStream(sseResponse(['data: {"name":"mcp_Read"}'])),
+    )
+    expect(output).toBe('data: {"name": "read"}')
+  })
+})

--- a/src/tests/transform.stream.test.ts
+++ b/src/tests/transform.stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   createStrippedStream,
+  MAX_RESPONSE_JSON_BYTES,
   MAX_SSE_LINE_BYTES,
   prefixToolNames,
   stripToolPrefix,
@@ -197,17 +198,84 @@ describe('createStrippedStream - correctness guards', () => {
 })
 
 describe('createStrippedStream - transport semantics', () => {
-  test('returns an oversized non-SSE response unchanged', async () => {
+  test('returns an oversized non-JSON response unchanged', async () => {
     const body = new Uint8Array(MAX_SSE_LINE_BYTES + 1).fill(0x78)
     const original = new Response(body, {
       status: 502,
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/octet-stream' },
     })
 
     const result = createStrippedStream(original)
 
     expect(result).toBe(original)
     expect((await result.arrayBuffer()).byteLength).toBe(body.byteLength)
+  })
+
+  test('strips tool prefixes from a non-streaming JSON response', async () => {
+    const payload =
+      '{"type":"message","content":[{"type":"tool_use","name":"mcp_Read","input":{}}]}'
+    const response = createStrippedStream(
+      new Response(payload, {
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+      }),
+    )
+
+    expect(await readText(response)).toContain('"name": "read"')
+    expect(response.headers.has('content-length')).toBe(false)
+  })
+
+  test('passes oversized chunked JSON through without the SSE line limit', async () => {
+    const body = new Uint8Array(MAX_RESPONSE_JSON_BYTES + 1).fill(0x78)
+    const response = createStrippedStream(
+      new Response(streamOf([body]), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    expect((await response.arrayBuffer()).byteLength).toBe(body.byteLength)
+  })
+
+  test('passes invalid UTF-8 JSON through byte-for-byte', async () => {
+    const body = new Uint8Array([0x7b, 0x22, 0xff, 0x22, 0x7d])
+    const response = createStrippedStream(
+      new Response(streamOf([body]), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(body)
+  })
+
+  test('strips stale representation headers after JSON transformation', async () => {
+    const response = createStrippedStream(
+      new Response(
+        '{"type":"message","content":[{"type":"tool_use","name":"mcp_Read"}]}',
+        {
+          headers: {
+            'content-digest': 'sha-256=:stale:',
+            'content-encoding': 'gzip',
+            'content-md5': 'stale',
+            'content-range': 'bytes 0-9/10',
+            digest: 'sha-256=stale',
+            etag: '"stale"',
+            'content-type': 'application/problem+json',
+          },
+        },
+      ),
+    )
+
+    expect(await readText(response)).toContain('"name": "read"')
+    for (const name of [
+      'content-digest',
+      'content-encoding',
+      'content-length',
+      'content-md5',
+      'content-range',
+      'digest',
+      'etag',
+    ]) {
+      expect(response.headers.has(name)).toBe(false)
+    }
   })
 
   test('accepts event-stream media type parameters case-insensitively', async () => {
@@ -243,6 +311,18 @@ describe('createStrippedStream - transport semantics', () => {
       }),
     )
     expect(response.headers.get('content-length')).toBeNull()
+  })
+
+  test('strips stale representation headers from transformed SSE', () => {
+    const response = createStrippedStream(
+      sseResponse([TOOL_EVENT], {
+        'content-encoding': 'gzip',
+        etag: '"stale"',
+      }),
+    )
+
+    expect(response.headers.get('content-encoding')).toBeNull()
+    expect(response.headers.get('etag')).toBeNull()
   })
 
   test('propagates an upstream stream error instead of truncating silently', async () => {

--- a/src/tests/transform.stream.test.ts
+++ b/src/tests/transform.stream.test.ts
@@ -197,6 +197,29 @@ describe('createStrippedStream - correctness guards', () => {
 })
 
 describe('createStrippedStream - transport semantics', () => {
+  test('returns an oversized non-SSE response unchanged', async () => {
+    const body = new Uint8Array(MAX_SSE_LINE_BYTES + 1).fill(0x78)
+    const original = new Response(body, {
+      status: 502,
+      headers: { 'content-type': 'application/json' },
+    })
+
+    const result = createStrippedStream(original)
+
+    expect(result).toBe(original)
+    expect((await result.arrayBuffer()).byteLength).toBe(body.byteLength)
+  })
+
+  test('accepts event-stream media type parameters case-insensitively', async () => {
+    const response = createStrippedStream(
+      sseResponse([TOOL_EVENT], {
+        'content-type': 'Text/Event-Stream; charset=utf-8',
+      }),
+    )
+
+    expect(await readText(response)).toBe(EXPECTED)
+  })
+
   test('preserves status, statusText and passthrough headers', () => {
     const response = createStrippedStream(
       new Response(streamOf([TOOL_EVENT]), {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -426,7 +426,10 @@ describe('createStrippedStream', () => {
       },
     })
 
-    const original = new Response(stream, { status: 200 })
+    const original = new Response(stream, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })
     const stripped = createStrippedStream(original)
 
     const text = await stripped.text()
@@ -446,7 +449,10 @@ describe('createStrippedStream', () => {
     const original = new Response(stream, {
       status: 201,
       statusText: 'Created',
-      headers: { 'x-custom': 'value' },
+      headers: {
+        'content-type': 'text/event-stream',
+        'x-custom': 'value',
+      },
     })
 
     const stripped = createStrippedStream(original)
@@ -469,7 +475,11 @@ describe('createStrippedStream', () => {
       },
     })
 
-    const text = await createStrippedStream(new Response(stream)).text()
+    const text = await createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    ).text()
 
     expect(text).toContain('"name": "bash"')
     expect(text).not.toContain('mcp_')
@@ -486,7 +496,11 @@ describe('createStrippedStream', () => {
       },
     })
 
-    const text = await createStrippedStream(new Response(stream)).text()
+    const text = await createStrippedStream(
+      new Response(stream, {
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+    ).text()
 
     expect(text).toContain('Привет 👋')
     expect(text).toContain('"name": "read"')
@@ -496,6 +510,7 @@ describe('createStrippedStream', () => {
   test('drops stale content-length after rewriting the response body', () => {
     const original = new Response('data: {"name":"mcp_Read"}\n\n', {
       headers: {
+        'content-type': 'text/event-stream',
         'content-length': '999',
         'x-custom': 'value',
       },

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import dedent from 'dedent'
 import {
   CLAUDE_CODE_IDENTITY,
@@ -225,6 +225,10 @@ describe('stripToolPrefix', () => {
 describe('rewriteUrl', () => {
   const originalEnv = process.env.ANTHROPIC_BASE_URL
 
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_BASE_URL
+  })
+
   afterEach(() => {
     if (originalEnv === undefined) {
       delete process.env.ANTHROPIC_BASE_URL
@@ -447,6 +451,59 @@ describe('createStrippedStream', () => {
 
     const stripped = createStrippedStream(original)
     expect(stripped.status).toBe(201)
+    expect(stripped.headers.get('x-custom')).toBe('value')
+  })
+
+  test('strips a tool prefix split across arbitrary stream chunks', async () => {
+    const chunks = [
+      'data: {"content_block":{"type":"tool_use","na',
+      'me":"m',
+      'cp_B',
+      'ash"}}\n\n',
+    ]
+    const encoder = new TextEncoder()
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+        controller.close()
+      },
+    })
+
+    const text = await createStrippedStream(new Response(stream)).text()
+
+    expect(text).toContain('"name": "bash"')
+    expect(text).not.toContain('mcp_')
+  })
+
+  test('preserves unicode when every input byte is a separate chunk', async () => {
+    const input =
+      'data: {"text":"Привет 👋","content_block":{"name":"mcp_Read"}}\n\n'
+    const bytes = new TextEncoder().encode(input)
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const byte of bytes) controller.enqueue(Uint8Array.of(byte))
+        controller.close()
+      },
+    })
+
+    const text = await createStrippedStream(new Response(stream)).text()
+
+    expect(text).toContain('Привет 👋')
+    expect(text).toContain('"name": "read"')
+    expect(text).not.toContain('�')
+  })
+
+  test('drops stale content-length after rewriting the response body', () => {
+    const original = new Response('data: {"name":"mcp_Read"}\n\n', {
+      headers: {
+        'content-length': '999',
+        'x-custom': 'value',
+      },
+    })
+
+    const stripped = createStrippedStream(original)
+
+    expect(stripped.headers.get('content-length')).toBeNull()
     expect(stripped.headers.get('x-custom')).toBe('value')
   })
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -10,6 +10,9 @@ import {
   USER_AGENT,
 } from './constants.ts'
 
+// Bound an incomplete SSE line so malformed streams cannot grow memory forever.
+export const MAX_SSE_LINE_BYTES = 5 * 1024 * 1024
+
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
  * Claude Code uses PascalCase tool names (e.g. mcp_Bash, mcp_Read);
@@ -370,27 +373,79 @@ export function rewriteRequestBody(body: string): string {
 export function createStrippedStream(response: Response): Response {
   if (!response.body) return response
 
-  const reader = response.body.getReader()
   const decoder = new TextDecoder()
   const encoder = new TextEncoder()
+  let pending = new Uint8Array(0)
+  let pendingLength = 0
 
-  const stream = new ReadableStream({
-    async pull(controller) {
-      const { done, value } = await reader.read()
-      if (done) {
-        controller.close()
-        return
+  const appendPending = (bytes: Uint8Array) => {
+    const requiredLength = pendingLength + bytes.byteLength
+    if (requiredLength > MAX_SSE_LINE_BYTES) {
+      throw new Error(`SSE line exceeds ${MAX_SSE_LINE_BYTES} byte limit`)
+    }
+
+    if (requiredLength > pending.byteLength) {
+      let capacity = Math.max(1024, pending.byteLength)
+      while (capacity < requiredLength) {
+        capacity = Math.min(MAX_SSE_LINE_BYTES, capacity * 2)
       }
+      const expanded = new Uint8Array(capacity)
+      expanded.set(pending.subarray(0, pendingLength))
+      pending = expanded
+    }
 
-      let text = decoder.decode(value, { stream: true })
-      text = stripToolPrefix(text)
-      controller.enqueue(encoder.encode(text))
-    },
-  })
+    pending.set(bytes, pendingLength)
+    pendingLength = requiredLength
+  }
+
+  const stream = response.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        let lastLineBreak = -1
+        let lineLength = pendingLength
+        for (let index = 0; index < chunk.byteLength; index++) {
+          if (chunk[index] === 0x0a || chunk[index] === 0x0d) {
+            lastLineBreak = index
+            lineLength = 0
+          } else {
+            lineLength++
+            if (lineLength > MAX_SSE_LINE_BYTES) {
+              throw new Error(
+                `SSE line exceeds ${MAX_SSE_LINE_BYTES} byte limit`,
+              )
+            }
+          }
+        }
+
+        if (lastLineBreak < 0) {
+          appendPending(chunk)
+          return
+        }
+
+        const completeLines =
+          decoder.decode(pending.subarray(0, pendingLength), {
+            stream: true,
+          }) + decoder.decode(chunk.subarray(0, lastLineBreak + 1))
+
+        pendingLength = 0
+        appendPending(chunk.subarray(lastLineBreak + 1))
+        controller.enqueue(encoder.encode(stripToolPrefix(completeLines)))
+      },
+      flush(controller) {
+        const trailing = decoder.decode(pending.subarray(0, pendingLength))
+        if (trailing) {
+          controller.enqueue(encoder.encode(stripToolPrefix(trailing)))
+        }
+      },
+    }),
+  )
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
 
   return new Response(stream, {
     status: response.status,
     statusText: response.statusText,
-    headers: response.headers,
+    headers,
   })
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -371,7 +371,12 @@ export function rewriteRequestBody(body: string): string {
  * Create a streaming response that strips the tool prefix from tool names.
  */
 export function createStrippedStream(response: Response): Response {
-  if (!response.body) return response
+  const mediaType = response.headers
+    .get('content-type')
+    ?.split(';', 1)[0]
+    ?.trim()
+    .toLowerCase()
+  if (!response.body || mediaType !== 'text/event-stream') return response
 
   const decoder = new TextDecoder()
   const encoder = new TextEncoder()

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,7 +12,6 @@ import {
 
 // Bound an incomplete SSE line so malformed streams cannot grow memory forever.
 export const MAX_SSE_LINE_BYTES = 5 * 1024 * 1024
-export const MAX_RESPONSE_JSON_BYTES = 5 * 1024 * 1024
 
 function headersAfterBodyTransform(source: Headers): Headers {
   const headers = new Headers(source)
@@ -28,6 +27,222 @@ function headersAfterBodyTransform(source: Headers): Headers {
     headers.delete(name)
   }
   return headers
+}
+
+type JsonToolNameState =
+  | 'after-colon'
+  | 'after-name-key'
+  | 'key-candidate'
+  | 'outside'
+  | 'prefix-candidate'
+  | 'string'
+  | 'tool-name-candidate'
+
+const JSON_NAME_KEY_SUFFIX = new TextEncoder().encode('name"')
+const JSON_TOOL_PREFIX = new TextEncoder().encode(TOOL_PREFIX)
+const UTF8_ENCODER = new TextEncoder()
+const UTF8_FATAL_DECODER = new TextDecoder('utf-8', { fatal: true })
+export const MAX_JSON_TOOL_NAME_BYTES = 1024
+
+function isJsonWhitespace(byte: number): boolean {
+  return byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d
+}
+
+/**
+ * Rewrite JSON `name` string values without buffering the whole document.
+ * Only a bounded tool-name candidate is retained across chunks; all document
+ * content outside that string value is emitted immediately.
+ */
+function createJsonToolNameStream(
+  body: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+  let state: JsonToolNameState = 'outside'
+  let held: number[] = []
+  let candidateIndex = 0
+  let escaped = false
+
+  const enterStringAfter = (byte: number) => {
+    if (byte === 0x22) {
+      state = 'outside'
+      escaped = false
+      return
+    }
+    state = 'string'
+    escaped = byte === 0x5c
+  }
+
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const output = new Uint8Array(chunk.byteLength + 32)
+        let outputLength = 0
+        const write = (byte: number) => {
+          output[outputLength++] = byte
+        }
+        const enqueueOutput = () => {
+          if (outputLength === 0) return
+          controller.enqueue(output.slice(0, outputLength))
+          outputLength = 0
+        }
+        const writeHeld = () => {
+          for (const byte of held) write(byte)
+          held = []
+        }
+        const processOutside = (byte: number) => {
+          if (byte === 0x22) {
+            held = [byte]
+            candidateIndex = 0
+            state = 'key-candidate'
+            return
+          }
+          write(byte)
+        }
+
+        for (const byte of chunk) {
+          if (state === 'outside') {
+            processOutside(byte)
+            continue
+          }
+
+          if (state === 'key-candidate') {
+            if (byte === JSON_NAME_KEY_SUFFIX[candidateIndex]) {
+              held.push(byte)
+              candidateIndex++
+              if (candidateIndex === JSON_NAME_KEY_SUFFIX.byteLength) {
+                writeHeld()
+                state = 'after-name-key'
+              }
+              continue
+            }
+            writeHeld()
+            write(byte)
+            enterStringAfter(byte)
+            continue
+          }
+
+          if (state === 'string') {
+            write(byte)
+            if (escaped) {
+              escaped = false
+            } else if (byte === 0x5c) {
+              escaped = true
+            } else if (byte === 0x22) {
+              state = 'outside'
+            }
+            continue
+          }
+
+          if (state === 'after-name-key') {
+            if (isJsonWhitespace(byte)) {
+              write(byte)
+            } else if (byte === 0x3a) {
+              write(byte)
+              state = 'after-colon'
+            } else {
+              processOutside(byte)
+            }
+            continue
+          }
+
+          if (state === 'after-colon') {
+            if (isJsonWhitespace(byte)) {
+              write(byte)
+            } else if (byte === 0x22) {
+              write(byte)
+              held = []
+              candidateIndex = 0
+              state = 'prefix-candidate'
+            } else {
+              processOutside(byte)
+            }
+            continue
+          }
+
+          if (state === 'prefix-candidate') {
+            if (byte === JSON_TOOL_PREFIX[candidateIndex]) {
+              held.push(byte)
+              candidateIndex++
+              if (candidateIndex === JSON_TOOL_PREFIX.byteLength) {
+                held = []
+                candidateIndex = 0
+                escaped = false
+                state = 'tool-name-candidate'
+              }
+              continue
+            }
+            writeHeld()
+            write(byte)
+            enterStringAfter(byte)
+            continue
+          }
+
+          if (escaped) {
+            held.push(byte)
+            escaped = false
+            if (held.length > MAX_JSON_TOOL_NAME_BYTES) {
+              throw new Error(
+                `JSON tool name exceeds ${MAX_JSON_TOOL_NAME_BYTES} byte limit`,
+              )
+            }
+            continue
+          }
+
+          if (byte === 0x5c) {
+            held.push(byte)
+            escaped = true
+            if (held.length > MAX_JSON_TOOL_NAME_BYTES) {
+              throw new Error(
+                `JSON tool name exceeds ${MAX_JSON_TOOL_NAME_BYTES} byte limit`,
+              )
+            }
+            continue
+          }
+
+          if (byte === 0x22) {
+            let replacement: Uint8Array
+            if (held.length === 0) {
+              replacement = JSON_TOOL_PREFIX
+            } else {
+              try {
+                replacement = UTF8_ENCODER.encode(
+                  unprefixName(
+                    UTF8_FATAL_DECODER.decode(Uint8Array.from(held)),
+                  ),
+                )
+              } catch {
+                replacement = Uint8Array.from([...JSON_TOOL_PREFIX, ...held])
+              }
+            }
+            enqueueOutput()
+            controller.enqueue(replacement)
+            write(byte)
+            held = []
+            candidateIndex = 0
+            state = 'outside'
+            continue
+          }
+
+          held.push(byte)
+          if (held.length > MAX_JSON_TOOL_NAME_BYTES) {
+            throw new Error(
+              `JSON tool name exceeds ${MAX_JSON_TOOL_NAME_BYTES} byte limit`,
+            )
+          }
+        }
+
+        enqueueOutput()
+      },
+      flush(controller) {
+        const trailing = Uint8Array.from(
+          state === 'tool-name-candidate'
+            ? [...JSON_TOOL_PREFIX, ...held]
+            : held,
+        )
+        if (trailing.byteLength === 0) return
+        controller.enqueue(trailing)
+      },
+    }),
+  )
 }
 
 /**
@@ -395,57 +610,7 @@ export function createStrippedStream(response: Response): Response {
     .toLowerCase()
   if (!response.body) return response
   if (mediaType === 'application/json' || mediaType?.endsWith('+json')) {
-    const declaredLength = Number(response.headers.get('content-length'))
-    if (
-      Number.isFinite(declaredLength) &&
-      declaredLength > MAX_RESPONSE_JSON_BYTES
-    ) {
-      return response
-    }
-
-    const decoder = new TextDecoder('utf-8', { fatal: true })
-    const encoder = new TextEncoder()
-    let chunks: Uint8Array[] = []
-    let bufferedBytes = 0
-    let passthrough = false
-    const stream = response.body.pipeThrough(
-      new TransformStream<Uint8Array, Uint8Array>({
-        transform(chunk, controller) {
-          if (passthrough) {
-            controller.enqueue(chunk)
-            return
-          }
-
-          if (bufferedBytes + chunk.byteLength > MAX_RESPONSE_JSON_BYTES) {
-            for (const buffered of chunks) controller.enqueue(buffered)
-            chunks = []
-            bufferedBytes = 0
-            passthrough = true
-            controller.enqueue(chunk)
-            return
-          }
-
-          chunks.push(chunk)
-          bufferedBytes += chunk.byteLength
-        },
-        flush(controller) {
-          if (passthrough) return
-          const body = new Uint8Array(bufferedBytes)
-          let offset = 0
-          for (const chunk of chunks) {
-            body.set(chunk, offset)
-            offset += chunk.byteLength
-          }
-          try {
-            controller.enqueue(
-              encoder.encode(stripToolPrefix(decoder.decode(body))),
-            )
-          } catch {
-            controller.enqueue(body)
-          }
-        },
-      }),
-    )
+    const stream = createJsonToolNameStream(response.body)
     const headers = headersAfterBodyTransform(response.headers)
     return new Response(stream, {
       status: response.status,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -12,6 +12,23 @@ import {
 
 // Bound an incomplete SSE line so malformed streams cannot grow memory forever.
 export const MAX_SSE_LINE_BYTES = 5 * 1024 * 1024
+export const MAX_RESPONSE_JSON_BYTES = 5 * 1024 * 1024
+
+function headersAfterBodyTransform(source: Headers): Headers {
+  const headers = new Headers(source)
+  for (const name of [
+    'content-digest',
+    'content-encoding',
+    'content-length',
+    'content-md5',
+    'content-range',
+    'digest',
+    'etag',
+  ]) {
+    headers.delete(name)
+  }
+  return headers
+}
 
 /**
  * Prefix a tool name with TOOL_PREFIX and uppercase the first character.
@@ -376,7 +393,67 @@ export function createStrippedStream(response: Response): Response {
     ?.split(';', 1)[0]
     ?.trim()
     .toLowerCase()
-  if (!response.body || mediaType !== 'text/event-stream') return response
+  if (!response.body) return response
+  if (mediaType === 'application/json' || mediaType?.endsWith('+json')) {
+    const declaredLength = Number(response.headers.get('content-length'))
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > MAX_RESPONSE_JSON_BYTES
+    ) {
+      return response
+    }
+
+    const decoder = new TextDecoder('utf-8', { fatal: true })
+    const encoder = new TextEncoder()
+    let chunks: Uint8Array[] = []
+    let bufferedBytes = 0
+    let passthrough = false
+    const stream = response.body.pipeThrough(
+      new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          if (passthrough) {
+            controller.enqueue(chunk)
+            return
+          }
+
+          if (bufferedBytes + chunk.byteLength > MAX_RESPONSE_JSON_BYTES) {
+            for (const buffered of chunks) controller.enqueue(buffered)
+            chunks = []
+            bufferedBytes = 0
+            passthrough = true
+            controller.enqueue(chunk)
+            return
+          }
+
+          chunks.push(chunk)
+          bufferedBytes += chunk.byteLength
+        },
+        flush(controller) {
+          if (passthrough) return
+          const body = new Uint8Array(bufferedBytes)
+          let offset = 0
+          for (const chunk of chunks) {
+            body.set(chunk, offset)
+            offset += chunk.byteLength
+          }
+          try {
+            controller.enqueue(
+              encoder.encode(stripToolPrefix(decoder.decode(body))),
+            )
+          } catch {
+            controller.enqueue(body)
+          }
+        },
+      }),
+    )
+    const headers = headersAfterBodyTransform(response.headers)
+    return new Response(stream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  }
+  if (mediaType !== 'text/event-stream') return response
 
   const decoder = new TextDecoder()
   const encoder = new TextEncoder()
@@ -445,8 +522,7 @@ export function createStrippedStream(response: Response): Response {
     }),
   )
 
-  const headers = new Headers(response.headers)
-  headers.delete('content-length')
+  const headers = headersAfterBodyTransform(response.headers)
 
   return new Response(stream, {
     status: response.status,


### PR DESCRIPTION
Fixes SSE rewriting across arbitrary chunk boundaries and split UTF-8 characters, and drops the stale content-length after body rewriting. Includes regression tests. Independent of #211.