### PR TITLE
Add a guarded v2 prerelease release train

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -29,8 +29,10 @@ When changesets are merged to a release branch, the [publish workflow](../.githu
 2. Opens a release PR with the result
 3. When that PR is merged, publishes to npm
 
-This branch (`v2/main`) is permanently in changesets prerelease mode under the `next` tag —
-`pre.json` in this directory is committed state, not scratch state, and must never be deleted.
+This branch (`v2/main`) stays in changesets prerelease mode under the `next` tag for as long
+as v2 ships as a prerelease — `pre.json` in this directory is committed state, not scratch
+state. Never delete it as part of ordinary work or conflict resolution. The single exception
+is the deliberate promotion to `latest`, where `changeset pre exit` retires it on purpose.
 It publishes `2.x.y-next.N` to npm's `next` tag, while `main` publishes the v1 line to `latest`.
 
 **[RELEASING.md](../RELEASING.md) is the authoritative runbook** for both trains, the publish

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -23,11 +23,19 @@ Not every PR needs a changeset — changes to docs, CI, or other non-published f
 
 ### Releases
 
-When changesets are merged to `main`, the [publish workflow](../.github/workflows/publish.yml) automatically:
+When changesets are merged to a release branch, the [publish workflow](../.github/workflows/publish.yml) automatically:
 
 1. Runs `bun change version` to consume all pending changesets, bump the version, and update the changelog
 2. Opens a release PR with the result
-3. When that PR is merged, runs `bun change publish` to publish to npm
+3. When that PR is merged, publishes to npm
+
+This branch (`v2/main`) is permanently in changesets prerelease mode under the `next` tag —
+`pre.json` in this directory is committed state, not scratch state, and must never be deleted.
+It publishes `2.x.y-next.N` to npm's `next` tag, while `main` publishes the v1 line to `latest`.
+
+**[RELEASING.md](../RELEASING.md) is the authoritative runbook** for both trains, the publish
+guard that prevents a v1-shaped prerelease from reaching the `next` tag, and the manual
+`main` → `v2/main` sync process.
 
 ### Adding changesets on behalf of contributors
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,6 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "v2/main",
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,7 +2,7 @@
   "mode": "pre",
   "tag": "next",
   "initialVersions": {
-    "@ex-machina/opencode-anthropic-auth": "1.8.1"
+    "@ex-machina/opencode-anthropic-auth": "1.8.2"
   },
   "changesets": []
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,8 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@ex-machina/opencode-anthropic-auth": "1.8.1"
+  },
+  "changesets": []
+}

--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,7 @@
+---
+'@ex-machina/opencode-anthropic-auth': patch
+---
+
+Carry the reported Claude Code version bump (`2.1.87` → `2.1.258`) into the v2 release line. Anthropic gates model access on this value server-side, so newer models were rejected with a 400 `claude_code_version_too_old`: "Claude Code 2.1.87 does not support this model; version 2.1.251 or newer is required". `USER_AGENT` is derived from `CLAUDE_CODE_VERSION` instead of repeating the version in a second literal, so future bumps only need to change one constant.
+
+The code already reached `v2/main`, but its original changeset was consumed by the v1.8.2 release on `main`, so this restates the release note for the v2 changelog.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit only auto-reviews PRs targeting the default branch. This repository runs a
+# second, long-lived release branch — `v2/main`, the OpenCode v2 line — so PRs against it
+# were being skipped with "Auto reviews are disabled on base/target branches other than
+# the default branch". Registering it here restores review coverage for that train.
+#
+# `inheritance: true` is load-bearing. A repository config outranks the organization UI
+# settings, so without it this file would *replace* the org configuration wholesale rather
+# than adding one key to it. With inheritance on, CodeRabbit deep-merges the parent
+# settings and only the values below win.
+# https://docs.coderabbit.ai/configuration/configuration-inheritance
+inheritance: true
+
+reviews:
+  auto_review:
+    base_branches:
+      - v2/main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,10 @@ name: Publish
 on:
   push:
     branches:
-      - main
+      - v2/main
 
 concurrency:
-  group: publish
+  group: publish-v2-next
 
 jobs:
   publish:
@@ -39,9 +39,9 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: bun change version
-          publish: bun run release
-          commit: "chore: version package"
-          title: "chore: version package"
+          publish: bun run release:next
+          commit: "chore(v2): version next package"
+          title: "chore(v2): version next package"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ""

--- a/README.md
+++ b/README.md
@@ -103,13 +103,15 @@ bun run dev:clean
 
 ### Publishing
 
