### PR TITLE
Add `main-to-v2-sync` local facet with `/sync-main` command

### DIFF
--- a/facets.json
+++ b/facets.json
@@ -4,6 +4,7 @@
     "viper-plans": "1.3.1",
     "facet-meta": "1.0.0",
     "worktrunk": "0.1.0",
-    "voice-to-text": "1.1.1"
+    "voice-to-text": "1.1.1",
+    "main-to-v2-sync": "./facets/main-to-v2-sync"
   }
 }

--- a/facets.lock
+++ b/facets.lock
@@ -25,6 +25,48 @@
         }
       ]
     },
+    "main-to-v2-sync": {
+      "source": {
+        "kind": "local",
+        "path": "./facets/main-to-v2-sync"
+      },
+      "version": "0.1.0",
+      "integrity": "sha256:b3f5a84f6f87ebd5cc2ce1ca27e75474185c52ab9118708d44a2f257fdfd27dc",
+      "assets": [
+        {
+          "scope": "project",
+          "type": "skill",
+          "name": "sync-main-to-v2",
+          "materialization": {
+            "kind": "authored"
+          },
+          "files": [
+            {
+              "path": "skills/sync-main-to-v2/SKILL.md",
+              "integrity": "sha256:9db00fe94f1676d4469fe4feb743abe42aed182c7e80c3aaae7ef883455dd533"
+            },
+            {
+              "path": "skills/sync-main-to-v2/references/plan.md",
+              "integrity": "sha256:20851f9d663afede0c96b79bf4cde9c3637cc39aa90d9d469b123eeed99c2f27"
+            }
+          ]
+        },
+        {
+          "scope": "project",
+          "type": "command",
+          "name": "sync-main",
+          "materialization": {
+            "kind": "authored"
+          },
+          "files": [
+            {
+              "path": "commands/sync-main.md",
+              "integrity": "sha256:00ab09b188ede02d7ab497320746076cf5073bf09c0e1b0900e4dff92848988c"
+            }
+          ]
+        }
+      ]
+    },
     "viper-plans": {
       "source": {
         "kind": "registry",

--- a/facets/main-to-v2-sync/README.md
+++ b/facets/main-to-v2-sync/README.md
@@ -1,0 +1,42 @@
+# main-to-v2-sync
+
+A **private, repository-local** facet. It packages this repository's `main` → `v2/main` forward-port
+workflow as a VIPER plan and exposes it as a single command.
+
+It is not published to the facet registry and is not intended to be. It lives in `facets/` and is
+installed from that path.
+
+## Requirements
+
+The `viper-plans` facet must be installed in this project. This facet reuses that installation — it
+declares no MCP server of its own.
+
+## Install
+
+From the repository root:
+
+```sh
+facet add ./facets/main-to-v2-sync
+```
+
+## Use
+
+```
+/sync-main
+```
+
+The command prepares and verifies a local `v2/sync/main` branch that merges `origin/main` into
+`origin/v2/main`, following [`RELEASING.md`](../../RELEASING.md). It stops there. Pushing the branch
+or opening a pull request happens only if you approve it at the plan's own gate, and the plan never
+merges a pull request or publishes a package.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `skills/sync-main-to-v2/references/plan.md` | The canonical VIPER plan — the source of truth for the workflow |
+| `skills/sync-main-to-v2/SKILL.md` | How to materialize and execute that plan |
+| `commands/sync-main.md` | The `/sync-main` entry point |
+
+`.opencode/plans/main-to-v2-sync/plan.md` is a **generated** copy written at run time. Edit the
+canonical companion instead; the runtime copy is overwritten on every invocation.

--- a/facets/main-to-v2-sync/commands/sync-main.md
+++ b/facets/main-to-v2-sync/commands/sync-main.md
@@ -1,0 +1,9 @@
+Load the `sync-main-to-v2` skill and follow it.
+
+That skill materializes the bundled `main-to-v2-sync` VIPER plan and runs it. It is the only
+instruction set for this command — do not restate, summarize, or improvise the synchronization
+workflow here.
+
+Invoking this command is authorization to **begin** the plan. It is not authorization to push a
+branch, open a pull request, merge anything, or publish a package. Those remain behind the plan's own
+gates.

--- a/facets/main-to-v2-sync/facet.json
+++ b/facets/main-to-v2-sync/facet.json
@@ -1,0 +1,22 @@
+{
+  "name": "main-to-v2-sync",
+  "version": "0.1.0",
+  "description": "Run the repository's main to v2/main synchronization workflow as a VIPER plan",
+  "private": true,
+  "skills": {
+    "sync-main-to-v2": {
+      "description": "Load BEFORE running the main to v2/main forward-port; materializes and executes the bundled main-to-v2-sync VIPER plan",
+      "files": [
+        "references/plan.md"
+      ]
+    }
+  },
+  "commands": {
+    "sync-main": {
+      "description": "Prepare a verified local v2/sync/main branch that merges main into v2/main"
+    }
+  },
+  "files": [
+    "README.md"
+  ]
+}

--- a/facets/main-to-v2-sync/skills/sync-main-to-v2/SKILL.md
+++ b/facets/main-to-v2-sync/skills/sync-main-to-v2/SKILL.md
@@ -1,0 +1,54 @@
+# Syncing `main` into `v2/main`
+
+This skill does not describe the synchronization workflow. The workflow lives in one place: the
+companion file `references/plan.md`, beside this skill. That file is a complete VIPER plan and is the
+**canonical source of truth**. This skill only explains how to materialize it and run it.
+
+Load `viper-execution-rules` before executing anything.
+
+## Prerequisites
+
+The `viper-plans` facet must be installed in the project. It supplies the execution rules and the
+plan tools. If neither the plan tools nor `.opencode/plans/` are available, say so and stop — do not
+improvise a substitute workflow.
+
+## Plan tools
+
+The `viper-plans` MCP server provides `viper-write-plan`, `viper-read-plan`, `viper-edit-plan`,
+`viper-list-plans`, and `viper-delete-plan`. A client may expose them under a prefixed name such as
+`viper-plans_viper-write-plan`, so treat any tool whose name ends with one of those canonical names
+as that tool. Prefer them whenever they are available; otherwise use the file-tool fallback noted
+below.
+
+## Procedure
+
+1. **Read the canonical plan.** Read `references/plan.md` relative to this skill's own directory, as
+   reported when the skill was loaded. Read it in full.
+
+2. **Materialize it as the runtime plan.** Persist that exact content under the plan name
+   `main-to-v2-sync`, using `viper-write-plan` if available; otherwise write
+   `.opencode/plans/main-to-v2-sync/plan.md` with your file tools, creating the directory if needed.
+
+   Overwrite any existing plan of that name without asking. The plan store holds a **generated copy**,
+   not the source. Never edit `references/plan.md` to reflect a runtime decision, and never merge a
+   stale runtime copy back into it.
+
+3. **Execute it immediately.** Count the `### Step` headings, state the plan name and step count in
+   one line, then follow the `viper-execution-rules` protocol: one TODO per step heading, steps in
+   document order, Propose and Review steps gated on the user, and a stop on any Verify failure.
+
+   Do not add an outer approval cycle around the plan. The plan carries its own Propose and Review
+   gates, and an invocation of the command is authorization to begin it.
+
+4. **Do not delete the runtime plan** at the end of the run unless the user asks. It is cheap to
+   regenerate and useful to inspect.
+
+## Authority
+
+The plan is authoritative over this skill and over the command that loads it. If the plan and any
+prose here appear to disagree, the plan wins, and the disagreement is a bug in this facet worth
+reporting to the user.
+
+Beginning the run authorizes only what the plan authorizes: it prepares and verifies a **local**
+branch. Pushing that branch or opening a pull request happens only through the plan's own explicit
+user gate. Nothing in this facet ever merges a pull request or publishes a package.

--- a/facets/main-to-v2-sync/skills/sync-main-to-v2/references/plan.md
+++ b/facets/main-to-v2-sync/skills/sync-main-to-v2/references/plan.md
@@ -1,0 +1,161 @@
+# Plan: Reusable `main` → `v2/main` Sync
+
+## Goal
+
+Safely forward-port `origin/main` into `origin/v2/main` on a local branch named `v2/sync/main`, following `RELEASING.md`. Use the current checkout, preserve v2 release infrastructure, restore missing release intent when necessary, and leave remote publication entirely behind an explicit user gate.
+
+## Decisions
+
+- `RELEASING.md` remains the authoritative release and conflict-resolution runbook.
+- Use the current checkout, not a worktree.
+- Require a clean working tree before switching branches.
+- Build `v2/sync/main` from the latest `origin/v2/main`.
+- Never reset, overwrite, or delete an existing `v2/sync/main` without approval.
+- Do not push or open a PR by default.
+- After local verification, ask whether to push and open the PR.
+- Never merge the PR or publish a package.
+
+## Step Types
+
+- **Verify** → CHECK. Run automated checks (tests, lint, type checks).
+  If all checks pass, proceed. If anything fails, STOP and notify the user.
+- **Implement** → WRITE. Make code changes — create, edit, or delete files.
+- **Propose** → READ-ONLY + USER GATE. Present intended changes in your message text first,
+  then ask for approval using the `question` tool with a short prompt (Approve / Reject / Request changes).
+  Never put details in the question — the question is just the gate. Do not write anything.
+- **Explore** → READ-ONLY. Read files, search the codebase, investigate broadly.
+  No writes allowed. Use this to understand the problem space before acting.
+- **Review** → READ-ONLY + USER GATE. Present findings and analysis in your message text first,
+  then ask for feedback using the `question` tool with a short prompt.
+  Never put details in the question — the question is just the gate.
+- **Pause** → PAUSE, NO TOOL. A model-switch pause. Emit this exact line of plain text and nothing else:
+  "Switch models if desired, then send any message to continue."
+  Then end the turn. Do NOT call the `question` tool, and do NOT tell the user to run a command.
+  An affirmative continuation resumes execution; a stop, revise-plan, or
+  question message is handled without advancing.
+
+### Step 1 - Implement: Refresh the remote branch references
+
+- Run `git fetch origin`.
+- Do not switch branches, alter tracked files, or modify remote branches.
+
+### Step 2 - Verify: Confirm synchronization prerequisites
+
+- Confirm `origin/main` and `origin/v2/main` resolve to commits.
+- Confirm no merge, rebase, cherry-pick, or revert is already in progress.
+- Confirm the current working tree and index are clean.
+- Record the current branch so the user knows which checkout will be changed.
+- Stop if these prerequisites are not satisfied.
+
+### Step 3 - Pause: Switch model for exploration
+
+### Step 4 - Explore: Analyze the pending forward-port
+
+- Re-read the synchronization section of `RELEASING.md`.
+- Enumerate commits and file changes in `origin/v2/main..origin/main`.
+- Inspect existing local and remote `v2/sync/main` branches and any open equivalent sync PR.
+- Use read-only merge analysis to identify likely conflicts.
+- Classify release-owned files using the runbook’s conflict table.
+- Determine which incoming changesets remain present and which release intents were already consumed on `main`.
+- Identify any changes that require replacement v2 changesets.
+- Inspect prior sync commits and PRs when they clarify expected resolutions.
+
+### Step 5 - Propose: Present the exact synchronization strategy
+
+Present for approval:
+
+- The commits and changes being forwarded.
+- How an existing `v2/sync/main`, if any, will be handled without destructive reset.
+- Expected conflict resolutions, distinguishing release-owned files from source-code conflicts.
+- Which original changesets will transfer naturally.
+- Which consumed changesets require equivalent replacements.
+- Any material uncertainty that requires user direction before merging.
+
+Do not alter the checkout until the proposal is approved.
+
+### Step 6 - Pause: Switch model for implementation
+
+### Step 7 - Implement: Prepare the local `v2/sync/main` merge
+
+- Create and switch to `v2/sync/main` from `origin/v2/main`.
+- If the branch already exists, follow only the approved non-destructive handling from Step 5.
+- Merge `origin/main`.
+- Resolve release-owned conflicts according to `RELEASING.md`:
+  - Preserve v2 prerelease state and Changesets base branch.
+  - Preserve the v2 publish trigger, concurrency, titles, and `release:next`.
+  - Preserve the v2 package version and both release scripts.
+  - Retain both changelog histories and v2 installation examples.
+  - Reconcile genuine infrastructure improvements manually.
+  - Resolve `src/**` on technical merit.
+  - Regenerate `bun.lock` from the resolved dependency set rather than hand-editing it.
+- Add equivalent replacement changesets for consumed v1 release intent identified in the approved proposal.
+- Complete the merge commit on the local branch.
+- Do not push or create a PR.
+
+### Step 8 - Verify: Validate the merged tree and release invariants
+
+Run:
+
+```bash
+bun install --frozen-lockfile
+bun run types
+bun run build
+bun test
+bun run check:package
+bun run format:check
+bun run lint
+```
+
+Also verify:
+
+- The branch is `v2/sync/main`.
+- The merge contains the intended `origin/main` commits.
+- `.changeset/pre.json` remains in `pre` mode with tag `next`.
+- `.changeset/config.json` still targets `v2/main`.
+- The package remains on a `2.x.y-next.N` version.
+- The v2 publishing workflow and `release:next` guard remain intact.
+- Every incoming user-visible change has transferred or replacement release intent.
+- No remote branch, PR, tag, release, or package was created.
+
+### Step 9 - Review: Present the verified local synchronization
+
+Report:
+
+- Merge commit and included commit range.
+- Conflicts encountered and their resolutions.
+- Original and replacement changesets.
+- Full verification results.
+- Remaining risks or review points.
+- The proposed PR title and summary.
+
+Ask the user to choose whether to:
+
+1. Keep the branch local and finish.
+2. Push `v2/sync/main` and open a PR.
+3. Request further local changes.
+
+### Step 10 - Implement: Optionally submit the synchronization PR
+
+Only if explicitly approved in Step 9:
+
+- Push `v2/sync/main` without force.
+- Open a PR targeting `v2/main` titled `chore: sync main into v2/main`.
+- Include the verified commit range, conflict decisions, changeset handling, and checks in the PR description.
+
+If the user chooses to keep the branch local, perform no remote mutation. Never merge the PR.
+
+### Step 11 - Verify: Confirm the selected final state
+
+- If kept local, confirm the verified branch remains available locally and no new remote branch or PR was created.
+- If submitted, confirm the remote branch and PR target `v2/main`, inspect initial checks, and report their status.
+- Confirm no PR was merged and no release or package publication occurred.
+
+## Acceptance Criteria
+
+- `origin/main` is merged into a local `v2/sync/main` based on current `origin/v2/main`.
+- V2 release-owned state remains intact.
+- Required replacement changesets restore consumed release intent.
+- The complete local check suite passes.
+- No destructive branch operation occurs without approval.
+- No remote action occurs unless separately approved.
+- The workflow never merges a PR or publishes a package.


### PR DESCRIPTION
Add a local `main-to-v2-sync` facet that packages the `main` → `v2/main` forward-port workflow as a VIPER plan and exposes it via a `/sync-main` command.

The facet is private and repository-local — it is not published to the facet registry. It depends on the existing `viper-plans` facet for plan tooling and execution rules rather than declaring its own MCP server.

Invoking `/sync-main` loads the `sync-main-to-v2` skill, which reads the canonical plan from `references/plan.md`, materializes it into the plan store as `main-to-v2-sync`, and executes it immediately. The plan covers fetching, prerequisite checks, conflict analysis, merge preparation, full local verification, and an optional push and PR — each destructive or remote action behind an explicit user gate. The plan never merges a PR or publishes a package.