### PR TITLE
Add Turbo to consolidate CI checks into `bun check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
       - run: bun install --frozen-lockfile
-      - run: bun run types
-      - run: bun run build
-      - run: bun test
-      - run: bun run format:check
-      - run: bun run lint
+      - run: bun check

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist/
+.turbo/
 
 # Agent Facets managed
 .agents/

--- a/biome.json
+++ b/biome.json
@@ -15,9 +15,14 @@
   "linter": {
     "enabled": true
   },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["src/**", "script/**", "*.json", "*.yml"]
+    "includes": ["src/**", "scripts/**", "*.json", "*.yml"]
   },
   "overrides": [
     {

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@types/bun": "1.3.14",
         "dedent": "^1.7.2",
         "lefthook": "2.1.9",
+        "turbo": "2.9.18",
         "typescript": "6.0.3",
       },
       "peerDependencies": {
@@ -112,6 +113,18 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tsconfig/bun": ["@tsconfig/bun@1.0.10", "", {}, "sha512-5AV5YknQjNyoYzZ/8NG0dawqew/wH+x7ANiCfCIn29qo0cdbd1EryvFD1k5NSZWLBMOI/fGqMIaxi58GPIP9Cg=="],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.18", "", { "os": "linux", "cpu": "x64" }, "sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.18", "", { "os": "win32", "cpu": "x64" }, "sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -314,6 +327,8 @@
     "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "turbo": ["turbo@2.9.18", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.18", "@turbo/darwin-arm64": "2.9.18", "@turbo/linux-64": "2.9.18", "@turbo/linux-arm64": "2.9.18", "@turbo/windows-64": "2.9.18", "@turbo/windows-arm64": "2.9.18" }, "bin": { "turbo": "bin/turbo" } }, "sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 

--- a/facets.json
+++ b/facets.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": 0.2,
   "facets": {
-    "viper-plans": "1.3.0"
+    "viper-plans": "1.3.1"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -6,8 +6,8 @@
         "kind": "registry",
         "registry": "https://api.agentfacets.io"
       },
-      "version": "1.3.0",
-      "integrity": "sha256:be85be9bc09b87be4ffca314ec83cd317589a3da573ec73abc28e0cdda0e2ab2",
+      "version": "1.3.1",
+      "integrity": "sha256:fb53a7239e3bf13114ec8196231e3d11d9ae126aa1a55eaaa23a1848c8e80c94",
       "assets": [
         {
           "scope": "project",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "packageManager": "bun@1.3.14",
   "engines": {
     "bun": "1.3.14"
   },
@@ -19,11 +20,12 @@
     "dev": "bun scripts/dev.ts",
     "dev:clean": "bun scripts/dev-clean.ts",
     "extract": "bun scripts/extract-system-prompt.ts",
+    "check": "bun turbo check:all",
     "test": "bun test",
     "types": "tsc",
     "format": "biome check --write --unsafe",
     "format:check": "biome format .",
-    "lint": "biome lint .",
+    "lint": "biome lint --error-on-warnings .",
     "change": "changeset",
     "release": "bun run build && bun change publish"
   },
@@ -39,6 +41,7 @@
     "@types/bun": "1.3.14",
     "dedent": "^1.7.2",
     "lefthook": "2.1.9",
+    "turbo": "2.9.18",
     "typescript": "6.0.3"
   }
 }

--- a/scripts/dev-clean.ts
+++ b/scripts/dev-clean.ts
@@ -1,7 +1,13 @@
 import { existsSync, unlinkSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const SYMLINK_PATH = resolve(import.meta.dirname, '..', '.opencode', 'plugins', 'anthropic-auth.js')
+const SYMLINK_PATH = resolve(
+  import.meta.dirname,
+  '..',
+  '.opencode',
+  'plugins',
+  'anthropic-auth.js',
+)
 
 if (existsSync(SYMLINK_PATH)) {
   unlinkSync(SYMLINK_PATH)

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs'
 import { resolve } from 'node:path'
 
-const PROJECT_ROOT = resolve(import.meta.dirname!, '..')
+const PROJECT_ROOT = resolve(import.meta.dirname, '..')
 const PLUGINS_DIR = resolve(PROJECT_ROOT, '.opencode', 'plugins')
 const SYMLINK_PATH = resolve(PLUGINS_DIR, 'anthropic-auth.js')
 const TARGET = '../../dist/index.js' // relative from .opencode/plugins/
@@ -19,7 +19,9 @@ function createSymlink() {
     try {
       const current = readlinkSync(SYMLINK_PATH)
       if (current === TARGET) {
-        console.log(`[dev] Symlink already exists: ${SYMLINK_PATH} -> ${TARGET}`)
+        console.log(
+          `[dev] Symlink already exists: ${SYMLINK_PATH} -> ${TARGET}`,
+        )
         return
       }
     } catch {}
@@ -57,11 +59,14 @@ createSymlink()
 // 3. Start tsc --watch
 console.log('[dev] Starting tsc --watch...')
 console.log('[dev] Restart OpenCode to pick up the linked plugin.')
-const child = Bun.spawn(['tsc', '-p', 'tsconfig.build.json', '--watch', '--preserveWatchOutput'], {
-  cwd: PROJECT_ROOT,
-  stdout: 'inherit',
-  stderr: 'inherit',
-})
+const child = Bun.spawn(
+  ['tsc', '-p', 'tsconfig.build.json', '--watch', '--preserveWatchOutput'],
+  {
+    cwd: PROJECT_ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  },
+)
 
 function cleanup() {
   console.log('\n[dev] Cleaning up...')

--- a/scripts/extract-system-prompt.ts
+++ b/scripts/extract-system-prompt.ts
@@ -140,10 +140,10 @@ const systemText = best.system
   .join('\n\n')
 
 if (values.output) {
-  writeFileSync(values.output, systemText + '\n')
+  writeFileSync(values.output, `${systemText}\n`)
   console.log(
     `Extracted system prompt (${systemText.length} chars) → ${values.output}`,
   )
 } else {
-  process.stdout.write(systemText + '\n')
+  process.stdout.write(`${systemText}\n`)
 }

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import dedent from 'dedent'
 import {
   CLAUDE_CODE_IDENTITY,
@@ -225,6 +225,10 @@ describe('stripToolPrefix', () => {
 
 describe('rewriteUrl', () => {
   const originalEnv = process.env.ANTHROPIC_BASE_URL
+
+  beforeEach(() => {
+    delete process.env.ANTHROPIC_BASE_URL
+  })
 
   afterEach(() => {
     if (originalEnv === undefined) {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "globalDependencies": ["bun.lock", "mise.toml"],
+  "globalPassThroughEnv": ["ANTHROPIC_BASE_URL", "ANTHROPIC_INSECURE"],
+  "tasks": {
+    "check:all": {
+      "dependsOn": ["types", "build", "test", "format:check", "lint"]
+    },
+    "types": {},
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "test": {},
+    "format:check": {},
+    "lint": {}
+  },
+  "ui": "tui"
+}


### PR DESCRIPTION
Introduces [Turbo](https://turbo.build/) as a task runner to consolidate the CI check pipeline. Previously, CI ran five separate steps (`types`, `build`, `test`, `format:check`, `lint`) sequentially. These are now orchestrated through a single `bun check` command that delegates to `turbo check:all`, enabling caching and a TUI output mode.

Additional changes:
- Enables `--error-on-warnings` for the Biome linter
- Enables Biome's VCS integration so it respects `.gitignore`
- Adds a `beforeEach` hook in `transform.test.ts` to reset `ANTHROPIC_BASE_URL` before each test, preventing state leakage between tests
- Adds `packageManager` field to `package.json`
- Ignores `.turbo/` in `.gitignore`