-This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing. See the [changeset README](.changeset/README.md) for more details.
+This project uses [changesets](https://github.com/changesets/changesets) for versioning and publishing. See the [changeset README](.changeset/README.md) for contributor details.
 
 ```bash
 bun change          # create a changeset describing your changes
 ```
 
-When changesets are merged to `main`, CI will automatically open a release PR. Merging that PR publishes to npm.
+Changesets merged to a release branch cause CI to open a release PR; merging that PR publishes to npm. This repository runs two release trains — `main` publishes the v1 line to npm's `latest`, and `v2/main` publishes the v2 line to `next` as `2.x.y-next.N` prereleases.
+
+Maintainers: see [RELEASING.md](RELEASING.md) for the full runbook, including how `main` is synced into `v2/main`.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,165 @@
+# Releasing
+
+This is the authoritative maintainer runbook for both release trains. `README.md` and
+[`.changeset/README.md`](.changeset/README.md) link here rather than restating any of it.
+
+## Branches and channels
+
+| Branch    | Plugin line | OpenCode | npm dist-tag | Versions        |
+|-----------|-------------|----------|--------------|-----------------|
+| `main`    | v1          | v1       | `latest`     | `1.x.y`         |
+| `v2/main` | v2          | v2       | `next`       | `2.x.y-next.N`  |
+
+Both branches publish the **same** npm package, `@ex-machina/opencode-anthropic-auth`.
+There is no separate `-next` package.
+
+`latest` belongs to v1 until we decide v2 is the default. `v2/main` is permanently in
+changesets prerelease mode, so it can never take `latest` by accident.
+
+`v2/main` is a long-lived branch, not a feature branch. It is never merged back into
+`main`; changes flow one way, `main` → `v2/main`.
+
+## Installing
+
+v1 (default):
+
+```json
+{ "plugin": ["@ex-machina/opencode-anthropic-auth"] }
+```
+
+v2 prerelease (opt-in). Pin exactly — `@next` moves whenever a prerelease publishes:
+
+```json
+{ "plugin": ["@ex-machina/opencode-anthropic-auth@2.0.0-next.0"] }
+```
+
+## Releasing v1 from `main`
+
+Unchanged from before the v2 train existed:
+
+1. A PR merges to `main` with a changeset.
+2. [`publish.yml`](.github/workflows/publish.yml) on `main` opens or updates the
+   `chore: version package` release PR.
+3. Merging that release PR runs `bun run release`, publishing to `latest`.
+
+## Releasing v2 from `v2/main`
+
+1. A PR merges to `v2/main` with a changeset.
+2. `publish.yml` on `v2/main` opens or updates the `chore(v2): version next package`
+   release PR. Because `.changeset/pre.json` is committed, `changeset version` produces
+   a `-next.N` version and bumps the counter on every subsequent run.
+3. Merging that release PR runs `bun run release:next`, which publishes to `next`.
+
+The two trains are isolated: different trigger branches, different concurrency groups
+(`publish` vs `publish-v2-next`), different release-PR titles, different publish commands.
+
+### The publish guard
+
+`bun run release:next` runs [`scripts/validate-next-release.ts`](scripts/validate-next-release.ts)
+before `changeset publish`. It aborts unless all of the following hold:
+
+- the package is `@ex-machina/opencode-anthropic-auth`
+- `.changeset/pre.json` exists and `mode` is `pre`
+- the pre `tag` is `next`
+- the version matches `2.x.y-next.N`
+
+This exists because changesets versions from wherever the branch currently sits. Until the
+v2 major changeset lands, a v2 release PR resolves to something like `1.8.2-next.0` — a
+v1-shaped prerelease on the v2 channel. **Do not merge a v2 release PR whose version is
+below `2.0.0-next.0`.** If one is merged anyway, the guard fails the job and nothing is
+published; the release PR simply reopens on the next push.
+
+Leave such a release PR sitting open. It is harmless, and it will re-resolve to
+`2.0.0-next.0` as soon as a `major` changeset lands on `v2/main`.
+
+If the v2 line ever moves to major 3, update `EXPECTED_MAJOR` in the guard in the same PR
+that lands the major changeset.
+
+## Syncing `main` → `v2/main`
+
+Sync PRs are created by hand. There is no scheduled or automated sync.
+
+```bash
+git fetch origin
+git switch --create sync/main-to-v2 origin/v2/main
+git merge origin/main
+# resolve conflicts per the table below
+gh pr create --base v2/main --title "chore: sync main into v2/main"
+```
+
+Review it like any other PR, then merge it.
+
+### Timing: sync before the v1 release PR merges
+
+A change's changeset file only exists between "the change merged to `main`" and "the v1
+release PR consumed it". Sync inside that window and the changeset rides along on its own,
+giving v2 the same release note for free.
+
+If you sync after the v1 release PR merged, the changeset is gone — the merge brings the
+code and the v1 `CHANGELOG.md`/`package.json` bump, but no release intent for v2. In that
+case **add a replacement changeset to the sync PR** describing the same change, so it
+appears in the v2 changelog. Do not skip it; a silently missing release note is worse than
+a duplicated one.
+
+### Conflict resolution
+
+Conflicts are expected and concentrated in release-owned files. `v2/main` always wins for
+anything that defines the v2 release train:
+
+| File | Resolution |
+|---|---|
+| `.changeset/pre.json` | Keep v2's. Never delete it. |
+| `.changeset/config.json` | Keep v2's `"baseBranch": "v2/main"`. |
+| `.github/workflows/publish.yml` | Keep v2's trigger, concurrency group, titles, and `release:next`. Take any genuine infrastructure improvement from `main` (action bumps, node version) by hand. |
+| `package.json` version | Keep v2's `-next` version. Never take `main`'s `1.x.y`. |
+| `package.json` scripts | Keep both `release` and `release:next`. |
+| `CHANGELOG.md` | Keep both histories. v1 entries above the v2 entries is fine; the file is append-only prose. |
+| `README.md` pin examples | Keep v2's examples. |
+| `bun.lock` | Resolve semantically: take the merged dependency set and re-run `bun install`, then commit the result. Never hand-edit. |
+| `src/**` | Resolve on the merits, like any code conflict. |
+
+Always run the full check suite locally on the merged tree before opening the sync PR:
+
+```bash
+bun install --frozen-lockfile
+bun run types && bun run build && bun test && bun run format:check && bun run lint
+```
+
+### Worked examples
+
+**#223 — synced after its changeset was consumed.** #223 merged to `main`, then release PR
+#224 consumed its changeset and shipped v1.8.2. Syncing it to `v2/main` therefore requires
+a replacement patch changeset in the sync PR restating the Claude Code version bump.
+
+**#218 — synced before its changeset is consumed.** Merge #218 to `main`, then open the
+sync PR *before* merging the resulting v1 release PR. `.changeset/calm-streams-flow.md`
+comes across in the merge and needs no replacement.
+
+## Promotion to `latest` (deferred)
+
+Not scheduled. When v2 becomes the default, it happens as its own reviewed change:
+
+1. `bun change pre exit` on `v2/main`. This flips `.changeset/pre.json` to `"mode": "exit"`;
+   the next `changeset version` drops the `-next.N` suffix and deletes the file.
+2. Retire or rewrite the `release:next` guard — it exists specifically to prevent stable
+   publishes and will block this.
+3. Version and publish `2.0.0` to `latest`.
+4. Decide `main`'s fate: keep it as a maintenance line for `1.x` (published with an
+   explicit `--tag`, never `latest`), or freeze it.
+5. Update `README.md` and this file.
+
+Until every one of those steps happens deliberately, `latest` stays on v1.
+
+## Rollback
+
+The v2 channel is prerelease, so rollback is cheap:
+
+- **Bad prerelease published.** Publish a fixed `-next.N+1`. Optionally
+  `npm deprecate '@ex-machina/opencode-anthropic-auth@2.0.0-next.N' '...'`. Users who
+  pinned exactly are unaffected until they move.
+- **Never** repair a v2 problem by moving `latest`. `latest` is a v1 pointer.
+- **Release train misbehaving.** Stop merging v2 release PRs. Nothing publishes without a
+  release-PR merge, so leaving them open is a complete stop.
+- **Prerelease mode lost.** If `.changeset/pre.json` is deleted (usually a bad conflict
+  resolution), the guard blocks the publish. Restore it with
+  `bun change pre enter next` and re-check the version in `package.json`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,8 +13,10 @@ This is the authoritative maintainer runbook for both release trains. `README.md
 Both branches publish the **same** npm package, `@ex-machina/opencode-anthropic-auth`.
 There is no separate `-next` package.
 
-`latest` belongs to v1 until we decide v2 is the default. `v2/main` is permanently in
-changesets prerelease mode, so it can never take `latest` by accident.
+`latest` belongs to v1 until we decide v2 is the default. `v2/main` stays in changesets
+prerelease mode for as long as v2 ships as a prerelease, so it can never take `latest` by
+accident. Leaving that mode is a deliberate, reviewed step — see
+[Promotion to `latest`](#promotion-to-latest-deferred).
 
 `v2/main` is a long-lived branch, not a feature branch. It is never merged back into
 `main`; changes flow one way, `main` → `v2/main`.
@@ -27,14 +29,18 @@ v1 (default):
 { "plugin": ["@ex-machina/opencode-anthropic-auth"] }
 ```
 
