### PR TITLE
Add review step for complex forward-port findings to `main-to-v2-sync`

### DIFF
--- a/facets.lock
+++ b/facets.lock
@@ -30,8 +30,8 @@
         "kind": "local",
         "path": "./facets/main-to-v2-sync"
       },
-      "version": "0.1.0",
-      "integrity": "sha256:b3f5a84f6f87ebd5cc2ce1ca27e75474185c52ab9118708d44a2f257fdfd27dc",
+      "version": "0.1.1",
+      "integrity": "sha256:3309150c306fb40c4d15c1e2077d23bc434edd77ccd4d3c888bc913b5c5e3a98",
       "assets": [
         {
           "scope": "project",
@@ -47,7 +47,7 @@
             },
             {
               "path": "skills/sync-main-to-v2/references/plan.md",
-              "integrity": "sha256:20851f9d663afede0c96b79bf4cde9c3637cc39aa90d9d469b123eeed99c2f27"
+              "integrity": "sha256:a87604c2ebb1b2ecc00dfb965f87bf5d5723f67eb1711588638447bbb7606a5a"
             }
           ]
         },

--- a/facets/main-to-v2-sync/facet.json
+++ b/facets/main-to-v2-sync/facet.json
@@ -1,6 +1,6 @@
 {
   "name": "main-to-v2-sync",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Run the repository's main to v2/main synchronization workflow as a VIPER plan",
   "private": true,
   "skills": {

--- a/facets/main-to-v2-sync/skills/sync-main-to-v2/references/plan.md
+++ b/facets/main-to-v2-sync/skills/sync-main-to-v2/references/plan.md
@@ -60,9 +60,24 @@ Safely forward-port `origin/main` into `origin/v2/main` on a local branch named 
 - Identify any changes that require replacement v2 changesets.
 - Inspect prior sync commits and PRs when they clarify expected resolutions.
 
-### Step 5 - Propose: Present the exact synchronization strategy
+### Step 5 - Review: Discuss complex forward-port findings when needed
 
-Present for approval:
+Use judgment to determine whether the analysis found complexity, ambiguity, or consequential
+tradeoffs that would benefit from user discussion.
+
+If the forward-port is straightforward and no user direction would materially affect the strategy,
+mark this review unnecessary and proceed directly to Step 6 without calling the `question` tool.
+
+Otherwise:
+
+- Present the relevant findings, uncertainties, tradeoffs, and available options in the message text.
+- Ask the user for feedback using the `question` tool with a short prompt.
+- Resolve or record the user’s direction before continuing.
+- Carry that direction into the synchronization strategy proposed in Step 6.
+
+### Step 6 - Propose: Present the exact synchronization strategy
+
+Present for approval, incorporating any direction obtained in Step 5:
 
 - The commits and changes being forwarded.
 - How an existing `v2/sync/main`, if any, will be handled without destructive reset.
@@ -73,12 +88,12 @@ Present for approval:
 
 Do not alter the checkout until the proposal is approved.
 
-### Step 6 - Pause: Switch model for implementation
+### Step 7 - Pause: Switch model for implementation
 
-### Step 7 - Implement: Prepare the local `v2/sync/main` merge
+### Step 8 - Implement: Prepare the local `v2/sync/main` merge
 
 - Create and switch to `v2/sync/main` from `origin/v2/main`.
-- If the branch already exists, follow only the approved non-destructive handling from Step 5.
+- If the branch already exists, follow only the approved non-destructive handling from Step 6.
 - Merge `origin/main`.
 - Resolve release-owned conflicts according to `RELEASING.md`:
   - Preserve v2 prerelease state and Changesets base branch.
@@ -92,7 +107,7 @@ Do not alter the checkout until the proposal is approved.
 - Complete the merge commit on the local branch.
 - Do not push or create a PR.
 
-### Step 8 - Verify: Validate the merged tree and release invariants
+### Step 9 - Verify: Validate the merged tree and release invariants
 
 Run:
 
@@ -117,7 +132,7 @@ Also verify:
 - Every incoming user-visible change has transferred or replacement release intent.
 - No remote branch, PR, tag, release, or package was created.
 
-### Step 9 - Review: Present the verified local synchronization
+### Step 10 - Review: Present the verified local synchronization
 
 Report:
 
@@ -134,9 +149,9 @@ Ask the user to choose whether to:
 2. Push `v2/sync/main` and open a PR.
 3. Request further local changes.
 
-### Step 10 - Implement: Optionally submit the synchronization PR
+### Step 11 - Implement: Optionally submit the synchronization PR
 
-Only if explicitly approved in Step 9:
+Only if explicitly approved in Step 10:
 
 - Push `v2/sync/main` without force.
 - Open a PR targeting `v2/main` titled `chore: sync main into v2/main`.
@@ -144,7 +159,7 @@ Only if explicitly approved in Step 9:
 
 If the user chooses to keep the branch local, perform no remote mutation. Never merge the PR.
 
-### Step 11 - Verify: Confirm the selected final state
+### Step 12 - Verify: Confirm the selected final state
 
 - If kept local, confirm the verified branch remains available locally and no new remote branch or PR was created.
 - If submitted, confirm the remote branch and PR target `v2/main`, inspect initial checks, and report their status.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,4 +2,4 @@ pre-commit:
   commands:
     biome:
       glob: "*.{ts,js,json}"
-      run: bunx biome check {staged_files}
+      run: bunx biome check --no-errors-on-unmatched {staged_files}


### PR DESCRIPTION
Adds an interactive review step to the main-to-v2 sync plan before the proposal is finalized. When the forward-port analysis uncovers complexity, ambiguity, or consequential tradeoffs, the new Step 5 prompts the user for direction via the `question` tool before proceeding. Straightforward syncs skip the step automatically. All subsequent steps are renumbered accordingly, and cross-references within the plan are updated to match.

Also fixes the Lefthook Biome pre-commit command to pass `--no-errors-on-unmatched`, preventing failures when staged files don't match the glob pattern.