### PR TITLE
fix: bump reported Claude Code version to 2.1.258

### DIFF
--- a/.changeset/olive-donuts-shave.md
+++ b/.changeset/olive-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@ex-machina/opencode-anthropic-auth': patch
+---
+
+Bump the reported Claude Code version from `2.1.87` to `2.1.258`. Anthropic gates model access on this value server-side, so newer models were rejected with a 400 `claude_code_version_too_old`: "Claude Code 2.1.87 does not support this model; version 2.1.251 or newer is required". `USER_AGENT` is now derived from `CLAUDE_CODE_VERSION` instead of repeating the version in a second literal, so future bumps only need to change one constant.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,10 +32,20 @@ export const CLAUDE_CODE_IDENTITY =
 
 export const CCH_SALT = '59cf53e54c78'
 export const CCH_POSITIONS = [4, 7, 20]
-export const CLAUDE_CODE_VERSION = '2.1.87'
+/**
+ * The Claude Code version we report to Anthropic, via both the `user-agent`
+ * header and the `cc_version` field of the billing header.
+ *
+ * Anthropic gates new models on this value server-side: requesting a model
+ * newer than the reported client returns a 400 `claude_code_version_too_old`
+ * (e.g. "Claude Code 2.1.87 does not support this model; version 2.1.251 or
+ * newer is required"). Keep this at or above the latest published
+ * `@anthropic-ai/claude-code` release, otherwise new models are unreachable.
+ */
+export const CLAUDE_CODE_VERSION = '2.1.258'
 export const CLAUDE_CODE_ENTRYPOINT = 'sdk-cli'
 
-export const USER_AGENT = 'claude-cli/2.1.87 (external, cli)'
+export const USER_AGENT = `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`
 
 /**
  * Anchors that identify paragraphs to remove from the system prompt.

--- a/src/tests/__snapshots__/transform.test.ts.snap
+++ b/src/tests/__snapshots__/transform.test.ts.snap
@@ -146,7 +146,7 @@ exports[`sanitizeSystemText – realistic prompt rewriteRequestBody output snaps
   ],
   "system": [
     {
-      "text": "x-anthropic-billing-header: cc_version=2.1.87.16a; cc_entrypoint=sdk-cli; cch=185f8;",
+      "text": "x-anthropic-billing-header: cc_version=2.1.258.59d; cc_entrypoint=sdk-cli; cch=185f8;",
       "type": "text",
     },
     {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 import dedent from 'dedent'
 import {
   CLAUDE_CODE_IDENTITY,
+  CLAUDE_CODE_VERSION,
   OPENCODE_IDENTITY_PREFIX,
   REQUIRED_BETAS,
 } from '../constants'
@@ -119,6 +120,16 @@ describe('setOAuthHeaders', () => {
     const headers = new Headers()
     setOAuthHeaders(headers, 'token')
     expect(headers.get('user-agent')).toContain('claude-cli')
+  })
+
+  // The user-agent and the billing header's cc_version must report the same
+  // version; Anthropic gates model access on it.
+  test('reports CLAUDE_CODE_VERSION in the user-agent', () => {
+    const headers = new Headers()
+    setOAuthHeaders(headers, 'token')
+    expect(headers.get('user-agent')).toBe(
+      `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`,
+    )
   })
 
   test('removes x-api-key', () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -122,16 +122,6 @@ describe('setOAuthHeaders', () => {
     expect(headers.get('user-agent')).toContain('claude-cli')
   })
 
-  // The user-agent and the billing header's cc_version must report the same
-  // version; Anthropic gates model access on it.
-  test('reports CLAUDE_CODE_VERSION in the user-agent', () => {
-    const headers = new Headers()
-    setOAuthHeaders(headers, 'token')
-    expect(headers.get('user-agent')).toBe(
-      `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`,
-    )
-  })
-
   test('removes x-api-key', () => {
     const headers = new Headers({ 'x-api-key': 'sk-ant-xxx' })
     setOAuthHeaders(headers, 'token')
@@ -834,6 +824,27 @@ describe('rewriteRequestBody', () => {
 
     // User message is untouched
     expect(result.messages[0].content).toBe('hi')
+  })
+})
+
+describe('reported Claude Code version', () => {
+  // Anthropic gates model access on the version we report, and we report it
+  // twice: in the user-agent header and in the billing header's cc_version.
+  // If those ever disagree, one of them is stale and new models start failing
+  // with a 400 claude_code_version_too_old. Assert both against the constant.
+  test('user-agent and billing header both report CLAUDE_CODE_VERSION', () => {
+    const headers = new Headers()
+    setOAuthHeaders(headers, 'token')
+    expect(headers.get('user-agent')).toBe(
+      `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`,
+    )
+
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'hello world test message' }],
+    })
+    const billingHeader = JSON.parse(rewriteRequestBody(body)).system[0].text
+    // cc_version is `<version>.<3-char suffix>`, so match the version segment.
+    expect(billingHeader).toContain(`cc_version=${CLAUDE_CODE_VERSION}.`)
   })
 })
 


### PR DESCRIPTION
Newer Anthropic models are unreachable through the plugin because it reports Claude Code `2.1.87`, and Anthropic gates model access on that value server-side.

Requesting `claude-fable-5-1` returns:

```
400 invalid_request_error
Claude Code 2.1.87 does not support this model; version 2.1.251 or newer is required.
Run 'claude update', or update the Claude desktop app, then try again.
error_code: claude_code_version_too_old
```

## Changes

- Bump `CLAUDE_CODE_VERSION` to `2.1.258` (latest published `@anthropic-ai/claude-code` at time of writing).
- Derive `USER_AGENT` from `CLAUDE_CODE_VERSION` rather than repeating the version in a second string literal. The version reaches Anthropic through two paths — the `user-agent` header and the `cc_version` field of the billing header injected as `system[0]` — and they were independently hardcoded, so a bump could easily update one and miss the other.
- Add a regression test asserting the `user-agent` reports `CLAUDE_CODE_VERSION`.
- Document the gating behaviour on the constant so the reason for keeping it current is discoverable.

`computeVersionSuffix` derives the `cc_version` suffix locally from `CCH_SALT` + sampled message characters + version, so bumping recomputes it correctly with no other coordination needed. The only follow-on change is the `transform.test.ts` snapshot, which pins the rendered billing header.

## Verification

Live `POST /v1/messages?beta=true` against `claude-fable-5-1` using the plugin's own `buildBillingHeaderValue` and `USER_AGENT`:

- `2.1.258` → `200`, model responds normally
- `2.1.87` → `400 claude_code_version_too_old`

Local checks: `bun test` 119 pass / 0 fail (baseline was 118/0), `bun run types` clean, `bun run lint` clean, `bun run format:check` clean.

## Note

This is a moving target — the constant will go stale again the next time Anthropic ships a gated model. Deriving the user-agent at least reduces it to a one-line bump. If you want, a follow-up could read the version from an env var override so users can unblock themselves without waiting on a release.