-v2 prerelease (opt-in), using OpenCode v2's `plugins` key. Pin exactly — `@next` moves
-whenever a prerelease publishes:
+v2 prerelease (opt-in), using OpenCode v2's `plugins` key. Substitute a prerelease that
+actually exists — `npm view @ex-machina/opencode-anthropic-auth dist-tags` shows the current
+`next`:
 
 ```json
-{ "plugins": ["@ex-machina/opencode-anthropic-auth@2.0.0-next.0"] }
+{ "plugins": ["@ex-machina/opencode-anthropic-auth@<2.x.y-next.N>"] }
 ```
 
-Nothing is published to `next` yet; the first prerelease waits on the v2 port.
+Pin the exact version rather than tracking `@next`, which moves on every prerelease publish.
+
+Nothing is published to `next` yet — the first prerelease waits on the v2 port — so there is
+no version to substitute until then.
 
 ## Releasing v1 from `main`
 
@@ -133,7 +139,7 @@ anything that defines the v2 release train:
 
 | File | Resolution |
 |---|---|
-| `.changeset/pre.json` | Keep v2's. Never delete it. |
+| `.changeset/pre.json` | Keep v2's. Never delete it here — only promotion retires it. |
 | `.changeset/config.json` | Keep v2's `"baseBranch": "v2/main"`. |
 | `.github/workflows/publish.yml` | Keep v2's trigger, concurrency group, titles, and `release:next`. Take any genuine infrastructure improvement from `main` (action bumps, node version) by hand. |
 | `package.json` version | Keep v2's `-next` version. Never take `main`'s `1.x.y`. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,11 +27,14 @@ v1 (default):
 { "plugin": ["@ex-machina/opencode-anthropic-auth"] }
 ```
 
-v2 prerelease (opt-in). Pin exactly — `@next` moves whenever a prerelease publishes:
+v2 prerelease (opt-in), using OpenCode v2's `plugins` key. Pin exactly — `@next` moves
+whenever a prerelease publishes:
 
 ```json
