### PR TITLE
feat(v2): harden Claude version reporting and package checks

### DIFF
--- a/.changeset/fresh-models-report.md
+++ b/.changeset/fresh-models-report.md
@@ -1,0 +1,5 @@
+---
+'@ex-machina/opencode-anthropic-auth': patch
+---
+
+Allow `CLAUDE_CODE_VERSION` to override the bundled Claude Code version reported in both the user-agent and billing headers. Anthropic gates new models on this value, so users can now adopt a required version without waiting for a plugin release. Invalid values are logged and ignored.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,4 @@ jobs:
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
       - run: bun install --frozen-lockfile
       - run: bun check
+      - run: bun run check:package

--- a/README.md
+++ b/README.md
@@ -1,50 +1,57 @@
 # OpenCode Anthropic Auth Plugin
 
+[![OpenCode v1 — npm latest tag](https://img.shields.io/npm/v/%40ex-machina%2Fopencode-anthropic-auth/latest?label=OpenCode%20v1%20(latest))](https://www.npmjs.com/package/@ex-machina/opencode-anthropic-auth?activeTab=versions)
+[![OpenCode v2 — npm next tag](https://img.shields.io/npm/v/%40ex-machina%2Fopencode-anthropic-auth/next?label=OpenCode%20v2%20(next))](https://www.npmjs.com/package/@ex-machina/opencode-anthropic-auth?activeTab=versions)
+
 > [!WARNING]
 > This plugin comes with no guarantees. You might be banned for breaking the TOS, you might not be. I don't work at Anthropic, nor am I an attorney.
 >
 > Use your best judgment and don't try to abuse the subscriptions. Plugins like oh-my-openagent are _known_ to trigger bans. Please be careful when using Ralph loops or insanely heavy usage patterns.
 
 > [!IMPORTANT]
-> If you are seeing issues, please try to `rm -rf ~/.cache/opencode/packages/@ex-machina` and check your `opencode.json` config to make sure you're on the latest version.
+> If you are seeing issues, try `rm -rf ~/.cache/opencode/packages/@ex-machina` and confirm that your `opencode.json` uses the plugin release line for your OpenCode version.
 >
 > Try this FIRST before making an Issue. Thanks!
 
 An [OpenCode](https://github.com/anomalyco/opencode) plugin that provides Anthropic OAuth authentication, enabling Claude Pro/Max users to use their subscription directly with OpenCode.
 
-## Version compatibility
+## Version support
 
-| Plugin version | OpenCode version | Package                                     |
-|-----------------|-------------------|---------------------------------------------|
-| 2.x (this readme) | OpenCode v2 (beta plugin API) | `@ex-machina/opencode-anthropic-auth` |
-| 1.x               | OpenCode v1       | `@ex-machina/opencode-anthropic-auth@1` |
+| OpenCode version | Plugin release | Support branch | npm dist-tag | Configuration key |
+|------------------|----------------|----------------|--------------|-------------------|
+| OpenCode v1 | 1.x | [`main`](https://github.com/ex-machina-co/opencode-anthropic-auth/tree/main) | `latest` | `plugin` |
+| OpenCode v2 | 2.x prereleases | [`v2/main`](https://github.com/ex-machina-co/opencode-anthropic-auth/tree/v2/main) | `next` | `plugins` |
 
-OpenCode v2's plugin API is still beta, and this plugin currently targets the `@opencode-ai/plugin@0.0.0-next-17444` prerelease of it — pin the plugin version and keep an eye on the changelog when bumping either side. If you're still on OpenCode v1, keep using a `1.x` release; v1 plugins are **not** loadable by OpenCode v2, and this v2 port is not loadable by OpenCode v1.
+Both release lines use the same npm package. They are not cross-compatible: the v1 plugin does not load in OpenCode v2, and the v2 plugin does not load in OpenCode v1. OpenCode v2's plugin API is still beta, so review the changelog before upgrading either side.
 
 ## Usage
 
-Add the plugin to your OpenCode configuration:
-
-```json
-{
-  "plugins": ["@ex-machina/opencode-anthropic-auth"]
-}
-```
-
 > [!TIP]
-> It is STRONGLY advised that you pin the plugin to a version. This will keep you from getting automatic updates; however, this will protect you from nefarious updates.
+> Pin an exact plugin version for a stable setup that changes only when you choose to upgrade. If you intentionally want automatic updates, use the moving npm tag for your OpenCode release line.
 >
-> This holds true for ANY OpenCode plugin. If you do not pin them, OpenCode will automatically update them on startup. It's a massive vulnerability waiting to happen.
+> This applies to every OpenCode plugin: an unpinned or moving-tag dependency can install new code on startup, so only track automatic updates from publishers you trust.
 
-#### Example of pinned version
+OpenCode v2 uses the plural `plugins` configuration key. Because npm's default tag points to the v1 line, specify `@next` if you want to track the newest v2 prerelease:
 
 ```json
 {
-  "plugins": ["@ex-machina/opencode-anthropic-auth@<2.x.y-next.N>"]
+  "plugins": ["@ex-machina/opencode-anthropic-auth@next"]
 }
 ```
 
-The v2 line ships as prereleases on npm's `next` tag, so substitute a version that actually exists — `npm view @ex-machina/opencode-anthropic-auth dist-tags` shows the current one. Pin that exact version rather than tracking `@next`, which moves on every prerelease publish.
+For a stable setup, look up the exact version currently published on `next`:
+
+```bash
+npm view @ex-machina/opencode-anthropic-auth dist-tags.next
+```
+
+Substitute the command output for `<version>`:
+
+```json
+{
+  "plugins": ["@ex-machina/opencode-anthropic-auth@<version>"]
+}
+```
 
 ## Authentication Methods
 
@@ -65,6 +72,9 @@ The plugin supports the following environment variables:
 |-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `ANTHROPIC_BASE_URL`              | Override the API endpoint URL (e.g. for proxying). Must be a valid HTTP(S) URL.                                                                                                             |
 | `ANTHROPIC_INSECURE`              | **Not supported under OpenCode v2.** OpenCode v2 plugin request hooks can rewrite a request but cannot disable TLS verification for it. If this is set, the plugin logs a warning and leaves TLS verification enabled — requests to a self-signed/untrusted `ANTHROPIC_BASE_URL` will fail. |
+| `CLAUDE_CODE_VERSION`             | Override the Claude Code version reported to Anthropic. Must be `major.minor.patch` (for example, `2.1.258`). Defaults to the bundled version; a malformed value is logged and ignored. |
+
+Anthropic gates model access on the reported Claude Code version. `CLAUDE_CODE_VERSION` lets you raise it without waiting for a plugin release. The value is read when the plugin loads, so restart OpenCode after changing it.
 
 ## How It Works
 
@@ -87,6 +97,14 @@ The Anthropic API for Max subscriptions has specific requirements for the system
 Everything else in the system prompt is preserved: tone/style guidance, task management instructions, tool usage policy, environment info, skills, user/project instructions, and file paths containing "opencode". The sanitized system prompt is structured as three blocks in `system[]`: the billing header, the Claude Code identity line, and the remaining system content.
 
 ## Development
+
+Verify the package tarball and its exported v2 plugin before publishing:
+
+```bash
+bun run check:package
+```
+
+This builds the plugin, packs it in a temporary directory, checks the package contents, imports the extracted entrypoint, and verifies that setup registers the Claude Pro/Max OAuth method. It does not use credentials or make model requests.
 
 ### Local Testing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,9 +39,6 @@ actually exists — `npm view @ex-machina/opencode-anthropic-auth dist-tags` sho
 
 Pin the exact version rather than tracking `@next`, which moves on every prerelease publish.
 
-Nothing is published to `next` yet — the first prerelease waits on the v2 port — so there is
-no version to substitute until then.
-
 ## Releasing v1 from `main`
 
 Unchanged from before the v2 train existed:
@@ -153,7 +150,7 @@ Always run the full check suite locally on the merged tree before opening the sy
 
 ```bash
 bun install --frozen-lockfile
-bun run types && bun run build && bun test && bun run format:check && bun run lint
+bun run types && bun run build && bun test && bun run check:package && bun run format:check && bun run lint
 ```
 
 ### Worked examples

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check": "bun turbo check:all",
     "test": "bun test",
     "types": "tsc",
+    "check:package": "bun run build && bun scripts/check-package.ts",
     "format": "biome check --write --unsafe",
     "format:check": "biome format .",
     "lint": "biome lint --error-on-warnings .",

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,0 +1,167 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const PROJECT_ROOT = resolve(import.meta.dirname, '..')
+const REQUIRED_FILES = ['package.json', 'dist/index.js', 'dist/index.d.ts']
+const PACKAGE_ROOT_FILES = new Set(['LICENSE', 'README.md', 'package.json'])
+
+function fail(message: string): never {
+  throw new Error(`[check:package] ${message}`)
+}
+
+function run(command: string[], cwd: string): Uint8Array {
+  const result = Bun.spawnSync(command, {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  if (result.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(result.stderr).trim()
+    fail(`${command.join(' ')} failed${stderr ? `:\n${stderr}` : '.'}`)
+  }
+
+  return result.stdout
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+const temporaryRoot = mkdtempSync(
+  join(tmpdir(), 'opencode-anthropic-auth-package-'),
+)
+
+try {
+  const output = new TextDecoder().decode(
+    run(
+      [
+        'npm',
+        'pack',
+        '--json',
+        '--ignore-scripts',
+        '--pack-destination',
+        temporaryRoot,
+      ],
+      PROJECT_ROOT,
+    ),
+  )
+  const packResult: unknown = JSON.parse(output)
+
+  if (
+    !Array.isArray(packResult) ||
+    packResult.length !== 1 ||
+    !isRecord(packResult[0])
+  ) {
+    fail('npm pack returned an unexpected result.')
+  }
+
+  const [{ filename, files }] = packResult
+  if (typeof filename !== 'string' || !Array.isArray(files)) {
+    fail('npm pack did not report a tarball and file list.')
+  }
+
+  const paths = files.flatMap((file) =>
+    isRecord(file) && typeof file.path === 'string' ? [file.path] : [],
+  )
+  const pathSet = new Set(paths)
+
+  for (const required of REQUIRED_FILES) {
+    if (!pathSet.has(required)) {
+      fail(`packed tarball is missing ${required}.`)
+    }
+  }
+
+  const unexpected = paths.filter(
+    (path) => !path.startsWith('dist/') && !PACKAGE_ROOT_FILES.has(path),
+  )
+  if (unexpected.length > 0) {
+    fail(`packed tarball contains unexpected files: ${unexpected.join(', ')}.`)
+  }
+
+  const tarball = resolve(temporaryRoot, filename)
+  if (!existsSync(tarball)) {
+    fail(`npm pack did not create ${filename}.`)
+  }
+
+  const extractedRoot = resolve(temporaryRoot, 'extracted')
+  mkdirSync(extractedRoot)
+  run(['tar', '-xzf', tarball, '-C', extractedRoot], PROJECT_ROOT)
+
+  const extractedPackage = resolve(extractedRoot, 'package')
+  symlinkSync(
+    resolve(PROJECT_ROOT, 'node_modules'),
+    resolve(extractedPackage, 'node_modules'),
+    'junction',
+  )
+
+  const module: unknown = await import(
+    pathToFileURL(resolve(extractedPackage, 'dist/index.js')).href
+  )
+  if (!isRecord(module) || Object.keys(module).join(',') !== 'default') {
+    fail('packed entrypoint must export only a default plugin.')
+  }
+
+  const plugin = module.default
+  if (
+    !isRecord(plugin) ||
+    plugin.id !== 'ex-machina.anthropic-auth' ||
+    typeof plugin.setup !== 'function'
+  ) {
+    fail('packed entrypoint is not the OpenCode v2 Anthropic auth plugin.')
+  }
+
+  const integrationMethods: unknown[] = []
+  await plugin.setup({
+    integration: {
+      transform: async (
+        transform: (editor: {
+          method: { update: (input: unknown) => void }
+        }) => void,
+      ) => {
+        transform({
+          method: {
+            update: (input) => integrationMethods.push(input),
+          },
+        })
+        return { dispose: async () => {} }
+      },
+      connection: {
+        active: async () => undefined,
+        resolve: async () => undefined,
+      },
+    },
+    session: {
+      hook: async () => ({ dispose: async () => {} }),
+    },
+  })
+
+  const registration = integrationMethods[0]
+  if (
+    integrationMethods.length !== 1 ||
+    !isRecord(registration) ||
+    registration.integrationID !== 'anthropic' ||
+    !isRecord(registration.method) ||
+    registration.method.id !== 'claude-max' ||
+    registration.method.type !== 'oauth' ||
+    registration.method.label !== 'Claude Pro/Max' ||
+    typeof registration.authorize !== 'function' ||
+    typeof registration.refresh !== 'function'
+  ) {
+    fail('packed plugin did not register the Claude Pro/Max OAuth method.')
+  }
+
+  console.log(
+    `[check:package] Verified ${filename} (${paths.length} packaged files) and Claude Pro/Max registration.`,
+  )
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true })
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,32 @@
+import { CLAUDE_CODE_VERSION } from './constants.ts'
+
+export const CLAUDE_CODE_VERSION_ENV_VAR = 'CLAUDE_CODE_VERSION'
+
+const VERSION_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+export type ClaudeCodeVersionResolution =
+  | { readonly type: 'success'; readonly version: string }
+  | { readonly type: 'invalid'; readonly error: string }
+
+/** Resolve and validate the Claude Code version reported to Anthropic. */
+export function resolveClaudeCodeVersion(
+  raw: string | undefined = process.env[CLAUDE_CODE_VERSION_ENV_VAR],
+): ClaudeCodeVersionResolution {
+  if (raw === undefined) {
+    return { type: 'success', version: CLAUDE_CODE_VERSION }
+  }
+
+  const version = raw.trim()
+  if (!VERSION_PATTERN.test(version)) {
+    return {
+      type: 'invalid',
+      error:
+        `${CLAUDE_CODE_VERSION_ENV_VAR} is set to ${JSON.stringify(raw)}, which is not a ` +
+        `Claude Code version. Expected major.minor.patch (for example, ${CLAUDE_CODE_VERSION}). ` +
+        `Reporting the bundled version ${CLAUDE_CODE_VERSION} instead; correct or unset ` +
+        `${CLAUDE_CODE_VERSION_ENV_VAR} and restart OpenCode to use the override.`,
+    }
+  }
+
+  return { type: 'success', version }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -45,7 +45,11 @@ export const CCH_POSITIONS = [4, 7, 20]
 export const CLAUDE_CODE_VERSION = '2.1.258'
 export const CLAUDE_CODE_ENTRYPOINT = 'sdk-cli'
 
-export const USER_AGENT = `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`
+export function formatUserAgent(version: string): string {
+  return `claude-cli/${version} (external, cli)`
+}
+
+export const USER_AGENT = formatUserAgent(CLAUDE_CODE_VERSION)
 
 /**
  * Anchors that identify paragraphs to remove from the system prompt.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { type Credential, Plugin } from '@opencode-ai/plugin'
 import { authorize, exchange, refreshToken } from './auth.ts'
-import { REQUIRED_BETAS } from './constants.ts'
+import { resolveClaudeCodeVersion } from './config.ts'
+import { CLAUDE_CODE_VERSION, REQUIRED_BETAS } from './constants.ts'
 import {
   createStrippedStream,
   isInsecure,
@@ -74,6 +75,14 @@ export default Plugin.define({
   id: PLUGIN_ID,
   setup: async (ctx) => {
     warnIfInsecureUnsupported()
+    const versionResolution = resolveClaudeCodeVersion()
+    if (versionResolution.type === 'invalid') {
+      console.error(`[ex-machina.anthropic-auth] ${versionResolution.error}`)
+    }
+    const claudeCodeVersion =
+      versionResolution.type === 'success'
+        ? versionResolution.version
+        : CLAUDE_CODE_VERSION
 
     // Retain successful refreshes for this plugin generation so a host call
     // holding the rotated token cannot submit it again before persistence.
@@ -151,10 +160,12 @@ export default Plugin.define({
       const hasBody = request.method !== 'GET' && request.method !== 'HEAD'
       const bodyText = hasBody ? await request.clone().text() : undefined
       const rewrittenBody =
-        bodyText !== undefined ? rewriteRequestBody(bodyText) : undefined
+        bodyText !== undefined
+          ? rewriteRequestBody(bodyText, claudeCodeVersion)
+          : undefined
 
       const headers = mergeHeaders(request)
-      setOAuthHeaders(headers, credential.access)
+      setOAuthHeaders(headers, credential.access, claudeCodeVersion)
       if (rewrittenBody !== undefined) headers.delete('content-length')
 
       const { input: rewrittenInput } = rewriteUrl(request.url)

--- a/src/tests/config.test.ts
+++ b/src/tests/config.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  CLAUDE_CODE_VERSION_ENV_VAR,
+  resolveClaudeCodeVersion,
+} from '../config'
+import { CLAUDE_CODE_VERSION } from '../constants'
+
+describe('resolveClaudeCodeVersion', () => {
+  const originalEnv = process.env[CLAUDE_CODE_VERSION_ENV_VAR]
+
+  beforeEach(() => {
+    delete process.env[CLAUDE_CODE_VERSION_ENV_VAR]
+  })
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env[CLAUDE_CODE_VERSION_ENV_VAR]
+    } else {
+      process.env[CLAUDE_CODE_VERSION_ENV_VAR] = originalEnv
+    }
+  })
+
+  test('uses the bundled version when unset', () => {
+    expect(resolveClaudeCodeVersion()).toEqual({
+      type: 'success',
+      version: CLAUDE_CODE_VERSION,
+    })
+  })
+
+  test('reads and trims a valid override', () => {
+    process.env[CLAUDE_CODE_VERSION_ENV_VAR] = '  2.9.99\n'
+
+    expect(resolveClaudeCodeVersion()).toEqual({
+      type: 'success',
+      version: '2.9.99',
+    })
+  })
+
+  test.each([
+    ['empty', ''],
+    ['two components', '2.9'],
+    ['four components', '2.9.99.1'],
+    ['prerelease suffix', '2.9.99-beta.1'],
+    ['v prefix', 'v2.9.99'],
+    ['leading-zero component', '02.1.258'],
+    ['non-numeric component', '2.x.99'],
+    ['tag', 'latest'],
+  ])('rejects a malformed override (%s)', (_label, raw) => {
+    const result = resolveClaudeCodeVersion(raw)
+
+    expect(result.type).toBe('invalid')
+    if (result.type === 'invalid') {
+      expect(result.error).toContain(CLAUDE_CODE_VERSION_ENV_VAR)
+      expect(result.error).toContain('major.minor.patch')
+      expect(result.error).toContain(CLAUDE_CODE_VERSION)
+    }
+  })
+})

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, spyOn, test } from 'bun:test'
+import { CLAUDE_CODE_VERSION } from '../constants'
 import plugin from '../index'
 
 /**
@@ -436,6 +437,76 @@ describe('session http.request hook', () => {
     expect(parsedBody.system[1].text).toBe(
       "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
     )
+  })
+
+  test('uses one configured Claude Code version for headers and billing', async () => {
+    const originalVersion = process.env.CLAUDE_CODE_VERSION
+    process.env.CLAUDE_CODE_VERSION = '2.9.99'
+
+    try {
+      const { ctx, sessionHooks } = anthropicOAuthContext()
+      await plugin.setup(ctx as any)
+      process.env.CLAUDE_CODE_VERSION = '3.0.0'
+
+      const event: any = {
+        model: { providerID: 'anthropic', modelID: 'claude-3' },
+        request: new Request('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: JSON.stringify({
+            messages: [{ role: 'user', content: 'hello world test message' }],
+          }),
+        }),
+      }
+      await sessionHooks.get('http.request')!(event)
+
+      expect(event.request.headers.get('user-agent')).toBe(
+        'claude-cli/2.9.99 (external, cli)',
+      )
+      const parsedBody = JSON.parse(await event.request.text())
+      expect(parsedBody.system[0].text).toContain('cc_version=2.9.99.')
+    } finally {
+      if (originalVersion === undefined) {
+        delete process.env.CLAUDE_CODE_VERSION
+      } else {
+        process.env.CLAUDE_CODE_VERSION = originalVersion
+      }
+    }
+  })
+
+  test('logs and ignores a malformed Claude Code version', async () => {
+    const originalVersion = process.env.CLAUDE_CODE_VERSION
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {})
+    process.env.CLAUDE_CODE_VERSION = 'latest'
+
+    try {
+      const { ctx, sessionHooks } = anthropicOAuthContext()
+      await plugin.setup(ctx as any)
+
+      expect(consoleError).toHaveBeenCalledTimes(1)
+      expect(String(consoleError.mock.calls[0]?.[0])).toContain(
+        'CLAUDE_CODE_VERSION',
+      )
+
+      const event: any = {
+        model: { providerID: 'anthropic', modelID: 'claude-3' },
+        request: new Request('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          body: '{}',
+        }),
+      }
+      await sessionHooks.get('http.request')!(event)
+
+      expect(event.request.headers.get('user-agent')).toBe(
+        `claude-cli/${CLAUDE_CODE_VERSION} (external, cli)`,
+      )
+    } finally {
+      consoleError.mockRestore()
+      if (originalVersion === undefined) {
+        delete process.env.CLAUDE_CODE_VERSION
+      } else {
+        process.env.CLAUDE_CODE_VERSION = originalVersion
+      }
+    }
   })
 
   test('preserves GET requests without a body', async () => {

--- a/src/tests/transform.test.ts
+++ b/src/tests/transform.test.ts
@@ -918,6 +918,23 @@ describe('reported Claude Code version', () => {
     // cc_version is `<version>.<3-char suffix>`, so match the version segment.
     expect(billingHeader).toContain(`cc_version=${CLAUDE_CODE_VERSION}.`)
   })
+
+  test('user-agent and billing header both report an explicit version', () => {
+    const version = '2.9.99'
+    const headers = new Headers()
+    setOAuthHeaders(headers, 'token', version)
+
+    const body = JSON.stringify({
+      messages: [{ role: 'user', content: 'hello world test message' }],
+    })
+    const billingHeader = JSON.parse(rewriteRequestBody(body, version))
+      .system[0].text
+
+    expect(headers.get('user-agent')).toBe(
+      `claude-cli/${version} (external, cli)`,
+    )
+    expect(billingHeader).toContain(`cc_version=${version}.`)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,12 +2,13 @@ import { buildBillingHeaderValue } from './cch.ts'
 import {
   CLAUDE_CODE_ENTRYPOINT,
   CLAUDE_CODE_IDENTITY,
+  CLAUDE_CODE_VERSION,
+  formatUserAgent,
   OPENCODE_IDENTITY_PREFIX,
   PARAGRAPH_REMOVAL_ANCHORS,
   REQUIRED_BETAS,
   TEXT_REPLACEMENTS,
   TOOL_PREFIX,
-  USER_AGENT,
 } from './constants.ts'
 
 // Bound an incomplete SSE line so malformed streams cannot grow memory forever.
@@ -325,10 +326,11 @@ export function mergeBetaHeaders(headers: Headers): string {
 export function setOAuthHeaders(
   headers: Headers,
   accessToken: string,
+  version: string = CLAUDE_CODE_VERSION,
 ): Headers {
   headers.set('authorization', `Bearer ${accessToken}`)
   headers.set('anthropic-beta', mergeBetaHeaders(headers))
-  headers.set('user-agent', USER_AGENT)
+  headers.set('user-agent', formatUserAgent(version))
   headers.delete('x-api-key')
   return headers
 }
@@ -569,7 +571,10 @@ export function prependClaudeCodeIdentity(system: unknown): SystemBlock[] {
 /**
  * Rewrite the full request body: sanitize system prompt and prefix tool names.
  */
-export function rewriteRequestBody(body: string): string {
+export function rewriteRequestBody(
+  body: string,
+  version: string = CLAUDE_CODE_VERSION,
+): string {
   try {
     const parsed = JSON.parse(body)
     const billingHeader =
@@ -579,7 +584,7 @@ export function rewriteRequestBody(body: string): string {
       )
         ? buildBillingHeaderValue(
             parsed.messages,
-            undefined,
+            version,
             CLAUDE_CODE_ENTRYPOINT,
           )
         : null

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["bun.lock", "mise.toml"],
-  "globalPassThroughEnv": ["ANTHROPIC_BASE_URL", "ANTHROPIC_INSECURE"],
+  "globalPassThroughEnv": [
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_INSECURE",
+    "CLAUDE_CODE_VERSION"
+  ],
   "tasks": {
     "check:all": {
       "dependsOn": ["types", "build", "test", "format:check", "lint"]


### PR DESCRIPTION
This is a follow-up to #211 that hardens the v2 release line without changing its plugin architecture or request-transform behavior.

## What changed

- add a validated `CLAUDE_CODE_VERSION` override, resolved once during plugin setup and used consistently in the user-agent and billing header
- fall back to the bundled Claude Code version with a clear error when the override is malformed
- add `check:package`, which builds and packs a real npm tarball, validates its contents, imports the extracted entrypoint, executes plugin setup, and confirms the Claude Pro/Max OAuth registration
- run the package check in CI and include it in the release checklist
- clarify the separate OpenCode v1/latest and OpenCode v2/next release lines in the README and release docs

The package validation is deterministic and credential-free. It does not start OpenCode or make model requests.

## Verification

- `bun check` — 211 tests passed; build, types, formatting, and lint passed
- `bun run check:package` — verified the 17-file tarball and Claude Pro/Max registration
- `git diff --check`