-{ "plugin": ["@ex-machina/opencode-anthropic-auth@2.0.0-next.0"] }
+{ "plugins": ["@ex-machina/opencode-anthropic-auth@2.0.0-next.0"] }
 ```
+
+Nothing is published to `next` yet; the first prerelease waits on the v2 port.
 
 ## Releasing v1 from `main`
 
@@ -45,13 +48,25 @@ Unchanged from before the v2 train existed:
 ## Releasing v2 from `v2/main`
 
 1. A PR merges to `v2/main` with a changeset.
-2. `publish.yml` on `v2/main` opens or updates the `chore(v2): version next package`
-   release PR. Because `.changeset/pre.json` is committed, `changeset version` produces
-   a `-next.N` version and bumps the counter on every subsequent run.
+2. `publish.yml` on `v2/main` opens or updates the `chore(v2): version next package (next)`
+   release PR. Because `.changeset/pre.json` is committed, `changeset version` produces a
+   `-next.N` version. (The action appends the pre tag to the title and commit message
+   itself, which is where the trailing `(next)` comes from.)
 3. Merging that release PR runs `bun run release:next`, which publishes to `next`.
 
 The two trains are isolated: different trigger branches, different concurrency groups
 (`publish` vs `publish-v2-next`), different release-PR titles, different publish commands.
+
+### How the release PR recomputes
+
+The release branch (`changeset-release/v2/main`) is **reset to the head of `v2/main` on
+every run** and re-versioned from scratch. An open release PR is therefore a preview of
+"what would ship if I merged right now", not an accumulating stack. Consequences:
+
+- Leaving a release PR open costs nothing. It does not burn `-next.N` counters.
+- The `-next.N` counter only advances when a release PR is **merged**, because that is what
+  moves `package.json` and `.changeset/pre.json` on `v2/main` itself.
+- Force-pushes to the release branch are expected and are not a sign of trouble.
 
 ### The publish guard
 
@@ -64,13 +79,23 @@ before `changeset publish`. It aborts unless all of the following hold:
 - the version matches `2.x.y-next.N`
 
 This exists because changesets versions from wherever the branch currently sits. Until the
-v2 major changeset lands, a v2 release PR resolves to something like `1.8.2-next.0` — a
-v1-shaped prerelease on the v2 channel. **Do not merge a v2 release PR whose version is
-below `2.0.0-next.0`.** If one is merged anyway, the guard fails the job and nothing is
-published; the release PR simply reopens on the next push.
+v2 major changeset lands, a v2 release PR resolves to something like `1.8.3-next.0` — a
+v1-shaped prerelease on the v2 channel.
 
-Leave such a release PR sitting open. It is harmless, and it will re-resolve to
-`2.0.0-next.0` as soon as a `major` changeset lands on `v2/main`.
+**Do not merge a v2 release PR whose version is below `2.0.0-next.0`.** Leave it open. It
+costs nothing, and because the release branch is recomputed from scratch on every run
+(see above), it will re-resolve to `2.0.0-next.0` as soon as a `major` changeset lands.
+
+If you merge one anyway, it is recoverable but messy:
+
+- The publish job fails on the guard. Nothing reaches npm — that is the guard working.
+- `v2/main` is now sitting on a `1.x.y-next.N` version with a `CHANGELOG.md` entry for a
+  release that does not exist.
+- Every later push to `v2/main` with no pending changesets re-runs publish and **fails
+  again**, so the branch stays red until the version reaches 2.x.
+- To recover, land the `major` changeset and merge the resulting release PR. The counter
+  continues from where the bad merge left it, so the first real prerelease will be
+  `2.0.0-next.N+1` rather than `2.0.0-next.0`. Cosmetic, but permanent.
 
 If the v2 line ever moves to major 3, update `EXPECTED_MAJOR` in the guard in the same PR
 that lands the major changeset.
@@ -127,13 +152,16 @@ bun run types && bun run build && bun test && bun run format:check && bun run li
 
 ### Worked examples
 
-**#223 — synced after its changeset was consumed.** #223 merged to `main`, then release PR
-#224 consumed its changeset and shipped v1.8.2. Syncing it to `v2/main` therefore requires
-a replacement patch changeset in the sync PR restating the Claude Code version bump.
+**#223 — code arrived after its changeset was consumed.** #223 merged to `main`, then
+release PR #224 consumed its changeset and shipped v1.8.2. `v2/main` was brought up to that
+commit, so the *code* is on the branch but no release intent came with it. The fix was a
+replacement patch changeset (`.changeset/quiet-moons-repeat.md`) restating the Claude Code
+version bump, so it appears in the v2 changelog.
 
-**#218 — synced before its changeset is consumed.** Merge #218 to `main`, then open the
-sync PR *before* merging the resulting v1 release PR. `.changeset/calm-streams-flow.md`
-comes across in the merge and needs no replacement.
+**#218 — sync before its changeset is consumed.** Merge #218 to `main`, then open the sync
+PR *before* merging the resulting v1 release PR. `.changeset/calm-streams-flow.md` comes
+across in the merge and needs no replacement. This is the shape every future sync should
+aim for.
 
 ## Promotion to `latest` (deferred)
 

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["src/**", "script/**", "*.json", "*.yml"]
+    "includes": ["src/**", "scripts/**", "*.json", "*.yml"]
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format:check": "biome format .",
     "lint": "biome lint .",
     "change": "changeset",
-    "release": "bun run build && bun change publish"
+    "release": "bun run build && bun change publish",
+    "release:next": "bun scripts/validate-next-release.ts && bun run release"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": "*"

--- a/scripts/dev-clean.ts
+++ b/scripts/dev-clean.ts
@@ -1,7 +1,13 @@
 import { existsSync, unlinkSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-const SYMLINK_PATH = resolve(import.meta.dirname, '..', '.opencode', 'plugins', 'anthropic-auth.js')
+const SYMLINK_PATH = resolve(
+  import.meta.dirname,
+  '..',
+  '.opencode',
+  'plugins',
+  'anthropic-auth.js',
+)
 
 if (existsSync(SYMLINK_PATH)) {
   unlinkSync(SYMLINK_PATH)

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -7,7 +7,7 @@ import {
 } from 'node:fs'
 import { resolve } from 'node:path'
 
-const PROJECT_ROOT = resolve(import.meta.dirname!, '..')
+const PROJECT_ROOT = resolve(import.meta.dirname, '..')
 const PLUGINS_DIR = resolve(PROJECT_ROOT, '.opencode', 'plugins')
 const SYMLINK_PATH = resolve(PLUGINS_DIR, 'anthropic-auth.js')
 const TARGET = '../../dist/index.js' // relative from .opencode/plugins/

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -19,7 +19,9 @@ function createSymlink() {
     try {
       const current = readlinkSync(SYMLINK_PATH)
       if (current === TARGET) {
-        console.log(`[dev] Symlink already exists: ${SYMLINK_PATH} -> ${TARGET}`)
+        console.log(
+          `[dev] Symlink already exists: ${SYMLINK_PATH} -> ${TARGET}`,
+        )
         return
       }
     } catch {}
@@ -57,11 +59,14 @@ createSymlink()
 // 3. Start tsc --watch
 console.log('[dev] Starting tsc --watch...')
 console.log('[dev] Restart OpenCode to pick up the linked plugin.')
-const child = Bun.spawn(['tsc', '-p', 'tsconfig.build.json', '--watch', '--preserveWatchOutput'], {
-  cwd: PROJECT_ROOT,
-  stdout: 'inherit',
-  stderr: 'inherit',
-})
+const child = Bun.spawn(
+  ['tsc', '-p', 'tsconfig.build.json', '--watch', '--preserveWatchOutput'],
+  {
+    cwd: PROJECT_ROOT,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  },
+)
 
 function cleanup() {
   console.log('\n[dev] Cleaning up...')

--- a/scripts/extract-system-prompt.ts
+++ b/scripts/extract-system-prompt.ts
@@ -140,10 +140,10 @@ const systemText = best.system
   .join('\n\n')
 
 if (values.output) {
-  writeFileSync(values.output, systemText + '\n')
+  writeFileSync(values.output, `${systemText}\n`)
   console.log(
     `Extracted system prompt (${systemText.length} chars) → ${values.output}`,
   )
 } else {
-  process.stdout.write(systemText + '\n')
+  process.stdout.write(`${systemText}\n`)
 }

--- a/scripts/validate-next-release.ts
+++ b/scripts/validate-next-release.ts
@@ -18,7 +18,10 @@ export const EXPECTED_PACKAGE_NAME = '@ex-machina/opencode-anthropic-auth'
 export const EXPECTED_PRE_TAG = 'next'
 export const EXPECTED_MAJOR = 2
 
-const NEXT_VERSION_PATTERN = /^(\d+)\.\d+\.\d+-next\.\d+$/
+/** `<major>.<minor>.<patch>-<EXPECTED_PRE_TAG>.<counter>`, capturing the major. */
+const NEXT_VERSION_PATTERN = new RegExp(
+  String.raw`^(\d+)\.\d+\.\d+-${EXPECTED_PRE_TAG}\.\d+$`,
+)
 
 /**
  * State of `.changeset/pre.json`.
@@ -32,7 +35,11 @@ export type PreStateSource =
   | { readonly kind: 'present'; readonly raw: unknown }
 
 export type ReleaseGuardVerdict =
-  | { readonly status: 'allowed'; readonly version: string; readonly tag: string }
+  | {
+      readonly status: 'allowed'
+      readonly version: string
+      readonly tag: string
+    }
   | { readonly status: 'blocked'; readonly reason: string }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -90,7 +97,10 @@ export function checkNextRelease(input: {
   const pre = preState.raw
 
   if (!isRecord(pre)) {
-    return { status: 'blocked', reason: '.changeset/pre.json is not a JSON object.' }
+    return {
+      status: 'blocked',
+      reason: '.changeset/pre.json is not a JSON object.',
+    }
   }
 
   if (pre.mode !== 'pre') {
@@ -152,7 +162,7 @@ function readPreState(root: string): PreStateSource {
 }
 
 if (import.meta.main) {
-  const root = resolve(import.meta.dirname!, '..')
+  const root = resolve(import.meta.dir, '..')
 
   const verdict = checkNextRelease({
     packageJson: readPackageJson(root),
@@ -164,5 +174,7 @@ if (import.meta.main) {
     process.exit(1)
   }
 
-  console.log(`[release:next] Publishing ${EXPECTED_PACKAGE_NAME}@${verdict.version} to "${verdict.tag}".`)
+  console.log(
+    `[release:next] Publishing ${EXPECTED_PACKAGE_NAME}@${verdict.version} to "${verdict.tag}".`,
+  )
 }

--- a/scripts/validate-next-release.ts
+++ b/scripts/validate-next-release.ts
@@ -162,7 +162,7 @@ function readPreState(root: string): PreStateSource {
 }
 
 if (import.meta.main) {
-  const root = resolve(import.meta.dir, '..')
+  const root = resolve(import.meta.dirname, '..')
 
   const verdict = checkNextRelease({
     packageJson: readPackageJson(root),

--- a/scripts/validate-next-release.ts
+++ b/scripts/validate-next-release.ts
@@ -1,0 +1,168 @@
+/**
+ * Release guard for the OpenCode v2 (`next`) channel.
+ *
+ * `v2/main` publishes prereleases of the 2.x line to npm's `next` dist-tag, while
+ * `main` keeps publishing the 1.x line to `latest`. Changesets happily prepares a
+ * release PR for whatever version the branch currently sits at, so before the v2
+ * major landed that PR can resolve to something like `1.8.2-next.0`. Publishing
+ * that would put a v1-shaped prerelease on the v2 channel.
+ *
+ * This guard runs immediately before `changeset publish` on `v2/main` and refuses
+ * to publish anything that is not a `2.x.y-next.N` prerelease.
+ */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export const EXPECTED_PACKAGE_NAME = '@ex-machina/opencode-anthropic-auth'
+export const EXPECTED_PRE_TAG = 'next'
+export const EXPECTED_MAJOR = 2
+
+const NEXT_VERSION_PATTERN = /^(\d+)\.\d+\.\d+-next\.\d+$/
+
+/**
+ * State of `.changeset/pre.json`.
+ *
+ * Absence is a meaningful, expected state (the branch is not in prerelease mode),
+ * so it is modelled explicitly rather than as a null/undefined `raw`.
+ */
+export type PreStateSource =
+  | { readonly kind: 'absent' }
+  | { readonly kind: 'unreadable'; readonly detail: string }
+  | { readonly kind: 'present'; readonly raw: unknown }
+
+export type ReleaseGuardVerdict =
+  | { readonly status: 'allowed'; readonly version: string; readonly tag: string }
+  | { readonly status: 'blocked'; readonly reason: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Decide whether the current working tree may publish to the `next` channel.
+ *
+ * Pure: takes already-read file contents so it can be exercised without touching
+ * the filesystem.
+ */
+export function checkNextRelease(input: {
+  readonly packageJson: unknown
+  readonly preState: PreStateSource
+}): ReleaseGuardVerdict {
+  const { packageJson, preState } = input
+
+  if (!isRecord(packageJson)) {
+    return { status: 'blocked', reason: 'package.json is not a JSON object.' }
+  }
+
+  const { name, version } = packageJson
+
+  if (name !== EXPECTED_PACKAGE_NAME) {
+    return {
+      status: 'blocked',
+      reason: `Expected package "${EXPECTED_PACKAGE_NAME}", found ${JSON.stringify(name)}.`,
+    }
+  }
+
+  if (typeof version !== 'string') {
+    return {
+      status: 'blocked',
+      reason: `package.json "version" must be a string, found ${JSON.stringify(version)}.`,
+    }
+  }
+
+  switch (preState.kind) {
+    case 'absent':
+      return {
+        status: 'blocked',
+        reason:
+          '.changeset/pre.json is missing. The v2 channel must stay in changesets pre mode; run `bun change pre enter next`.',
+      }
+    case 'unreadable':
+      return {
+        status: 'blocked',
+        reason: `.changeset/pre.json could not be parsed: ${preState.detail}`,
+      }
+    case 'present':
+      break
+  }
+
+  const pre = preState.raw
+
+  if (!isRecord(pre)) {
+    return { status: 'blocked', reason: '.changeset/pre.json is not a JSON object.' }
+  }
+
+  if (pre.mode !== 'pre') {
+    return {
+      status: 'blocked',
+      reason: `Changesets is not in pre mode (mode is ${JSON.stringify(pre.mode)}). The v2 channel must never publish a stable release.`,
+    }
+  }
+
+  if (pre.tag !== EXPECTED_PRE_TAG) {
+    return {
+      status: 'blocked',
+      reason: `Changesets pre tag must be "${EXPECTED_PRE_TAG}", found ${JSON.stringify(pre.tag)}.`,
+    }
+  }
+
+  const match = NEXT_VERSION_PATTERN.exec(version)
+
+  if (!match) {
+    return {
+      status: 'blocked',
+      reason: `Version "${version}" is not a "${EXPECTED_MAJOR}.x.y-${EXPECTED_PRE_TAG}.N" prerelease.`,
+    }
+  }
+
+  const major = Number(match[1])
+
+  if (major !== EXPECTED_MAJOR) {
+    return {
+      status: 'blocked',
+      reason: `Version "${version}" is major ${major}; the ${EXPECTED_PRE_TAG} channel only publishes major ${EXPECTED_MAJOR}.`,
+    }
+  }
+
+  return { status: 'allowed', version, tag: EXPECTED_PRE_TAG }
+}
+
+function readPackageJson(root: string): unknown {
+  return JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
+}
+
+function readPreState(root: string): PreStateSource {
+  let contents: string
+
+  try {
+    contents = readFileSync(resolve(root, '.changeset', 'pre.json'), 'utf8')
+  } catch (error) {
+    if (isRecord(error) && error.code === 'ENOENT') {
+      return { kind: 'absent' }
+    }
+    return { kind: 'unreadable', detail: String(error) }
+  }
+
+  try {
+    return { kind: 'present', raw: JSON.parse(contents) }
+  } catch (error) {
+    return { kind: 'unreadable', detail: String(error) }
+  }
+}
+
+if (import.meta.main) {
+  const root = resolve(import.meta.dirname!, '..')
+
+  const verdict = checkNextRelease({
+    packageJson: readPackageJson(root),
+    preState: readPreState(root),
+  })
+
+  if (verdict.status === 'blocked') {
+    console.error(`[release:next] Refusing to publish. ${verdict.reason}`)
+    process.exit(1)
+  }
+
+  console.log(`[release:next] Publishing ${EXPECTED_PACKAGE_NAME}@${verdict.version} to "${verdict.tag}".`)
+}

--- a/src/tests/validate-next-release.test.ts
+++ b/src/tests/validate-next-release.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  checkNextRelease,
+  EXPECTED_PACKAGE_NAME,
+  type PreStateSource,
+} from '../../scripts/validate-next-release'
+
+const PRE_NEXT: PreStateSource = {
+  kind: 'present',
+  raw: {
+    mode: 'pre',
+    tag: 'next',
+    initialVersions: { [EXPECTED_PACKAGE_NAME]: '1.8.1' },
+    changesets: [],
+  },
+}
+
+function check(version: string, preState: PreStateSource = PRE_NEXT) {
+  return checkNextRelease({
+    packageJson: { name: EXPECTED_PACKAGE_NAME, version },
+    preState,
+  })
+}
+
+describe('next-channel release guard', () => {
+  test('allows the first v2 prerelease', () => {
+    expect(check('2.0.0-next.0')).toEqual({
+      status: 'allowed',
+      version: '2.0.0-next.0',
+      tag: 'next',
+    })
+  })
+
+  test('allows later v2 prereleases', () => {
+    expect(check('2.3.1-next.12')).toEqual({
+      status: 'allowed',
+      version: '2.3.1-next.12',
+      tag: 'next',
+    })
+  })
+
+  test('blocks the interim 1.x prerelease that changesets prepares before the v2 major lands', () => {
+    const verdict = check('1.8.2-next.0')
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('major 1'),
+    })
+  })
+
+  test('blocks a stable 2.x release', () => {
+    const verdict = check('2.0.0')
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('prerelease'),
+    })
+  })
+
+  test('blocks a prerelease that is not tagged next', () => {
+    const verdict = check('2.0.0-beta.0')
+
+    expect(verdict.status).toBe('blocked')
+  })
+
+  test('blocks when changesets is in pre mode under a different tag', () => {
+    const verdict = check('2.0.0-next.0', {
+      kind: 'present',
+      raw: { mode: 'pre', tag: 'beta' },
+    })
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('pre tag'),
+    })
+  })
+
+  test('blocks when pre mode has been exited', () => {
+    const verdict = check('2.0.0-next.0', {
+      kind: 'present',
+      raw: { mode: 'exit', tag: 'next' },
+    })
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('not in pre mode'),
+    })
+  })
+
+  test('blocks when pre.json is absent', () => {
+    const verdict = check('2.0.0-next.0', { kind: 'absent' })
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('pre.json is missing'),
+    })
+  })
+
+  test('blocks when pre.json cannot be parsed', () => {
+    const verdict = check('2.0.0-next.0', {
+      kind: 'unreadable',
+      detail: 'SyntaxError: Unexpected end of JSON input',
+    })
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining('could not be parsed'),
+    })
+  })
+
+  test('blocks when pre.json is not an object', () => {
+    const verdict = check('2.0.0-next.0', { kind: 'present', raw: 'pre' })
+
+    expect(verdict.status).toBe('blocked')
+  })
+
+  test('blocks a different package', () => {
+    const verdict = checkNextRelease({
+      packageJson: { name: '@someone-else/plugin', version: '2.0.0-next.0' },
+      preState: PRE_NEXT,
+    })
+
+    expect(verdict.status).toBe('blocked')
+    expect(verdict).toMatchObject({
+      reason: expect.stringContaining(EXPECTED_PACKAGE_NAME),
+    })
+  })
+
+  test('blocks a missing version', () => {
+    const verdict = checkNextRelease({
+      packageJson: { name: EXPECTED_PACKAGE_NAME },
+      preState: PRE_NEXT,
+    })
+
+    expect(verdict.status).toBe('blocked')
+  })
+
+  test('blocks a package.json that is not an object', () => {
+    const verdict = checkNextRelease({ packageJson: null, preState: PRE_NEXT })
+
+    expect(verdict.status).toBe('blocked')
+  })
+})


### PR DESCRIPTION
Sets up `v2/main` as an independently releasable branch so the OpenCode v2 port (#211) has somewhere to ship. It has been blocked on exactly this.

The shape: one npm package, two release trains. `main` keeps publishing the v1 line to `latest`, untouched. `v2/main` publishes the v2 line to `next` as `2.x.y-next.N` prereleases. A second npm package would have duplicated the package identity, trusted-publisher config, docs, and eventual migration path for no benefit.

`v2/main` is permanently in changesets pre mode, so `.changeset/pre.json` is committed state rather than scratch state. That is what makes the arrangement reversible — promotion to `latest` later is a deliberate `pre exit`, not a default.

The two trains are isolated by trigger branch, concurrency group, release-PR title, and publish command. The workflow **filename** deliberately stays `publish.yml`, because npm's trusted publisher is bound to it.

### The publish guard

`bun run release:next` runs a validator before `changeset publish`. It refuses anything that is not `2.x.y-next.N` under a `next` pre tag for this package.

This is not belt-and-braces. Changesets versions from wherever the branch currently sits, and `v2/main` sits at 1.8.2 — so until the v2 major changeset lands, the v2 release PR resolves to `1.8.3-next.0`. That is a v1-shaped prerelease pointed at the v2 channel. The guard makes publishing it impossible rather than relying on someone noticing.

**So: do not merge the v2 release PR until it says `2.0.0-next.0`.** Leaving it open is free — the changesets action resets its release branch to the base on every run, so an open release PR is a preview, not an accumulating stack, and it does not burn `-next.N` counters. Merging the interim one early is recoverable but permanently costs a counter and leaves the branch red until 2.x is reached. Both paths are documented in `RELEASING.md`.

### Two things that are not release plumbing

`#223` reached `v2/main` as code, but its changeset had already been consumed by the v1.8.2 release on `main`, so the v2 changelog had no record of it. Added a replacement changeset. This is the recurring hazard with a long-lived branch, so `RELEASING.md` documents the timing rule: sync a change before its v1 release PR consumes the changeset, and write a replacement when you cannot.

`biome.json` listed `script/**`, but the directory is `scripts/**`. Nothing under `scripts/` has ever been formatted or linted. Fixed, which required formatting the two existing scripts it newly covers.

### Verification

Full suite green: types, build, 132 tests (13 new, covering the guard's accept and reject paths), format, lint.

Behavior was confirmed against throwaway repos rather than assumed, since the counter semantics are load-bearing for the merge advice above:

- interim state → `1.8.3-next.0`, guard blocks
- leave that PR open, land the major → `2.0.0-next.0`, guard allows
- merge that PR anyway → publish blocked, and the major later lands as `2.0.0-next.1`
- `pre exit`, missing `pre.json`, malformed `pre.json`, wrong tag → all blocked
- packed the candidate tarball; no publish, no tag mutation

npm is untouched: `latest` is still `1.8.2` and no `next` tag exists.

### Before the first real publish

Confirm the npm trusted publisher still points at `publish.yml` for this repo. The registry does not expose that setting to the API, so it could not be checked here.

### After this lands

#218 merging into `main` and then syncing to `v2/main` is the intended end-to-end test of the sync process, since its changeset should transfer on its own. #211 lands afterward and supplies the major changeset that turns the release PR into a real `2.0.0-next.0`.
